### PR TITLE
Fix call to ELP

### DIFF
--- a/content/notebooks/romancal/romancal.ipynb
+++ b/content/notebooks/romancal/romancal.ipynb
@@ -132,8 +132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pipe = ExposurePipeline(save_results=False, steps={'source_detection': {'skip': True}, 'tweakreg': {'skip': True}})\n",
-    "result = pipe.process('r0000101001001001001_01101_0001_WFI01_uncal.asdf')"
+    "result = ExposurePipeline.call('r0000101001001001001_01101_0001_WFI01_uncal.asdf', save_results=False, steps={'source_catalog': {'skip': True}, 'tweakreg': {'skip': True}})"
    ]
   },
   {
@@ -222,8 +221,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wcs_step = romancal.assign_wcs.AssignWcsStep()\n",
-    "result = wcs_step.process(dm)"
+    "result = romancal.assign_wcs.AssignWcsStep.call(dm)"
    ]
   },
   {
@@ -255,8 +253,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# wcs_step = romancal.assign_wcs.AssignWcsStep(override_distortion='my_distortion_file.asdf')\n",
-    "# result = wcs_step.process(dm)"
+    "# wcs_step = romancal.assign_wcs.AssignWcsStep.call(dm, override_distortion='my_distortion_file.asdf')"
    ]
   },
   {
@@ -309,9 +306,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Roman Calibration latest (2024-03-25)",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "roman-cal"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -323,7 +320,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR does two things
- Fixes the way the exposure level pipeline and a step are called by using the `.call` method. 
There are two ways to execute a step or a pipeline.
   `.call` : combines parameter values from the defaults in the code, CRDS parameter files and user supplied parameters
   `.run`: uses the default parameter values in the code and ignores parameter files in CRDS.
- Changes the step name : `source_detection` to `source_catalog` as this has changed in the pipeline. The change was made in romancal v 16.