### PR TITLE
Bug assigning input flux and shear

### DIFF
--- a/content/notebooks/measuring_galaxy_shapes/measuring_galaxy_shapes.ipynb
+++ b/content/notebooks/measuring_galaxy_shapes/measuring_galaxy_shapes.ipynb
@@ -596,8 +596,8 @@
    "source": [
     "def sersic_mod(cutout, n, hlr, influx, pa, x0, y0, q):\n",
     "    nx, ny = cutout.array.shape\n",
-    "    ser = galsim.Sersic(n, half_light_radius=hlr, flux=flux)\n",
-    "    ser.shear(q=q, beta=pa * galsim.degrees)  # change PA and axis ratio\n",
+    "    ser = galsim.Sersic(n, half_light_radius=hlr, flux=influx)\n",
+    "    ser = ser.shear(q=q, beta=pa * galsim.degrees)  # change PA and axis ratio\n",
     "    offset = galsim.PositionD(x=x0, y=y0)  # potentially shift a bit the profile\n",
     "    ser = galsim.convolve.Convolve(ser, psf_obj)  # add PSF\n",
     "    img = galsim.ImageD(nx, ny, scale=0.11)  \n",


### PR DESCRIPTION
In the `measuring_galaxy_shapes` notebook. There's a bug in the function that generates the model for fitting, that dismisses both shear and user-provided input flux.