### PR TITLE
Fix file name for grism data

### DIFF
--- a/content/notebooks/grism_spectral_extraction/grism_spectral_extraction.ipynb
+++ b/content/notebooks/grism_spectral_extraction/grism_spectral_extraction.ipynb
@@ -124,7 +124,7 @@
     "    direct_img = direct_asdf.data.copy()\n",
     "\n",
     "# Read in the grism image\n",
-    "asdf_file_uri = asdf_dir_uri + 'r0007601002004013001_0001_wfi01_grism_cal.asdf'\n",
+    "asdf_file_uri = asdf_dir_uri + 'r0007601002004013002_0001_wfi01_grism_cal.asdf'\n",
     "with fs.open(asdf_file_uri, 'rb') as f:\n",
     "    af = asdf.open(f)\n",
     "    grism_asdf = rdm.open(af)\n",


### PR DESCRIPTION
File name for grism data off by one character causing cell to crash. This updates to the correct file name.