### PR TITLE
Minor cosmetic changes to webbpsf notebook

### DIFF
--- a/content/notebooks/webbpsf/webbpsf.ipynb
+++ b/content/notebooks/webbpsf/webbpsf.ipynb
@@ -79,7 +79,7 @@
    "id": "8d611320-085b-4683-be9f-88cd62c417a5",
    "metadata": {},
    "source": [
-    "We also edit `matplotlib` configuration parameters to make figures larger by default and prevent any smoothing of pixel edges."
+    "We also edit `matplotlib`'s interpolation setting to prevent any smoothing of pixel edges."
    ]
   },
   {
@@ -89,7 +89,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "matplotlib.rcParams['figure.figsize'] = (16, 7)\n",
     "matplotlib.rcParams['image.interpolation'] = 'nearest'"
    ]
   },
@@ -124,7 +123,9 @@
    "source": [
     "#### Default parameters\n",
     "\n",
-    "After selecting the proper instrument (Roman WFI), generating a PSF can be as short as a single line."
+    "After selecting the proper instrument (Roman WFI), generating a PSF can be as short as a single line.\n",
+    "\n",
+    "**Note:** allow about a minute for this to run"
    ]
   },
   {
@@ -135,6 +136,7 @@
    "outputs": [],
    "source": [
     "wfi = webbpsf.roman.WFI()\n",
+    "plt.figure(figsize=(6, 8))\n",
     "default_psf = wfi.calc_psf(display=True)"
    ]
   },


### PR DESCRIPTION
- Changed figure size for first figure because some labels were overlapping. It now aligns with [the similar figure in the documentation](https://webbpsf.readthedocs.io/en/latest/usage.html#Basic-Usage-and-Examples)
- Added note that first figure takes about a minute to run