### PR TITLE
Fix Mosaic Pipeline for AAS246

### DIFF
--- a/content/notebooks/mosaic_pipeline/mosaic_pipeline.ipynb
+++ b/content/notebooks/mosaic_pipeline/mosaic_pipeline.ipynb
@@ -236,7 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mos_file = rdm.open('my_roman_mosaic_i2d.asdf')\n",
+    "mos_file = rdm.open('my_roman_mosaic_coadd.asdf')\n",
     "mos_file.info()"
    ]
   },
@@ -284,7 +284,7 @@
    "source": [
     "## About this Notebook\n",
     "**Author:** Tyler Desjardins\\\n",
-    "**Updated On:** 2025-01-10"
+    "**Updated On:** 2025-05-26"
    ]
   },
   {
@@ -319,7 +319,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/content/notebooks/mosaic_pipeline/mosaic_pipeline.ipynb
+++ b/content/notebooks/mosaic_pipeline/mosaic_pipeline.ipynb
@@ -42,8 +42,12 @@
     "\n",
     "## Imports\n",
     " Libraries used\n",
-    "- *romancal* for running the processing pipeline\n",
+    "- *romancal* for creating association files and running the pipeline\n",
+    "- *astropy.visualization* for creating image normalizations\n",
     "- *roman_datamodels* for opening Roman WFI ASDF files\n",
+    "- *glob* for creating lists of files\n",
+    "- *os* for checking if files exist\n",
+    "- *json* for creating association files\n",
     "- *s3fs* for streaming files from an S3 bucket"
    ]
   },
@@ -84,9 +88,7 @@
     "3. **Outlier detection step:** Examine the input images to detect and flag outliers in the pixel values for a given sky position.\n",
     "4. **Resample step:** Use the drizzle algorithm to combine the input data products. Reject outliers and other undesirable pixels based on data quality flags and oversample the pixels if indicated.\n",
     "\n",
-    "**Note:** L3 data products in the Roman Archive will be tessellated on the sky such that individual L3 files (\"sky cells\") will be small with some overlap between adjacent cells. More information is available on the [RDox pages on sky tessellation](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/skymap-tessellation). In this tutorial, we will not utilize tessellation. The tutorial will be updated in the future to demonstrate the creation of both tessellated and non-tessellated products.\n",
-    "\n",
-    "**Note:** An additional step, the source catalog step, is included at the end of the Mosaic Pipeline to create Level 4 (L4; catalogs and other high-level products) products. In this tutorial, the source catalog step has been disabled. As development on the Roman pipeline is ongoing, enabling the source catalog step may currently result in an error."
+    "**Note:** L3 data products in the Roman Archive will be tessellated on the sky such that individual L3 files (\"sky cells\") will be small with some overlap between adjacent cells. More information is available on the [RDox pages on sky tessellation](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/skymap-tessellation). In this tutorial, we will not utilize tessellation. The tutorial will be updated in the future to demonstrate the creation of both tessellated and non-tessellated products."
    ]
   },
   {
@@ -120,9 +122,9 @@
     "\n",
     "Association table files (often abbreviated \"association files\" or \"ASN files\") are JavaScript Object Notation (JSON) formatted files containing a list of the input products to be processed together, and the output products to be created. In the Mosaic Pipeline, association files specifically enumerate the input L2 products that are used to create a single L3 product. For more information, please visit the [RDox pages on association files](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products/associations).\n",
     "\n",
-    "The association generator function `asn_from_list()` can be used to create a properly formatted JSON file for use with the Mosaic Pipeline. The code takes as input a list of L2 products and the name of the L3 output product.\n",
+    "The association generator function `asn_from_list()` can be used to create a properly formatted JavaScript Object Notation (JSON) file for use with the Mosaic Pipeline. The code takes as input a list of L2 products and the name of the L3 output product. You can include either one or many L2 products as input. For use cases that do use a single input file, you can skip several pipeline steps (skymatch and outlier_detection).\n",
     "\n",
-    "If you have not completed the previous tutorial [Calibrating WFI Exposures with RomanCal](../exposure_pipeline/exposure_pipeline.ipynb), then you can download the data products from the Nexus S3 bucket. The code cell below will check if you have the files saved on disk and, if not, it will retrieve them from the S3 bucket."
+    "If you have not completed the previous [Exposure Pipeline](../exposure_pipeline/exposure_pipeline.ipynb) tutorial, then you can download the data products from the Nexus S3 bucket. The code cell below will check if you have the files saved on disk and, if not, it will retrieve them from the S3 bucket."
    ]
   },
   {
@@ -210,6 +212,10 @@
     "### Running the Mosaic Pipeline\n",
     "\n",
     "Next we run the Mosaic Pipeline using the `MosaicPipeline` class. As with the L1 to L2 Exposure Pipeline, there are many optional arguments to customize the behavior of the pipeline. At this time, we will not delve into these optional parameters. The simulated input files are based on a simple gap-filling dither pattern rather than sub-pixel dithering optimized for the point spread function(PSF). As a result, we use the default native sampling of the WFI detectors. In the future, additional details may be provided to explore optimizing the Mosaic Pipeline output.\n",
+    "\n",
+    "If we had only a single input image, this is where we would skip the skymatch and outlier detection steps by passing the optional argument `steps={'skymatch': {'skip': True}, 'outlier_detection': {'skip': True}}`. For now, we will skip the source catalog step that would normally make the single-band source catalog and segmentation map, which are Level 4 (L4; high-level extracted information) files.\n",
+    "\n",
+    "**IMPORTANT NOTE:** At this time, L4 products are still being developed and validated, and we expect significant changes in their format and the algorithms used to generate them. We do not recommend the use of these products until they are fully validated.\n",
     "\n",
     "**Note:** The following cell will take several minutes to complete."
    ]
@@ -305,9 +311,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Calibration",
    "language": "python",
-   "name": "python3"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {
@@ -319,7 +325,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.10"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR updates the suffix of the L3 products created by the mosaic pipeline. This was necessary because one of the cells broke looking for `*_i2d.asdf` when it needs to look for `*_coadd.asdf` now.