### PR TITLE
Notebook for Creating Cutouts with Astrocut

### DIFF
--- a/notebooks/astrocut/requirements.txt
+++ b/notebooks/astrocut/requirements.txt
@@ -1,0 +1,6 @@
+asdf>=3.2.0
+astrocut>=0.11.0
+astropy>=6.1.0
+matplotlib>=3.10.0
+numpy>=1.26.4
+s3fs>=2024.5.0

--- a/notebooks/roman_cutouts/requirements.txt
+++ b/notebooks/roman_cutouts/requirements.txt
@@ -2,6 +2,6 @@ asdf>=3.2.0
 asdf-astropy>=0.6.1
 astrocut>=0.11.0
 astropy>=6.1.0
-matplotlib>=3.10.0
+matplotlib>=3.9.0
 numpy>=1.26.4
 s3fs>=2024.5.0

--- a/notebooks/roman_cutouts/requirements.txt
+++ b/notebooks/roman_cutouts/requirements.txt
@@ -1,6 +1,6 @@
 asdf>=3.2.0
 asdf-astropy>=0.6.1
-astrocut>=0.11.0
+astrocut>=0.11.1
 astropy>=6.1.0
 matplotlib>=3.9.0
 numpy>=1.26.4

--- a/notebooks/roman_cutouts/requirements.txt
+++ b/notebooks/roman_cutouts/requirements.txt
@@ -1,4 +1,5 @@
 asdf>=3.2.0
+asdf-astropy>=0.6.1
 astrocut>=0.11.0
 astropy>=6.1.0
 matplotlib>=3.10.0

--- a/notebooks/roman_cutouts/roman_cutouts.ipynb
+++ b/notebooks/roman_cutouts/roman_cutouts.ipynb
@@ -412,6 +412,7 @@
     "    plt.title('Cutout in Pixel Coordinates')\n",
     "    plt.show()\n",
     "\n",
+    "\n",
     "plot_cutout_pixel(img)"
    ]
   },

--- a/notebooks/roman_cutouts/roman_cutouts.ipynb
+++ b/notebooks/roman_cutouts/roman_cutouts.ipynb
@@ -2,6 +2,36 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "3c0a6cde-7792-4d71-80fe-5f95b7a00b05",
+   "metadata": {},
+   "source": [
+    "# Creating Cutouts of Roman Data with Astrocut\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aa597792-e981-4447-b3ad-f217bce73526",
+   "metadata": {},
+   "source": [
+    "## Table of Contents\n",
+    "\n",
+    "1. [Introduction](#Introduction)\n",
+    "2. [Imports](#Imports)\n",
+    "3. [Setup](#Setup)\n",
+    "4. [Examine Coordinates](#Examine-Coordinates)\n",
+    "5. [Create Image Cutout in FITS Format](#Create-Image-Cutout-in-FITS-Format)\n",
+    "6. [Create Image Cutout in ASDF Format](#Create-Image-Cutout-in-ASDF-Format)\n",
+    "7. [Partial Image Cutouts](#Partial-Image-Cutouts)\n",
+    "8. [Additional Resources](#Additional-Resources)\n",
+    "9. [About this Notebook](#About-this-Notebook)\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "77bdd3ee",
    "metadata": {},
    "source": [
@@ -17,7 +47,9 @@
     "\n",
     "The `astrocut` service allows users to generate cutouts out of large images from survey satellites such as the [Transiting Exoplanet Survey Satellite (TESS)](https://archive.stsci.edu/missions-and-data/tess). Future plans for `astrocut` involve expanding its functionality so that it supports generating cutouts from different missions, including the [Roman Space Telescope](https://archive.stsci.edu/missions-and-data/roman) mission, which will involve supporting the ASDF file type.\n",
     "\n",
-    "This notebook demonstrates an initial proof-of-concept script created for this expansion of the astrocut functionality, which takes in a single Roman calibrated file and generates a cutout from the input image."
+    "This notebook demonstrates an initial proof-of-concept script created for this expansion of the astrocut functionality, which takes in a single Roman calibrated file and generates a cutout from the input image.\n",
+    "\n",
+    "---"
    ]
   },
   {
@@ -61,6 +93,14 @@
     "from astropy.coordinates import SkyCoord\n",
     "from astropy.wcs import WCS\n",
     "from astropy.nddata import Cutout2D"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7601bb9-5e24-4dcc-9774-402a0b2f05d4",
+   "metadata": {},
+   "source": [
+    "---"
    ]
   },
   {
@@ -118,6 +158,14 @@
    "source": [
     "# URI to a level 2 image in S3 bucket\n",
     "asdf_file_uri = asdf_dir_uri + '/DENSE_REGION/R0.5_DP0.5_PA0/r0000101001001001002_01101_0001_WFI18_cal.asdf'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d9355b5-1e9d-43bd-8754-ccdc3ed15406",
+   "metadata": {},
+   "source": [
+    "---"
    ]
   },
   {
@@ -239,10 +287,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "d53d649a-86c3-42bb-a870-d42df7d691bd",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5a37e0f7-6a0d-4bd9-b708-c845618e1d31",
    "metadata": {},
    "source": [
-    "## Create Image Cutout (FITS)\n",
+    "## Create Image Cutout in FITS Format\n",
     "Here, we will create the image cutout as a FITS file.  First, we plot the expected cutout on the input image with a red square."
    ]
   },
@@ -304,7 +360,7 @@
    "id": "e1460b04-2620-44f4-97c3-a0e246687e76",
    "metadata": {},
    "source": [
-    "## Inspect Cutout Image (FITS)\n",
+    "### Inspect FITS Cutout Image\n",
     "Now let's inspect the cutout a bit and display the image cutout with matplotlib.  The ``asdf_cut`` function returns an [Astropy Cutout2D](https://docs.astropy.org/en/stable/nddata/utils.html#overview) object.  "
    ]
   },
@@ -338,7 +394,7 @@
    "id": "ab0ce5d0-df21-4e26-b2ae-d40e7443293b",
    "metadata": {},
    "source": [
-    "### Cutout in Pixel Coordinates"
+    "#### Cutout in Pixel Coordinates"
    ]
   },
   {
@@ -369,7 +425,7 @@
    "id": "60db4ff2-b179-4c2b-9513-e0a546337291",
    "metadata": {},
    "source": [
-    "### Cutout in Sky Coordinates"
+    "#### Cutout in Sky Coordinates"
    ]
   },
   {
@@ -421,10 +477,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "ec76fa78-7bf1-4522-887b-fe5b5ec50dc0",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "60b7e1a4-3d17-45a9-984e-7f27b98cd816",
    "metadata": {},
    "source": [
-    "## Create Image Cutout (ASDF)\n",
+    "## Create Image Cutout in ASDF Format\n",
     "Now, we will create the image cutout as an ASDF file. This time, we will take the cutout from a different section of the original image, and make it a bit longer on each side."
    ]
   },
