### PR TITLE
Workshop bug fixes

### DIFF
--- a/content/notebooks/aperture_photometry/aperture_photometry.ipynb
+++ b/content/notebooks/aperture_photometry/aperture_photometry.ipynb
@@ -147,7 +147,7 @@
     "    with fs.open(asdf_file_uri, 'rb') as f:\n",
     "        af = asdf.open(f)\n",
     "        dm = rdm.open(af)\n",
-    "        image = dm.data.value.copy()\n",
+    "        image = dm.data.copy()\n",
     "        wcs = copy.deepcopy(dm.meta.wcs)"
    ]
   },
@@ -448,7 +448,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.8"
   }
  },
  "nbformat": 4,

--- a/content/notebooks/working_with_asdf/working_with_asdf.ipynb
+++ b/content/notebooks/working_with_asdf/working_with_asdf.ipynb
@@ -127,10 +127,11 @@
     "asdf_dir_uri = 's3://roman-sci-test-data-prod-summer-beta-test/'\n",
     "fs = s3fs.S3FileSystem()\n",
     "\n",
-    "asdf_file_uri_l2 = asdf_dir_uri + 'ROMANISIM/DENSE_REGION/R0.5_DP0.5_PA0/r0000101001001001001_01101_0001_WFI01_cal.asdf'\n",
+    "asdf_file_uri_l2 = asdf_dir_uri + 'AAS_WORKSHOP/r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
     "\n",
     "with fs.open(asdf_file_uri_l2, 'rb') as fb:\n",
-    "    f = rdm.open(fb).copy()"
+    "    af = asdf.open(fb)\n",
+    "    f = rdm.open(af).copy()"
    ]
   },
   {


### PR DESCRIPTION
Remove .value call in photometry notebook that causes it to crash after quantity arrays were removed