@@ -450,7 +514,7 @@
    "id": "e6059a6f-e854-49c9-924b-9b98be726a39",
    "metadata": {},
    "source": [
-    "## Inspect Cutout Image (ASDF)"
+    "### Inspect ASDF Cutout Image"
    ]
   },
   {
@@ -470,7 +534,7 @@
    "id": "eb970e0d-17db-40b6-9be0-7c13a7f10eff",
    "metadata": {},
    "source": [
-    "### Cutout in Pixel Coordinates"
+    "#### Cutout in Pixel Coordinates"
    ]
   },
   {
@@ -488,7 +552,7 @@
    "id": "8568536a-8b82-407c-a70d-b35610c340ca",
    "metadata": {},
    "source": [
-    "### Cutout in Sky Coordinates"
+    "#### Cutout in Sky Coordinates"
    ]
   },
   {
@@ -511,10 +575,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "4444510a-5c87-46d5-9eba-e003eec58a70",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5b604f31-2363-4c6d-b509-1cd33963632d",
    "metadata": {},
    "source": [
-    "# Partial Image Cutouts\n",
+    "## Partial Image Cutouts\n",
     "\n",
     "Sometimes, cutouts are made near the edge of Roman images. In these cases, part of the cutout may fall outside of the original image.\n",
     "\n",
@@ -648,12 +720,28 @@
   },
   {
    "cell_type": "markdown",
+   "id": "7a0388ce-8b95-47b8-949e-498e34211106",
+   "metadata": {},
+   "source": [
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "26b9e4a3-3321-488f-b72b-f2d4a16bf4c8",
    "metadata": {},
    "source": [
-    "# Additional Resources\n",
+    "## Additional Resources\n",
     "- [Astrocut Documentation](https://astrocut.readthedocs.io)\n",
     "- [Advanced Scientific Data Format Documentation](https://asdf.readthedocs.io/en/latest/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c9f597d-56fc-4aaa-9fd0-3caccffbfa38",
+   "metadata": {},
+   "source": [
+    "---"
    ]
   },
   {
@@ -661,7 +749,7 @@
    "id": "99d925a3-122e-4742-91d2-979efaa4d0a5",
    "metadata": {},
    "source": [
-    "# About this Notebook\n",
+    "## About this Notebook\n",
     "\n",
     "**Authors**: Thomas Dutkiewicz, Brian Cherinka, Sam Bianco<br>\n",
     "**Last Updated**: May 2024"

--- a/notebooks/roman_cutouts/roman_cutouts.ipynb
+++ b/notebooks/roman_cutouts/roman_cutouts.ipynb
@@ -45,9 +45,9 @@
    "source": [
     "The Roman Space Telescope will introduce a new file type that will be used to store astronomical data in a seemless fashion. This file type is called ASDF which is short for [Advanced Scientific Data Format](https://asdf.readthedocs.io/en/latest/).\n",
     "\n",
-    "The `astrocut` service allows users to generate cutouts out of large images from survey satellites such as the [Transiting Exoplanet Survey Satellite (TESS)](https://archive.stsci.edu/missions-and-data/tess). Future plans for `astrocut` involve expanding its functionality so that it supports generating cutouts from different missions, including the [Roman Space Telescope](https://archive.stsci.edu/missions-and-data/roman) mission, which will involve supporting the ASDF file type.\n",
+    "The [`astrocut`](https://astrocut.readthedocs.io) service allows users to generate cutouts out of large images from survey satellites such as the [Transiting Exoplanet Survey Satellite (TESS)](https://archive.stsci.edu/missions-and-data/tess). Future plans for `astrocut` involve expanding its functionality to generate cutouts from different missions, including the [Roman Space Telescope](https://archive.stsci.edu/missions-and-data/roman) mission, which will use the ASDF file type.\n",
     "\n",
-    "This notebook demonstrates an initial proof-of-concept script created for this expansion of the astrocut functionality, which takes in a single Roman calibrated file and generates a cutout from the input image.\n",
+    "This notebook demonstrates an initial proof-of-concept script. It loads a single Roman calibrated file and generates cutouts from the input image.\n",
     "\n",
     "---"
    ]
@@ -127,7 +127,7 @@
    "id": "1d01819b-7745-47e4-9871-f543dc3f6baa",
    "metadata": {},
    "source": [
-    "After launch, Roman data will be available through MAST. For testing purposes, some simulated data has been placed in a separate S3 bucket. We can access this bucket and peruse the available files similarly to a Unix terminal. A full list of commands can be found in the `s3fs` documentation [here.](https://s3fs.readthedocs.io/en/latest/api.html#)"
+    "After launch, Roman data will be available through the [Mikulski Archive for Space Telescopes (MAST)](https://archive.stsci.edu/). For testing purposes, some simulated data has been placed in a separate S3 bucket. We can access this bucket and peruse the available files similarly to a Unix terminal. A full list of commands can be found in the [`s3fs` documentation](https://s3fs.readthedocs.io/en/latest/api.html#)."
    ]
   },
   {
@@ -146,7 +146,7 @@
    "id": "51f2e580-53ab-414c-8c47-39c962fc18e2",
    "metadata": {},
    "source": [
-    "Above, we see the data available from the romanism simulations. The directories listed contain test data for Roman level 1 ramps (`_uncal.asdf`) and level 2 images (`_cal.asdf`), for all 18 detectors on 2 exposures. This POC currently only supports cutouts on level 2 images.  The relevant filename syntax is: `r[program]xxx_xxxx_[exposure_num]_WFI[detector]_cal.asdf`"
+    "Above, we see the data available from the romanism simulations. The directories listed contain test data for Roman level 1 ramps (`_uncal.asdf`) and level 2 images (`_cal.asdf`), for all 18 detectors on 2 exposures. This proof-of-concept currently only supports cutouts on level 2 images.  The relevant filename syntax is: `r[program]xxx_xxxx_[exposure_num]_WFI[detector]_cal.asdf`"
    ]
   },
   {
@@ -177,7 +177,7 @@
     "\n",
     "### GWCS\n",
     "\n",
-    "Roman ASDF images use [GWCS](https://gwcs.readthedocs.io/en/latest/index.html) to handle coordinate transformations, as opposed to FITS WCS. GWCS is more flexible than FITS WCS, and contains a pipeline of transformations from detector to world coordinates.  It is stored in the image files within the `roman['meta']['wcs']` dictionary.  Let's extract the gwcs object and examine the sky and pixel coordinates.   "
+    "Roman ASDF images use [Generalized World Coordinate System (GWCS)](https://gwcs.readthedocs.io/en/latest/index.html) to handle coordinate transformations, as opposed to the [World Coordinate System (WCS)](https://fits.gsfc.nasa.gov/fits_wcs.html) used in [Flexible Image Transport System (FITS)](https://fits.gsfc.nasa.gov/fits_primer.html) files. GWCS is more flexible than FITS WCS, and contains a pipeline of transformations from detector to world coordinates.  It is stored in the image files within the `roman['meta']['wcs']` dictionary.  Let's extract the gwcs object and examine the sky and pixel coordinates."
    ]
   },
   {
@@ -486,7 +486,7 @@
    "metadata": {},
    "source": [
     "## Create Image Cutout in ASDF Format\n",
-    "Now, we will create the image cutout as an ASDF file. This time, we will take the cutout from a different section of the original image, and make it a bit longer on each side."
+    "Now, we will create the image cutout as an ASDF file. This time, we will take the cutout from a different section of the original image, and make it 300 pixels on each side."
    ]
   },
   {
@@ -606,16 +606,8 @@
     "\n",
     "# convert to sky coordinates\n",
     "edge_coord = gwcs(edge_x, edge_y, with_units=True)\n",
-    "edge_coord"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15743bb8-9815-4472-8d15-48f51bf70651",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "edge_coord\n",
+    "\n",
     "# plot expected cutout on original image\n",
     "pc, ww = get_center_pixel(gwcs, edge_coord.ra, edge_coord.dec)\n",
     "plt.imshow(data.value, vmin=0, vmax=5, origin='lower')\n",

--- a/notebooks/roman_cutouts/roman_cutouts.ipynb
+++ b/notebooks/roman_cutouts/roman_cutouts.ipynb
@@ -92,7 +92,27 @@
     "from astropy.io import fits\n",
     "from astropy.coordinates import SkyCoord\n",
     "from astropy.wcs import WCS\n",
-    "from astropy.nddata import Cutout2D"
+    "from astropy.nddata import Cutout2D\n",
+    "from astropy.utils.exceptions import AstropyDeprecationWarning"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3afc9ce2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "\n",
+    "# Ignore warnings from the 'astropy.wcs' module\n",
+    "# When creating cutouts -> WARNING: Polynomial distortion is not implemented.\n",
+    "warnings.filterwarnings('ignore', module='astropy.wcs')\n",
+    "\n",
+    "# Ignore AstropyDeprecationWarning\n",
+    "# When creating cutouts -> WARNING: AstropyDeprecationWarning: The class \"Fits\" has been renamed to \"FITS\" in version 7.0. \n",
+    "# The old name is deprecated and may be removed in a future version. Use FITS instead. [astropy.units.format]\n",
+    "warnings.filterwarnings('ignore', category=AstropyDeprecationWarning)"
    ]
   },
   {

--- a/notebooks/roman_cutouts/roman_cutouts.ipynb
+++ b/notebooks/roman_cutouts/roman_cutouts.ipynb
@@ -234,12 +234,14 @@
     "    \"\"\" Compute separation between two sky coordinates \"\"\"\n",
     "    return coord1.separation(coord2).to(u.arcsec)\n",
     "    \n",
+    "\n",
     "def get_pix_info(xx, coord):\n",
     "    \"\"\" Print some pixel coordinate info \"\"\"\n",
     "    print('Pixel Coord:', xx)\n",
     "    ss = gwcs(*xx, with_units=True)\n",
     "    print('Computed Sky Coord:', ss)\n",
     "    print('Separation:', get_sep(coord, ss))    \n",
+    "\n",
     "\n",
     "def print_coord_info(coord):\n",
     "    \"\"\" Print some sky coordinate info \"\"\"\n",
@@ -450,7 +452,7 @@
     "    ax.scatter([center_loc], [center_loc], s=100, edgecolor='white', facecolor='none')\n",
     "    \n",
     "    # plot sky coord of central pixel\n",
-    "    cc = SkyCoord(*cutout.wcs.all_pix2world([center_loc],[center_loc], 0), unit=u.degree)\n",
+    "    cc = SkyCoord(*cutout.wcs.all_pix2world([center_loc], [center_loc], 0), unit=u.degree)\n",
     "    ax.scatter_coord(cc, s=50, edgecolor='yellow', facecolor='none')\n",
     "    \n",
     "    plt.show()"
@@ -652,7 +654,7 @@
    "source": [
     "# create the image cutout as a FITS file\n",
     "cutout_partial = asdf_cut(asdf_file_uri, edge_coord.ra, edge_coord.dec, cutout_size=cutout_size, \n",
-    "                  fill_value=0, output_file=\"partial-cut.fits\")"
+    "                          fill_value=0, output_file=\"partial-cut.fits\")"
    ]
   },
   {

--- a/notebooks/roman_cutouts/roman_cutouts.ipynb
+++ b/notebooks/roman_cutouts/roman_cutouts.ipynb
@@ -1,0 +1,709 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "77bdd3ee",
+   "metadata": {},
+   "source": [
+    "## Introduction"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d107a95c",
+   "metadata": {},
+   "source": [
+    "The Roman Space Telescope will introduce a new file type that will be used to store astronomical data in a seemless fashion. This file type is called ASDF which is short for [Advanced Scientific Data Format](https://asdf.readthedocs.io/en/latest/).\n",
+    "\n",
+    "The `astrocut` service allows users to generate cutouts out of large images from survey satellites such as the [Transiting Exoplanet Survey Satellite (TESS)](https://archive.stsci.edu/missions-and-data/tess). Future plans for `astrocut` involve expanding its functionality so that it supports generating cutouts from different missions, including the [Roman Space Telescope](https://archive.stsci.edu/missions-and-data/roman) mission, which will involve supporting the ASDF file type.\n",
+    "\n",
+    "This notebook demonstrates an initial proof-of-concept script created for this expansion of the astrocut functionality, which takes in a single Roman calibrated file and generates a cutout from the input image."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8cfd24b2",
+   "metadata": {},
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fe0ee3f4",
+   "metadata": {},
+   "source": [
+    "The following packages are used for these reasons:\n",
+    "\n",
+    "`asdf` - To handle ASDF input and output <br>\n",
+    "`s3fs` - To access cloud files as though they were local <br>\n",
+    "`matplotlib` - The plotting package used for demonstrating the cutout <br>\n",
+    "`numpy` - To handle array functions <br>\n",
+    "`astrocut` - The main package import, used to generate the cutouts from the input file <br>\n",
+    "`astropy` - To manage the output FITS data file type and handle input sky coordinates <br>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59019294",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import asdf\n",
+    "import s3fs\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "from astrocut import get_center_pixel, asdf_cut\n",
+    "import astropy.units as u\n",
+    "from astropy.io import fits\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy.wcs import WCS\n",
+    "from astropy.nddata import Cutout2D"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7402d2cc-a274-4c3c-a528-c5e72a3eb618",
+   "metadata": {},
+   "source": [
+    "## Setup\n",
+    "Here, we load some Roman test data. We will use `s3fs` to directly access data stored in the AWS S3 servers."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8b75c86-2b70-4777-a8d9-2d57b5aeed68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs = s3fs.S3FileSystem()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d01819b-7745-47e4-9871-f543dc3f6baa",
+   "metadata": {},
+   "source": [
+    "After launch, Roman data will be available through MAST. For testing purposes, some simulated data has been placed in a separate S3 bucket. We can access this bucket and peruse the available files similarly to a Unix terminal. A full list of commands can be found in the `s3fs` documentation [here.](https://s3fs.readthedocs.io/en/latest/api.html#)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b12d10f0-1e18-4f85-8766-f129b853d636",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "asdf_dir_uri = 's3://roman-sci-test-data-prod-summer-beta-test/ROMANISIM'\n",
+    "fs.ls(asdf_dir_uri)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51f2e580-53ab-414c-8c47-39c962fc18e2",
+   "metadata": {},
+   "source": [
+    "Above, we see the data available from the romanism simulations. The directories listed contain test data for Roman level 1 ramps (`_uncal.asdf`) and level 2 images (`_cal.asdf`), for all 18 detectors on 2 exposures. This POC currently only supports cutouts on level 2 images.  The relevant filename syntax is: `r[program]xxx_xxxx_[exposure_num]_WFI[detector]_cal.asdf`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0ff71bc2-c07e-46bf-a918-95eaf02f31ac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# URI to a level 2 image in S3 bucket\n",
+    "asdf_file_uri = asdf_dir_uri + '/DENSE_REGION/R0.5_DP0.5_PA0/r0000101001001001002_01101_0001_WFI18_cal.asdf'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "744b1151-c16a-4144-9f12-e879975f3741",
+   "metadata": {},
+   "source": [
+    "## Examine Coordinates\n",
+    "\n",
+    "### GWCS\n",
+    "\n",
+    "Roman ASDF images use [GWCS](https://gwcs.readthedocs.io/en/latest/index.html) to handle coordinate transformations, as opposed to FITS WCS. GWCS is more flexible than FITS WCS, and contains a pipeline of transformations from detector to world coordinates.  It is stored in the image files within the `roman['meta']['wcs']` dictionary.  Let's extract the gwcs object and examine the sky and pixel coordinates.   "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32b1c37d-a8c6-4664-8ed2-9e59d43c2c39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open URI with S3FileSystem, and then with asdf package\n",
+    "with fs.open(asdf_file_uri, 'rb') as f:\n",
+    "    with asdf.open(f) as af:\n",
+    "        # print info about the file\n",
+    "        af.info()\n",
+    "        data = af['roman']['data']\n",
+    "        gwcs = af['roman']['meta']['wcs']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e8fde1f9-09c3-4bb4-adfe-3855806621d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('some gwcs info:')\n",
+    "print('---------------')\n",
+    "print('- input frame: ', gwcs.input_frame)\n",
+    "print('- output frame: ', gwcs.output_frame)\n",
+    "print('- pixel bounds: ', gwcs.bounding_box)\n",
+    "print('- sky footprint: ', gwcs.footprint())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1882905b-cb9b-46d2-b383-ebf323c0ed77",
+   "metadata": {},
+   "source": [
+    "### Coordinate Analysis\n",
+    "\n",
+    "Next, we will do some coordinate analysis of points in the image. For three sets of input sky coordinates, we will compute the pixel coordinates, the computed sky coordinates, and the separation between the input and computed sky coordinates. The points correspond to the center of the image, the far upper right, and the far lower left."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c1553c0-41d3-42cc-8aa1-6ee5f29a938f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define some helper functions\n",
+    "\n",
+    "def get_sep(coord1, coord2):\n",
+    "    \"\"\" Compute separation between two sky coordinates \"\"\"\n",
+    "    return coord1.separation(coord2).to(u.arcsec)\n",
+    "    \n",
+    "def get_pix_info(xx, coord):\n",
+    "    \"\"\" Print some pixel coordinate info \"\"\"\n",
+    "    print('Pixel Coord:', xx)\n",
+    "    ss = gwcs(*xx, with_units=True)\n",
+    "    print('Computed Sky Coord:', ss)\n",
+    "    print('Separation:', get_sep(coord, ss))    \n",
+    "\n",
+    "def print_coord_info(coord):\n",
+    "    \"\"\" Print some sky coordinate info \"\"\"\n",
+    "    print('Input Sky Coord:', coord)\n",
+    "    xx = gwcs.invert(coord)\n",
+    "    get_pix_info(xx, coord)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6995ac65-c6e1-4049-a043-5e63b40e5a4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sky coord of central pixel\n",
+    "print('Central Image Pixel')\n",
+    "print('-------------------')\n",
+    "pix_x, pix_y = np.shape(data.value)[0] // 2, np.shape(data.value)[1] // 2\n",
+    "center_coord = gwcs(pix_x, pix_y, with_units=True)\n",
+    "print_coord_info(center_coord)\n",
+    "print('\\n')\n",
+    "\n",
+    "# sky coord at far edge (upper right)\n",
+    "print('Far Edge Pixel - Upper Right')\n",
+    "print('-----------------------------')\n",
+    "ss = gwcs(4077, 4077, with_units=True)\n",
+    "print_coord_info(ss)\n",
+    "print('\\n')\n",
+    "\n",
+    "# sky coord at far edge (lower left)\n",
+    "print('Far Edge Pixel - Lower Left')\n",
+    "print('---------------------------')\n",
+    "ss = gwcs(2, 2, with_units=True)\n",
+    "print_coord_info(ss)\n",
+    "print('\\n')\n",
+    "\n",
+    "# get computed pixel coordinates from world coordinates with get_center_pixel\n",
+    "test_coord = SkyCoord('0.8 0.3', unit='deg') # test out different sky coordinates here!\n",
+    "print('Computed Closet Pixel Coordinate')\n",
+    "print('--------------------------------')\n",
+    "pc, ww = get_center_pixel(gwcs, test_coord.ra, test_coord.dec)\n",
+    "get_pix_info(pc, test_coord)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a37e0f7-6a0d-4bd9-b708-c845618e1d31",
+   "metadata": {},
+   "source": [
+    "## Create Image Cutout (FITS)\n",
+    "Here, we will create the image cutout as a FITS file.  First, we plot the expected cutout on the input image with a red square."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "268f4637-94ca-4dcd-a9e9-39e81291b6cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define cutout size\n",
+    "cutout_size = 200\n",
+    "\n",
+    "# define cutout coordinates\n",
+    "coord = center_coord\n",
+    "\n",
+    "# plot expected cutout on original image\n",
+    "print('Expected cutout position:')\n",
+    "pc, ww = get_center_pixel(gwcs, coord.ra, coord.dec)\n",
+    "plt.imshow(data.value, vmin=0, vmax=5, origin='lower')\n",
+    "tmp = Cutout2D(data, position=pc, wcs=ww, size=cutout_size, mode='partial')\n",
+    "tmp.plot_on_original(color='red')\n",
+    "padding = 500\n",
+    "plt.xlim(pix_x - padding, pix_x + padding)\n",
+    "plt.ylim(pix_y - padding, pix_y + padding)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "784020a0-32ff-4d0b-b260-d8e116319df0",
+   "metadata": {},
+   "source": [
+    "The ``asdf_cut`` function takes as input the following: \n",
+    "- `input_file`: The input ASDF filename or URI\n",
+    "- `ra`: The right ascension of the central cutout\n",
+    "- `dec`: The declination of the central cutout\n",
+    "- `cutout_size`: The image cutout pixel size (optional, default `200`)\n",
+    "- `output_file`: The name of the output cutout file. The output format is determined by the filename extension (optional, default `\"example_roman_cutout.fits\"`)\n",
+    "- `write_file`: Flag to write the cutout to a file or not (optional, default `True`)\n",
+    "- `fill_value`: The fill value for any pixels outside the original image (optional, default `np.nan`)\n",
+    "  \n",
+    "Let's create a square cutout, at the center of the image, 200 pixels on a side, and save the output to a new FITS file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b71c7031-ffe6-4941-8a12-25d7b1948937",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create the image cutout as a FITS file\n",
+    "cutout = asdf_cut(asdf_file_uri, coord.ra, coord.dec, cutout_size=cutout_size, output_file=\"roman-demo.fits\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1460b04-2620-44f4-97c3-a0e246687e76",
+   "metadata": {},
+   "source": [
+    "## Inspect Cutout Image (FITS)\n",
+    "Now let's inspect the cutout a bit and display the image cutout with matplotlib.  The ``asdf_cut`` function returns an [Astropy Cutout2D](https://docs.astropy.org/en/stable/nddata/utils.html#overview) object.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84597c63-0d92-423c-a13a-521bb6249ac1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('shape:', cutout.shape)\n",
+    "print('orginal position:', cutout.position_original)\n",
+    "print('cutout position:', cutout.position_cutout)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a29c636f-4b21-497d-baa2-415818750a27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with fits.open(\"roman-demo.fits\") as hdulist:\n",
+    "    hdulist.info()\n",
+    "    header = hdulist[0].header\n",
+    "    img = hdulist[0].data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ab0ce5d0-df21-4e26-b2ae-d40e7443293b",
+   "metadata": {},
+   "source": [
+    "### Cutout in Pixel Coordinates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "69ac82b9-57ab-4b7c-854d-a5e74698d1ee",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_cutout_pixel(img):\n",
+    "    plt.figure(figsize=(6, 6))\n",
+    "    plt.imshow(img, vmin=0, vmax=5, origin=\"lower\")\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b6907af",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_cutout_pixel(img)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60db4ff2-b179-4c2b-9513-e0a546337291",
+   "metadata": {},
+   "source": [
+    "### Cutout in Sky Coordinates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "337ee97b-19ce-4df3-9963-50d64723aafb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_cutout_world(cutout, img, coord, wcs):        \n",
+    "    # plot the figure with wcs\n",
+    "    plt.figure(figsize=(6, 6))\n",
+    "    ax = plt.subplot(projection=wcs)\n",
+    "    ax.imshow(img, vmin=0, vmax=5, origin='lower')\n",
+    "    ax.grid(color='white', ls='solid')\n",
+    "    \n",
+    "    # overplot the original sky coordinate\n",
+    "    ax.scatter_coord(coord, s=100, edgecolor='cyan', facecolor='none')\n",
+    "    \n",
+    "    # plot central pixel\n",
+    "    center_loc = img.shape[0] // 2\n",
+    "    ax.scatter([center_loc], [center_loc], s=100, edgecolor='white', facecolor='none')\n",
+    "    \n",
+    "    # plot sky coord of central pixel\n",
+    "    cc = SkyCoord(*cutout.wcs.all_pix2world([center_loc],[center_loc], 0), unit=u.degree)\n",
+    "    ax.scatter_coord(cc, s=50, edgecolor='yellow', facecolor='none')\n",
+    "    \n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a737be26-ab56-43a6-97a6-87412e5a1949",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print the cutout wcs\n",
+    "wcs = WCS(header)\n",
+    "print(wcs, '\\n')\n",
+    "\n",
+    "# print FITS WCS position of various sky coordinates\n",
+    "print(\"SkyCoords Info:\")\n",
+    "print('Input Requested', coord)\n",
+    "\n",
+    "# plot the figure with wcs\n",
+    "plot_cutout_world(cutout, img, coord, wcs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "60b7e1a4-3d17-45a9-984e-7f27b98cd816",
+   "metadata": {},
+   "source": [
+    "## Create Image Cutout (ASDF)\n",
+    "Now, we will create the image cutout as an ASDF file. This time, we will take the cutout from a different section of the original image, and make it a bit longer on each side."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8b65ff3f-de2d-4348-babd-75df9842f360",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# define cutout size\n",
+    "cutout_size = 300\n",
+    "\n",
+    "# define cutout coordinates\n",
+    "coord = SkyCoord('0.8 0.3', unit='deg')\n",
+    "\n",
+    "# create the image cutout as an ASDF file\n",
+    "cutout_asdf = asdf_cut(asdf_file_uri, coord.ra, coord.dec, cutout_size=cutout_size, output_file=\"roman-demo.asdf\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6059a6f-e854-49c9-924b-9b98be726a39",
+   "metadata": {},
+   "source": [
+    "## Inspect Cutout Image (ASDF)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32efde9c-e218-48c1-be3b-4430b4110927",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('shape:', cutout_asdf.shape)\n",
+    "print('orginal position:', cutout_asdf.input_position_original)\n",
+    "print('cutout position:', cutout_asdf.input_position_cutout)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb970e0d-17db-40b6-9be0-7c13a7f10eff",
+   "metadata": {},
+   "source": [
+    "### Cutout in Pixel Coordinates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9692964e-9467-48d0-a65b-1897612fbcdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_cutout_pixel(cutout_asdf.data.value)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8568536a-8b82-407c-a70d-b35610c340ca",
+   "metadata": {},
+   "source": [
+    "### Cutout in Sky Coordinates"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d7f663f0-ccd0-473a-b351-feee6cc805fe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print the cutout wcs\n",
+    "print(cutout_asdf.wcs, '\\n')\n",
+    "\n",
+    "# print FITS WCS position of various sky coordinates\n",
+    "print(\"SkyCoords Info:\")\n",
+    "print('Input Requested', coord)\n",
+    "\n",
+    "# plot the figure with wcs\n",
+    "plot_cutout_world(cutout_asdf, cutout_asdf.data.value, coord, cutout_asdf.wcs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5b604f31-2363-4c6d-b509-1cd33963632d",
+   "metadata": {},
+   "source": [
+    "# Partial Image Cutouts\n",
+    "\n",
+    "Sometimes, cutouts are made near the edge of Roman images. In these cases, part of the cutout may fall outside of the original image.\n",
+    "\n",
+    "The `asdf_cut` function takes an optional `fill_value` parameter for this circumstance. It describes the value that should be given to any pixels in the cutout that fall outside of the input image. The default value is `np.nan`.\n",
+    "\n",
+    "To illustrate this, we will take a cutout from the lower right corner of the image."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e44ac158-b88e-484a-95f8-4ada5f0803de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Roman images are 4088 x 4088, so pick values for edge_x and edge_y that are greater than 4088 - cutout_size\n",
+    "cutout_size = 300\n",
+    "edge_x = 4000\n",
+    "edge_y = 4000\n",
+    "\n",
+    "# convert to sky coordinates\n",
+    "edge_coord = gwcs(edge_x, edge_y, with_units=True)\n",
+    "edge_coord"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15743bb8-9815-4472-8d15-48f51bf70651",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot expected cutout on original image\n",
+    "print('Expected cutout position:')\n",
+    "pc, ww = get_center_pixel(gwcs, edge_coord.ra, edge_coord.dec)\n",
+    "plt.imshow(data.value, vmin=0, vmax=5, origin='lower')\n",
+    "tmp = Cutout2D(data, position=pc, wcs=ww, size=cutout_size, mode='partial')\n",
+    "tmp.plot_on_original(color='red')\n",
+    "padding = 500\n",
+    "plt.xlim(edge_x - padding, edge_x + padding)\n",
+    "plt.ylim(edge_y - padding, edge_y + padding)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2c9d0f88-ec6c-4aeb-ad3e-7f92c0e4a661",
+   "metadata": {},
+   "source": [
+    "Notice how the top and right side of the square are outside of the image? We can assign the value of these pixels in our cutout using the `fill_value` parameter.\n",
+    "\n",
+    "### Create Image Cutout\n",
+    "\n",
+    "We will create the partial cutout as a FITS file, and we will fill in any outside pixels with a value of 0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "956ab4b3-8609-4493-8603-41e03143ae96",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create the image cutout as a FITS file\n",
+    "cutout_partial = asdf_cut(asdf_file_uri, edge_coord.ra, edge_coord.dec, cutout_size=cutout_size, \n",
+    "                  fill_value=0, output_file=\"partial-cut.fits\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8bacd46f-c449-4689-8451-95f060aff5a0",
+   "metadata": {},
+   "source": [
+    "### Inspect Image Cutout"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8c4166c5-62d4-46b1-af35-3754d006a599",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('shape:', cutout_partial.shape)\n",
+    "print('orginal position:', cutout_partial.position_original)\n",
+    "print('cutout position:', cutout_partial.position_cutout, '\\n')\n",
+    "\n",
+    "with fits.open(\"partial-cut.fits\") as hdulist:\n",
+    "    hdulist.info()\n",
+    "    header_partial = hdulist[0].header\n",
+    "    img_partial = hdulist[0].data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44897d9e-07bf-4729-b3fa-7ec8d4556102",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# plot cutout in pixel coordinates\n",
+    "plot_cutout_pixel(img_partial)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a315be9b-53ec-4852-a79c-b21682b375de",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# print the cutout wcs\n",
+    "wcs = WCS(header_partial)\n",
+    "print(wcs, '\\n')\n",
+    "\n",
+    "# print FITS WCS position of various sky coordinates\n",
+    "print(\"SkyCoords Info:\")\n",
+    "print('Input Requested', edge_coord)\n",
+    "\n",
+    "# plot the figure with wcs\n",
+    "plot_cutout_world(cutout_partial, img_partial, edge_coord, wcs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16d79e1a-8175-4482-8a41-9fb3a713837c",
+   "metadata": {},
+   "source": [
+    "As expected, the pixels that fall outside of the original image have been assigned a value of 0."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26b9e4a3-3321-488f-b72b-f2d4a16bf4c8",
+   "metadata": {},
+   "source": [
+    "# Additional Resources\n",
+    "- [Astrocut Documentation](https://astrocut.readthedocs.io)\n",
+    "- [Advanced Scientific Data Format Documentation](https://asdf.readthedocs.io/en/latest/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99d925a3-122e-4742-91d2-979efaa4d0a5",
+   "metadata": {},
+   "source": [
+    "# About this Notebook\n",
+    "\n",
+    "**Authors**: Thomas Dutkiewicz, Brian Cherinka, Sam Bianco<br>\n",
+    "**Last Updated**: May 2024"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b20a4a1-2c07-488e-ac35-ae08b965e97f",
+   "metadata": {},
+   "source": [
+    "***"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "86513da4-1356-4a23-b264-3a2f835b3bc7",
+   "metadata": {},
+   "source": [
+    "[Top of Page](#top)\n",
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Roman Calibration latest (2024-03-25)",
+   "language": "python",
+   "name": "roman-cal"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/roman_cutouts/roman_cutouts.ipynb
+++ b/notebooks/roman_cutouts/roman_cutouts.ipynb
@@ -318,11 +318,11 @@
     "coord = center_coord\n",
     "\n",
     "# plot expected cutout on original image\n",
-    "print('Expected cutout position:')\n",
     "pc, ww = get_center_pixel(gwcs, coord.ra, coord.dec)\n",
     "plt.imshow(data.value, vmin=0, vmax=5, origin='lower')\n",
     "tmp = Cutout2D(data, position=pc, wcs=ww, size=cutout_size, mode='partial')\n",
     "tmp.plot_on_original(color='red')\n",
+    "plt.title('Expected Cutout Position')\n",
     "padding = 500\n",
     "plt.xlim(pix_x - padding, pix_x + padding)\n",
     "plt.ylim(pix_y - padding, pix_y + padding)\n",
@@ -409,16 +409,9 @@
     "def plot_cutout_pixel(img):\n",
     "    plt.figure(figsize=(6, 6))\n",
     "    plt.imshow(img, vmin=0, vmax=5, origin=\"lower\")\n",
-    "    plt.show()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9b6907af",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "    plt.title('Cutout in Pixel Coordinates')\n",
+    "    plt.show()\n",
+    "\n",
     "plot_cutout_pixel(img)"
    ]
   },
@@ -440,6 +433,7 @@
     "def plot_cutout_world(cutout, img, coord, wcs):        \n",
     "    # plot the figure with wcs\n",
     "    plt.figure(figsize=(6, 6))\n",
+    "    plt.title('Cutout in Sky Coordinates')\n",
     "    ax = plt.subplot(projection=wcs)\n",
     "    ax.imshow(img, vmin=0, vmax=5, origin='lower')\n",
     "    ax.grid(color='white', ls='solid')\n",
@@ -622,11 +616,11 @@
    "outputs": [],
    "source": [
     "# plot expected cutout on original image\n",
-    "print('Expected cutout position:')\n",
     "pc, ww = get_center_pixel(gwcs, edge_coord.ra, edge_coord.dec)\n",
     "plt.imshow(data.value, vmin=0, vmax=5, origin='lower')\n",
     "tmp = Cutout2D(data, position=pc, wcs=ww, size=cutout_size, mode='partial')\n",
     "tmp.plot_on_original(color='red')\n",
+    "plt.title('Expected Cutout Position')\n",
     "padding = 500\n",
     "plt.xlim(edge_x - padding, edge_x + padding)\n",
     "plt.ylim(edge_y - padding, edge_y + padding)\n",

--- a/notebooks/roman_cutouts/roman_cutouts.ipynb
+++ b/notebooks/roman_cutouts/roman_cutouts.ipynb
@@ -456,6 +456,8 @@
     "    \"\"\" Display the cutout using world coordinate system \"\"\"\n",
     "    plt.figure(figsize=(6, 6))\n",
     "    plt.title('Cutout in Sky Coordinates')\n",
+    "    plt.xticks([])\n",
+    "    plt.yticks([])\n",
     "    ax = plt.subplot(projection=wcs)\n",
     "    ax.imshow(img, vmin=0, vmax=5, origin='lower')\n",
     "    ax.grid(color='white', ls='solid')\n",

--- a/notebooks/roman_cutouts/roman_cutouts.ipynb
+++ b/notebooks/roman_cutouts/roman_cutouts.ipynb
@@ -427,6 +427,7 @@
    "outputs": [],
    "source": [
     "def plot_cutout_pixel(img):\n",
+    "    \"\"\" Display the cutout using pixel coordinates \"\"\"\n",
     "    plt.figure(figsize=(6, 6))\n",
     "    plt.imshow(img, vmin=0, vmax=5, origin=\"lower\")\n",
     "    plt.title('Cutout in Pixel Coordinates')\n",
@@ -451,8 +452,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def plot_cutout_world(cutout, img, coord, wcs):        \n",
-    "    # plot the figure with wcs\n",
+    "def plot_cutout_world(cutout, img, coord, wcs):    \n",
+    "    \"\"\" Display the cutout using world coordinate system \"\"\"\n",
     "    plt.figure(figsize=(6, 6))\n",
     "    plt.title('Cutout in Sky Coordinates')\n",
     "    ax = plt.subplot(projection=wcs)\n",
@@ -506,7 +507,7 @@
    "metadata": {},
    "source": [
     "## Create Image Cutout in ASDF Format\n",
-    "Now, we will create the image cutout as an ASDF file. This time, we will take the cutout from a different section of the original image, and make it 300 pixels on each side."
+    "Now, we will create the image cutout as an ASDF file. We will create the cutout with the same parameters as the FITS version to illustrate that both cutouts contain the same data."
    ]
   },
   {
@@ -517,10 +518,10 @@
    "outputs": [],
    "source": [
     "# define cutout size\n",
-    "cutout_size = 300\n",
+    "cutout_size = 200\n",
     "\n",
     "# define cutout coordinates\n",
-    "coord = SkyCoord('0.8 0.3', unit='deg')\n",
+    "coord = center_coord\n",
     "\n",
     "# create the image cutout as an ASDF file\n",
     "cutout_asdf = asdf_cut(asdf_file_uri, coord.ra, coord.dec, cutout_size=cutout_size, output_file=\"roman-demo.asdf\")"


### PR DESCRIPTION
This notebook checklist has been made available to us by the [the Notebooks For All team](https://github.com/Iota-School/notebooks-for-all/blob/main/resources/event-hackathon/notebook-authoring-checklist.md).
Its purpose is to serve as a guide for both the notebook author and the technical reviewer highlighting critical aspects to consider when striving to develop an accessible and effective notebook.

### The First Cell

- [x] The title of the notebook in a first-level heading (eg. `<h1>` or `# in markdown`).
- [x] A brief description of the notebook.
- [x] A table of contents in an [ordered list](https://www.markdownguide.org/basic-syntax/#ordered-lists) (`1., 2.,` etc. in Markdown).
- [x] The author(s) and affiliation(s) (if relevant).
- [ ] The date first published.
- [x] The date last edited (if relevant).
- [x] A link to the notebook's source(s) (if relevant).

### The Rest of the Cells

- [x] There is only one H1 (`#` in Markdown) used in the notebook.
- [x] The notebook uses other [heading tags](https://www.markdownguide.org/basic-syntax/#headings) in order (meaning it does not skip numbers). 

## Text

- [x] All link text is descriptive. It tells users where they will be taken if they open the link.
- [x] All acronyms are defined at least the first time they are used. 
- [x] Field-specific/specialized terms are used when needed, but not excessively.

## Code

- [x] Code sections are introduced and explained before they appear in the notebook. This can be fulfilled with a heading in a prior Markdown cell, a sentence preceding it, or a code comment in the code section.
- [x] Code has explanatory comments (if relevant). This is most important for long sections of code.
- [x] If the author has control over the syntax highlighting theme in the notebook, that theme has enough color contrast to be legible.
- [x] Code and code explanations focus on one task at a time. Unless comparison is the point of the notebook, only one method for completing the task is described at a time.

### Images

- [x] All images (jpg, png, svgs) have an [image description](https://www.w3.org/WAI/tutorials/images/decision-tree/). This could be
    - [x] [Alt text](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt) (an `alt` property) 
    - [x] [Empty alt text](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt#decorative_images) for decorative images/images meant to be skipped (an `alt` attribute with no value)
    - [x] Captions
    - [x] If no other options will work, the image is decribed in surrounding paragraphs.

- [x] Any [text present in images](https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html) exists in a text form outside of the image (this can be alt text, captions, or surrounding text.)

### Visualizations

- [x] All visualizations have an image description. Review the previous section, Images, for more information on how to add it.
- [x] [Visualization descriptions](http://diagramcenter.org/specific-guidelines-e.html) include
    - [x] The type of visualization (like bar chart, scatter plot, etc.)
    - [x] Title
    - [x] Axis labels and range
    - [x] Key or legend
    - [x] An explanation of the visualization's significance to the notebook (like the trend, an outlier in the data, what the author learned from it, etc.)

- [x] All visualizations and their parts have [enough color contrast](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) ([color contrast checker](https://webaim.org/resources/contrastchecker/)) to be legible. Remember that transparent colors have lower contrast than their opaque versions.
- [ ] All visualizations [convey information with more visual cues than color coding](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html). Use text labels, patterns, or icons alongside color to achieve this.
- [ ] All visualizations have an additional way for notebook readers to access the information. Linking to the original data, including a table of the data in the same notebook, or sonifying the plot are all options.