### PR TITLE
Update Data Visualization for AAS246

### DIFF
--- a/content/notebooks/data_visualization/data_visualization.ipynb
+++ b/content/notebooks/data_visualization/data_visualization.ipynb
@@ -39,11 +39,16 @@
     "## Imports\n",
     "- *astropy.visualization.simple_norm* for automatically scaling image arrays\n",
     "- *astropy.coordinates.SkyCoord* to create Python objects containing sky coordinate transforms\n",
+    "- *astropy.table.Table* to create Astropy tables\n",
+    "- *astropy.wcs.WCS* to create Astropy WCS objects\n",
+    "- *copy* to copy Python objects in memory\n",
     "- *matplotlib.pyplot* for creating static image previews\n",
+    "- *numpy* for array calculations and manipulation\n",
     "- *jdaviz.Imviz* to examine Wide Field Instrument (WFI) images interactively\n",
     "- *roman_datamodels* for opening Roman WFI ASDF files\n",
     "- *asdf* for opening Roman WFI ASDF files\n",
-    "- *time* for creating pauses in the notebook cells"
+    "- *time* for creating pauses in the notebook cells\n",
+    "- *s3fs* to access data in an AWS S3 bucket"
    ]
   },
   {
@@ -60,6 +65,8 @@
     "from astropy.visualization import simple_norm\n",
     "from astropy.coordinates import SkyCoord\n",
     "from astropy.table import Table\n",
+    "from astropy.wcs import WCS\n",
+    "import copy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "\n",
@@ -157,7 +164,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see a bright, extended source in the lower portion of the image. We isolate and examine that region a little more closely. Looking at the output image above, we can see that it is located approximately between science Y coordinates 3000 – 3500 and science X coordinates 1750 - 2250."
+    "We can see a bright, extended sources in the right portion of the image. We isolate and examine that region a little more closely. Based on the image above, let's isolate science Y coordinates 2000 – 2500 and science X coordinates 3500 - 4000."
    ]
   },
   {
@@ -166,13 +173,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Close the previous figure\n",
+    "plt.close()\n",
+    "\n",
+    "# Make new figure zoomed in on 1750 <= X <= 2250 and 500 <= Y <= 1000:\n",
     "fig, ax = plt.subplots(figsize=(8, 6))\n",
     "sc = ax.imshow(file.data, norm=norm, origin='lower')\n",
     "ax.set_xlabel('X Science Axis (pixels)')\n",
     "ax.set_ylabel('Y Science Axis (pixels)')\n",
-    "ax.set_title('Roman I-Sim Simulation WFI01')\n",
-    "ax.set_xlim(1750, 2250)\n",
-    "ax.set_ylim(3000, 3500)\n",
+    "ax.set_title('Roman I-Sim Simulation (Data) WFI01')\n",
+    "ax.set_xlim(3500, 4088)\n",
+    "ax.set_ylim(2000, 2588)\n",
     "plt.colorbar(sc, ax=ax)\n",
     "plt.tight_layout();"
    ]
@@ -181,7 +192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we want to add information about the sky coordinates rather than displaying the image in pixels, we can use the `gwcs.wcs.WCS` object in the file metadata."
+    "We can see some strange features in the right side of this image. They were also in the previous plot, but were not as evident at the previous level of zoom. These features are not some interesting new science, but are actually instrumental artifacts, and we can see in the data quality (DQ) array that they are marked for our reference in any analysis we may perform. Not all artifacts or DQ flags are necessarily bad for analysis, but here we show all pixels with DQ values > 0 (any quality flags; white) compared to pixels with DQ values equal to 0 (good; black). For more information on how to work with DQ flags, see the [Working with ASDF](../working_with_asdf/working_with_asdf.ipynb) tutorial. The [Detector Performance](https://roman-docs.stsci.edu/roman-instruments-home/wfi-imaging-mode-user-guide/wfi-detectors/detector-performance) article and the articles under it will provide detail on instrumental artifacts and detector performance. Please note that several analyses are still ongoing and RDox will be updated in the future."
    ]
   },
   {
@@ -190,12 +201,67 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(8, 6), subplot_kw={'projection': file.meta.wcs})\n",
+    "# Close the previous figure\n",
+    "plt.close()\n",
+    "\n",
+    "# Display the data quality (DQ) array for the same region.\n",
+    "# Convert the DQ values to boolean True (bad) and False (good) for simple display.\n",
+    "# The binary colormap normally goes from white to black, but we have inverted it\n",
+    "# using binary_r to ease visibility of flagged pixels.\n",
+    "fig, ax = plt.subplots(figsize=(8, 6))\n",
+    "ax.imshow(np.bool(file.dq), origin='lower', cmap='binary_r')\n",
+    "ax.set_xlabel('X Science Axis (pixels)')\n",
+    "ax.set_ylabel('Y Science Axis (pixels)')\n",
+    "ax.set_title('Roman I-Sim Simulation (DQ) WFI01')\n",
+    "ax.set_xlim(3500, 4088)\n",
+    "ax.set_ylim(2000, 2588)\n",
+    "plt.tight_layout();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we want to add information about the sky coordinates rather than displaying the image in pixels, we can use the `gwcs.wcs.WCS` object in the file metadata. To overlay the coordinate grid, however, we will need to transform the WCS to an `astropy.wcs.WCS` object, which needs a FITS Simple Imaging Polynomial (SIP) representation of the WCS. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close the previous figure\n",
+    "plt.close()\n",
+    "\n",
+    "# Set the matplotlib backend (change this to \"%matplotlib widget\" for interactive plots)\n",
+    "%matplotlib inline\n",
+    "\n",
+    "fig, ax = plt.subplots(figsize=(8, 6), subplot_kw={'projection': WCS(file.meta.wcs.to_fits_sip())})\n",
     "sc = ax.imshow(file.data, norm=norm, origin='lower')\n",
-    "ax.grid(':', color='white', alpha=0.5)\n",
+    "ax.imshow(file.data, norm=norm, origin='lower')\n",
     "plt.colorbar(sc, ax=ax)\n",
+    "ax.grid(color='white', alpha=0.3)\n",
     "ax.set_xlabel('Right Ascension (deg)')\n",
-    "ax.set_ylabel('Declination (deg)');"
+    "ax.set_ylabel('Declination (deg)')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close figures before proceeding\n",
+    "plt.close('all')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can also use `matplotlib` to examine the image interactively using the `%matplotlib widget` magic command. To do this, try re-running the cell above, but replacing `%matplotlib inline` with `%matplotlib widget`. If you use this command, you will see some basic icons on the left of the image that allow you to pan, zoom, return to the original display, and save the current view to a file. Notice that the WCS gridlines will adjust for different levels of zoom. You can do this for any of the `matplotlib` plots above. For even more interactivity, we next look at Imviz."
    ]
   },
   {
@@ -207,8 +273,6 @@
     "### Introduction and Setup\n",
     "\n",
     "We can also use Imviz, the 2-D image viewer from the Jdaviz package, to visualize and explore the 2-D arrays contained within WFI L2 ASDF files. We highly recommend that users consult the [Imviz documentation](https://jdaviz.readthedocs.io/en/latest/imviz/index.html), which describes many of the features in Imviz in detail. In this tutorial, we will cover the basics to get you started.\n",
-    "\n",
-    "**Note:** An enhancement to Cubeviz, the 3-D datacube visualization tool in Jdaviz, will soon allow interactive exploration of WFI L1 data cubes. This functionality is currently being tested and will be available in a future Jdaviz release.\n",
     "\n",
     "The first cell below loads Imviz and creates a split panel to the right. You can control the height, or use a pop out window or an inline viewer. For more information, please see the [display options](https://jdaviz.readthedocs.io/en/latest/display.html) documentation."
    ]
@@ -231,9 +295,9 @@
     "\n",
     "### Loading Data and Programmatically Adjusting Display\n",
     "\n",
-    "Next, we load the image into Imviz. By default, for Roman WFI data, Imviz only loads the data array in the viewer to improve performance. Additional arrays (e.g., the data quality array) may be loaded using the `ext` optional argument. An example demonstrating how to load the data quality array is provided in a commented line in the following cell. For more information on the arrays contained within WFI L2 files, please see the RDox article on WFI [Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products#DataLevelsandProducts-L2ScienceDataSpecifications).\n",
+    "Next, we load the image into Imviz. By default, for Roman WFI data, Imviz only loads the data array in the viewer to improve performance. Additional arrays (e.g., the DQ array) may be loaded using the `ext` optional argument. An example demonstrating how to load the data quality array is provided in a commented line in the following cell. For more information on the arrays contained within WFI L2 files, please see the RDox article on WFI [Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products#DataLevelsandProducts-L2ScienceDataSpecifications).\n",
     "\n",
-    "**Note:** We have added a few pauses in the notebook cells with, e.g., `time.sleep(5)`, which should cause the cell to pause for several seconds before completing. This is to ensure that the previous cell has had enough time to complete its tasks before moving on to the next step. These pauses may make Imviz feel a little slow, but it is meant to slow you down so you don't try to issue new commands before the previous ones finish executing."
+    "**Note:** We have added a few pauses in the notebook cells with, e.g., `time.sleep(5)`, which should cause the cell to pause for several seconds before completing. This is to ensure that the previous cell has had enough time to complete its tasks before moving on to the next step. These pauses may make Imviz feel a little slow, but it is meant to slow you down so you don't try to issue new commands before the previous ones finish executing. You may still want to execute the following cells slowly to prevent errors. **Important:** if you do get an error message, try re-running the cell and waiting a moment."
    ]
   },
   {
@@ -249,6 +313,7 @@
     "with fs.open(asdf_file_uri, 'rb') as f:\n",
     "    af = asdf.open(f)\n",
     "    file = rdm.open(af)\n",
+    "    wcs1 = copy.copy(file.meta.wcs)\n",
     "    imviz.load_data(file, data_label='WFI01_POS1')\n",
     "    # imviz.load_data(file, ext='dq', data_label='WFI01 DQ')\n",
     "\n",
@@ -261,7 +326,7 @@
    "source": [
     "The colormap, stretch, and scale limits may be adjusted interactively in the viewer by clicking the plot options icon (three vertically-stacked sliders to the far right of the teal bar above the image display, hereafter the \"tool bar\"), and expanding the \"Plot Options\" section. Note that there are additional options such as the minimum and maximum scale limits under the \"More Stretch Options\" expander.\n",
     "\n",
-    "If we know the settings we want to apply, we can do so via the API as follows:"
+    "If we know the settings we want to apply, we can do so via the Imviz API as follows:"
    ]
   },
   {
@@ -282,7 +347,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we will display a second image, showing the same field but slightly dithered, and we will link the two images by their WCS. The second image is dithered by ~200 arcseconds compared to the first, so sources should move by ~1000 pixels between the two images. This is easy to observe with the galaxy in the bottom-left quadrant of the first image, which is located in the bottom-middle of the second image."
+    "Now we will display a second image, showing the same field but slightly dithered, and we will link the two images by their WCS. The second image is dithered by ~200 arcseconds compared to the first, so sources should move by ~1000 pixels between the two images."
    ]
   },
   {
@@ -295,6 +360,7 @@
     "with fs.open(asdf_file_uri, 'rb') as f:\n",
     "    af = asdf.open(f)\n",
     "    file = rdm.open(af)\n",
+    "    wcs2 = copy.copy(file.meta.wcs)\n",
     "    imviz.load_data(file, data_label='WFI01_POS2')\n",
     "\n",
     "viewer = imviz.default_viewer\n",
@@ -308,9 +374,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that the second image has been displayed, we can blink between the two using the \"b\" button. Make sure that your cursor is placed over the image to make it the active window, then blink between the images.\n",
+    "Now that the second image has been displayed, we can blink between the two using the \"b\" button. Make sure that your cursor is placed over the image to make it the active window, then blink between the images. Try identifying a few sources that are common between the two images to see the effect of dithering between exposures.\n",
     "\n",
-    "Similarly to our matplotlib demonstration, let's investigate a region of interest and focus on the large extended source in the lower portion of the image. In this case, we know the galaxy has science pixel coordinates of (X, Y) ~ (3100, 2000) pixels or sky coordinates of (RA, Dec) ~ (270.86998, -0.131080) degrees. This information can be determined from the catalog used to simulate the products, or may come from interactive examintion of the image or a source detection algorithm. Regardless of how we obtained the coordinates, we can center the viewer on them using the API as shown below:"
+    "Similarly to our matplotlib demonstration, let's investigate a region of interest and focus on the extended source in the right portion of the first image. In this case, we know the galaxy has science pixel coordinates of (X, Y) ~ (3700, 2300) pixels in the first image. We can use the WCS from the first image (which we saved as the variable `wcs1`) to transform this to sky coordinates:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ra, dec = wcs1(3700, 2300)\n",
+    "print(f'RA = {ra} deg, Dec = {dec} deg')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we can center the viewer at this position using the Imviz API as shown below. We can use either the sky coordinates, or alternatively the pixel coordinates (which has been commented out). Note that the centering occurs on the currently displayed image, so if you have the second image actively displayed and use the pixel coordinates, it will center to the incorrect location when using pixel coordinates from the first image. Using sky coordinates is independent of which image is actively displayed."
    ]
   },
   {
@@ -320,11 +403,11 @@
    "outputs": [],
    "source": [
     "# Center the image on given sky coordinates.\n",
-    "sky = SkyCoord(ra=270.86998, dec=-0.131080, unit=('deg', 'deg'))\n",
+    "sky = SkyCoord(ra=ra, dec=dec, unit=('deg', 'deg'))\n",
     "viewer.center_on(sky)\n",
     "\n",
     "# Center the image on given pixel coordinates.\n",
-    "# viewer.center_on((3100, 2000))\n",
+    "# viewer.center_on((3700, 2300))\n",
     "\n",
     "time.sleep(5)"
    ]
@@ -339,7 +422,7 @@
     "* 0.5: zoomed out by a factor of 2.\n",
     "* 'fit' means zoomed to fit the whole image into display.\n",
     "\n",
-    "In this case, we will set the zoom level to 0.4 so we can see the extended source in both images and blink between them. Recall that to blink the images, you need to place the cursor over the viewer and press the \"b\" key on your keyboard."
+    "In this case, we will set the zoom level to 1.2 so we can better see the extended source:"
    ]
   },
   {
@@ -348,7 +431,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.zoom_level = 0.4\n",
+    "viewer.zoom_level = 1.2\n",
     "time.sleep(5)"
    ]
   },
@@ -356,9 +439,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As you can see, when blinking the images in detector coordinates, the sources seem to move because the second image is slightly dithered. If we link the images by their WCS information, we see that the sources remain fixed, but the regions of the sky observed are slightly different.\n",
+    "Recall that to blink the images, you need to place the cursor over the viewer and press the \"b\" key on your keyboard. As you can see, when blinking the images in detector coordinates, the extended source is only visible in one image due to dithering between the exposures. Next, we will link the images by their WCS information so that the sources remain fixed in the display. Linking the images by WCS will reset the center and zoom, so let's reapply that as well.\n",
     "\n",
-    "**Note:** Roman WFI ASDF files use a Generalized World Coordinate System (gwcs) object in Python to store the WCS transformation. The transformation is only well-defined within a bounding box, and moving outside that bounding box produces unexpected behavior, particularly due to the polynomial terms in the transformation between pixel and sky coordinates. As a result, the current version of Imviz might have some difficulties with setting a position and zooming after linking the images by WCS."
+    "**Important note:** Roman WFI ASDF files use a Generalized World Coordinate System (GWCS) object in Python to store the WCS transformation. The transformation is only well-defined within a bounding box, and moving outside that bounding box produces unexpected behavior, particularly due to the polynomial terms in the transformation between pixel and sky coordinates. As a result, the current version of Imviz might have some difficulties with setting a position and zooming after linking the images by WCS."
    ]
   },
   {
@@ -376,7 +459,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can also save the current view to a PNG file on your cloud storage:"
+    "We can still pan and zoom manually to locate our galaxy of interest and use the 'b' button with the cursor on the Imviz window to blink between the two images. Blinking between the two images in any region where they overlap on the sky shows that we have succesfully aligned the images using sky coordinates.\n",
+    "\n",
+    "You can also save the current view to a PNG file on your Nexus storage:"
    ]
   },
   {
@@ -393,11 +478,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This should save the file to your current working directory on the the science platform. If you want to download this file, you can do so by right-clicking on the file in the file browser and selecting the \"Download\" option.\n",
+    "This should save the file to your current working directory on the Nexus. If you want to download this file, you can do so by right-clicking on the file in the file browser and selecting the \"Download\" option.\n",
     "\n",
     "### Overlaying Catalog Data\n",
     "\n",
-    "First, let's read in the catalog used to generate this image using Roman I-Sim:"
+    "A common exercise is to mark sources of interest on an image. We can do this with Imviz as well. First, let's read in the catalog used to generate this image using Roman I-Sim:"
    ]
   },
   {
@@ -416,7 +501,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are a lot of sources in this file, but let's pare them down somewhat for display purposes. In this case, let's filter down to the brightest ($m_{AB}$ < 18) sources in the F106 filter. The flux columns in the table are in units of maggies, which may be converted to AB magnitudes as $m_{AB} = -2.5\\log_{10}(f)$ where $m_{AB}$ is the magnitude in AB mags and $f$ is the flux in maggies."
+    "There are a lot of sources in this file, but let's pare them down somewhat for display purposes. In this case, let's filter down to the brightest ($m_{AB}$ < 18) sources in the F106 filter. The flux columns in the table are in units of maggies, which may be converted to AB magnitudes as $m_{AB} = -2.5\\log_{10}(f)$ where $m_{AB}$ is the magnitude in AB mags and $f$ is the flux in maggies.\n",
+    "\n",
+    "Let's also filter the catalog for sources that lie in the overlap region between the two images. We can do this by transforming our sky positions to pixel positions with the WCS objects from each image and creating a mask by combining multiple conditions on the pixel positions (i.e., that they must lie within the bounds 0 <= X <= 4088 and 0 <= Y <= 4088)."
    ]
   },
   {
@@ -425,9 +512,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Create SkyCoord objects\n",
+    "# Filter objects by brightness\n",
     "bright = np.where(-2.5 * np.log10(tab['F106']) < 18)\n",
-    "coords = Table({'coord': [SkyCoord(ra = tab['ra'][bright], dec = tab['dec'][bright], unit = 'deg')]})"
+    "\n",
+    "# Make SkyCoord objects\n",
+    "coords = SkyCoord(ra = tab['ra'][bright].value, dec = tab['dec'][bright].value, unit = 'deg')\n",
+    "\n",
+    "# Filter the SkyCoord objects on the WCS objects for each image to find only things in the overlap region.\n",
+    "x1, y1 = wcs1.invert(coords)\n",
+    "x2, y2 = wcs2.invert(coords)\n",
+    "mask = (x1 > 0) & (x1 < 4088) & (y1 > 0) & (y1 < 4088) & (x2 > 0) & (x2 < 4088) & (y2 > 0) & (y2 < 4088)\n",
+    "\n",
+    "final_coords = Table({'coord': coords[mask]})\n",
+    "print(f'Number of sources in overlap region: {len(final_coords)}')"
    ]
   },
   {
@@ -447,7 +544,7 @@
     "viewer.marker = {'color': 'white', 'alpha': 0.8, 'markersize': 120, 'fill': False}\n",
     "\n",
     "# Overlay markers\n",
-    "viewer.add_markers(coords, use_skycoord=True, marker_name='My_Markers')\n",
+    "viewer.add_markers(final_coords, use_skycoord=True, marker_name='My_Markers')\n",
     "time.sleep(5)"
    ]
   },
@@ -499,7 +596,7 @@
    "source": [
     "## About this Notebook\n",
     "**Author:** Tyler Desjardins, Brett Morris  \n",
-    "**Updated On:** 2025-01-09"
+    "**Updated On:** 2025-05-26"
    ]
   },
   {
@@ -520,9 +617,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Calibration",
    "language": "python",
-   "name": "python3"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {
@@ -534,7 +631,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/content/notebooks/exposure_pipeline/exposure_pipeline.ipynb
+++ b/content/notebooks/exposure_pipeline/exposure_pipeline.ipynb
@@ -42,6 +42,8 @@
     "- *roman_datamodels* for opening Roman WFI ASDF files\n",
     "- *asdf* for opening Roman WFI ASDF files\n",
     "- *os* for checking if files exist\n",
+    "- *copy* for making copies of Python objects\n",
+    "- *astropy.coordinates* for working with celestial coordinates\n",
     "- *s3fs* for streaming files from an S3 bucket"
    ]
   },
@@ -57,6 +59,8 @@
    "source": [
     "import roman_datamodels as rdm\n",
     "import asdf\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "import copy\n",
     "import romancal\n",
     "from romancal.pipeline import ExposurePipeline\n",
     "import os\n",
@@ -74,7 +78,7 @@
     "## Introduction\n",
     "The purpose of this notebook is to calibrate Level 1 (L1; uncalibrated ramp cube) data with the Roman WFI science calibration pipeline RomanCal (Python package name `romancal`) to produce Level 2 (L2; calibrated rate image) exposure level data. To learn more, please visit the [RDox pages on the Exposure Level Pipeline](https://roman-docs.stsci.edu/data-handbook-home/roman-stsci-data-pipelines/exposure-level-pipeline).\n",
     "\n",
-    "Details about the Roman data levels can be found in the RDox article [Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products). A L1 file contains a single uncalibrated ramp in units of Data Numbers (DN).  L1 files are three-dimensional data cubes, one dimension for time and two dimensions for image coordinates, that are shaped as  arrays with (N resultants, 4096 image rows, 4096 image columns). L2 WFI files are calibrated rate images in instrumental units of DN / second.  They are two-dimensional arrays shaped as (4088 image rows, 4088 image columns)."
+    "Details about the Roman data levels can be found in the RDox article [Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products). A L1 file contains a single uncalibrated ramp in units of Data Numbers (DN).  L1 files are three-dimensional data cubes, one dimension for time and two dimensions for image coordinates, that are shaped as  arrays with (N resultants, 4096 image rows, 4096 image columns). A resultant contains either one read or the arithmetic mean of multiple reads of the WFI detectors. L2 WFI files are calibrated rate images in instrumental units of DN / second.  They are two-dimensional arrays shaped as (4088 image rows, 4088 image columns). Note the smaller image size of L2 files, which is due to the removal of the 4-pixel border of reference pixels around the image during pipeline processing."
    ]
   },
   {
@@ -93,7 +97,7 @@
    },
    "source": [
     "## Tutorial Data\n",
-    "In this tutorial, we use L1 WFI data files simulated with `romanisim`. We will use as an example the output from running the [Roman I-Sim](../romanisim/romanisim.ipynb) tutorial notebook. If you did not run the simulation tutorial, then the files are also stored in the RRN S3 bucket. For more information on how to access these data, see the [Data Discovery and Access](../data_discovery_and_access/data_discovery_and_access.ipynb) tutorial."
+    "In this tutorial, we use L1 WFI data files simulated with `romanisim`. We will use as an example the output from running the [Roman I-Sim](../romanisim/romanisim.ipynb) tutorial notebook. If you did not run the simulation tutorial, then the files are also stored in the Nexus S3 bucket. For more information on how to access these data, see the [Data Discovery and Access](../data_discovery_and_access/data_discovery_and_access.ipynb) tutorial."
    ]
   },
   {
@@ -107,7 +111,7 @@
     "\n",
     "### Basic Example: Full Pipeline\n",
     "\n",
-    "The input file for our example is a WFI L1 ASDF file. We must copy the file to our local storage as the RomanCal exposure pipeline currently only works with an input file on disk. Individual pipeline steps (described further below) can run directly on datamodels in memory."
+    "The input file for our example is a WFI L1 ASDF file. We first check to see if we already have the file saved on disk (if the Roman I-Sim tutorial was run), and if not then we stream the L1 file into memory (as a datamodel) from the Nexus S3 bucket:"
    ]
   },
   {
@@ -116,23 +120,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if not os.path.exists('r0003201001001001004_0001_wfi01_f106_uncal.asdf'):\n",
+    "l1_file = 'r0003201001001001004_0001_wfi01_f106_uncal.asdf'\n",
+    "\n",
+    "if os.path.exists(l1_file):\n",
+    "    dm_l1 = rdm.open(l1_file)\n",
+    "else:\n",
     "    asdf_dir_uri = 's3://roman-sci-test-data-prod-summer-beta-test/'\n",
     "    fs = s3fs.S3FileSystem()\n",
     "\n",
-    "    asdf_file_uri = asdf_dir_uri + 'AAS_WORKSHOP/r0003201001001001004_0001_wfi01_f106_uncal.asdf'\n",
-    "    _ = fs.get(asdf_file_uri, '.')"
+    "    asdf_file_uri = asdf_dir_uri + f'AAS_WORKSHOP/{l1_file}'\n",
+    "    with fs.open(asdf_file_uri, 'rb') as f:\n",
+    "        af = asdf.open(f)\n",
+    "        dm_l1 = rdm.open(af).copy()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's start with the basic example of running the \"complete\" pipeline. Please note that we are skipping the final two steps in the pipeline: source catalog and tweakreg (see note below). Alignment to Gaia is not necessary for these data as they are simulated using the Gaia catalog. There are other optional parameters that may be set for individual steps in a similar manner, and more information can be found in the [romancal documentation](https://roman-pipeline.readthedocs.io/en/latest/index.html).\n",
-    "\n",
-    "The save_results optional parameter will save the resulting file to your local disk. You can enable this by setting the value to `True`. In our example, we will keep the output calibrated result in memory without saving it locally.\n",
-    "\n",
-    "**Note:** Recent testing has shown that the source catalog step may crash under specific conditions. Caution is advised while we work on fixing the problem."
+    "First, let's take a look at what kind of data we have using the `type()` function:"
    ]
   },
   {
@@ -141,14 +147,45 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = ExposurePipeline.call('r0003201001001001004_0001_wfi01_f106_uncal.asdf', save_results=False, steps={'source_catalog': {'skip': True}, 'tweakreg': {'skip': True}})"
+    "type(dm_l1)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output from the exposure pipeline is currently returned as a list. You will need to index the results variable with a `[0]` to access the datamodel object."
+    "Reading the ASDF file with `roman_datamodels` returns a `ScienceRawModel` datamodel, which is the datamodel for L1 files. We can also use the `.info()` method on the datamodel to look at the file contents:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dm_l1.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can see that this L1 file was made with Roman I-Sim as it contains the \"romanisim\" block inside the file.\n",
+    "\n",
+    "Next, let's look at a basic example of running the complete pipeline.\n",
+    "\n",
+    "The `save_results` optional parameter will save the resulting L2 datamodel as a file on your Nexus storage. You can enable this by setting the value to `True`. In our example, we will keep the output calibrated L2 datamodel (as the variable `result`) in memory without saving it locally. We have explicitly set `save_results=False`, however this is also the default behavior."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "result = ExposurePipeline.call(dm_l1, save_results=False)"
    ]
   },
   {
@@ -161,19 +198,50 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we can see, the output from the Exposure Pipeline is an `ImageModel` object, which is the datamodel for L2 files.\n",
+    "\n",
+    "If you look in your file browser in the directory where you are running this tutorial, you will also see two other files were created with similar names to our L1 file. These have names like `*_cat.asdf` and `*_segm.asdf`. These are Level 4 (L4; high-level extracted information) files corresponding to a single-band source catalog and a segmentation map, respectively.\n",
+    "\n",
+    "**IMPORTANT NOTE:** At this time, L4 products are still being developed and validated, and we expect significant changes in their format and the algorithms used to generate them. These L4 products are automatically created by the source catalog step (a necessary input to the Gaia alignment). We do not recommend the use of these products until they are fully validated.\n",
+    "\n",
+    "We can also pass optional parameters to individual pipeline steps using a dictionary called `steps`. Here we show how to skip the source catalog step and the step that aligns the image with the Gaia astrometric catalog (this is the TweakReg step, which is named after the software used to update the image World Coordinate System (WCS)). Other optional parameters may be similarly set for individual steps, and more information can be found in the [romancal documentation](https://roman-pipeline.readthedocs.io/en/latest/index.html)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
-    "type(result[0])"
+    "result = ExposurePipeline.call(dm_l1, save_results=False, steps={'source_catalog': {'skip': True}, 'tweakreg': {'skip': True}})"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the example above, you can see how we passed optional parameters to individual steps in the pipeline. The pipeline steps in order are:\n",
+    "If you examine the end of the pipeline log messages, you will see that the source catalog and tweakreg steps were skipped as expected. Since we skipped the source catalog step, the L4 source catalog and segmentation maps were not regenerated. If we want to check on the status of a step, we can also check the metadata of the output datamodel:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result.meta.cal_step.source_catalog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For reference, the pipeline steps in order are:\n",
     "\n",
     "- `romancal.dq_init.dq_init_step`: Bad pixel masking and data quality initialization\n",
     "- `romancal.saturation.SaturationStep`: Saturation flagging up-the-ramp\n",
@@ -187,11 +255,11 @@
     "- `romancal.source_detection.SourceCatalog`: Run source detection on the image, perform point spread function (PSF) fitting photometry, and generate a source catalog\n",
     "- `romancal.tweakreg.TweakRegStep`: Match sources to Gaia and update WCS information\n",
     "\n",
+    "The [Exposure Pipeline](https://roman-docs.stsci.edu/data-handbook-home/roman-stsci-data-pipelines/exposure-level-pipeline) article on RDox provides more information on the Exposure Pipeline steps.\n",
+    "\n",
     "Note that the ramp fitting step transforms the datamodel in memory. Therefore, steps following ramp fitting cannot be applied to a data model that has not undergone ramp fitting, and similarly, steps preceeding ramp fitting should not be applied to a  data model after this step.\n",
     "\n",
-    "### Advanced Example: Running Individual Pipeline Steps\n",
-    "\n",
-    "Now, for a more advanced use case, let's update the WCS based on the pointing information. In this example, let's imagine that we have simulated a field in a L2 calibrated file, and we want to update the distortion model in the file's GWCS (Generalized World Coordinate System) object. We can accomplish this by running the individual AssignWcsStep on an L2 ASDF file. If you ran the previous cells, the file should already be saved on disk. If not, we can stream it from the S3 bucket."
+    "Once we are satisfied with our datamodel, if we want to we can save it to disk with the `.save()` method:"
    ]
   },
   {
@@ -200,16 +268,108 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if os.path.exists('r0003201001001001004_0001_wfi01_f106_cal.asdf'):\n",
+    "result.save('my_roman_l2_file.asdf')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you look at the file browser in the directory you ran this tutorial, you should see a new file called \"my_roman_l2_file.asdf.\" Note: you may need to wait a moment or manually refresh the file browser before the file appears.\n",
+    "\n",
+    "### Advanced Example: Running Individual Pipeline Steps\n",
+    "\n",
+    "Now, for a more advanced use case, let's update the WCS based on the pointing information. An example use case may be that we simulated a L1 file, calibrated it with the Exposure Pipeline, and now we want to try shifting the pointing information and creating a new WCS to test the Gaia alignment. After editing any of the `meta.wcsinfo` values that we want to change, we can generate a new WCS by running the individual AssignWcsStep on our L2 ASDF file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "l2_file = 'r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
+    "\n",
+    "if os.path.exists(l2_file):\n",
     "    dm = rdm.open(f)\n",
     "else:\n",
     "    asdf_dir_uri = 's3://roman-sci-test-data-prod-summer-beta-test/'\n",
     "    fs = s3fs.S3FileSystem()\n",
     "\n",
-    "    asdf_file_uri = asdf_dir_uri + 'AAS_WORKSHOP/r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
+    "    asdf_file_uri = asdf_dir_uri + f'AAS_WORKSHOP/{l2_file}'\n",
     "    with fs.open(asdf_file_uri, 'rb') as f:\n",
     "        af = asdf.open(f)\n",
-    "        dm = rdm.open(af)"
+    "        dm = rdm.open(af)\n",
+    "        original_wcs = copy.deepcopy(dm.meta.wcs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take a quick look at the file we just opened:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dm.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The WCS that is initially populate in L2 files before alignment with Gaia is based on the pointing information. This is called the \"course\" WCS. The `meta.pointing` section of the metadata describes the spacecraft pointing, while the detector-dependent information used to construct the course WCS is contained in the `meta.wcsinfo` section. Realistically, the values in `meta.pointing` and `meta.wcsinfo` are linked, but in practice the course WCS only uses `meta.wcsinfo`. Let's examine our `meta.wcsinfo` values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dm.meta.wcsinfo"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In particular, we see values for `ra_ref`, `dec_ref`, and `roll_ref`. Let's take a look at the descriptions of these fields:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"ra_ref = {dm.schema_info(path='roman.meta.wcsinfo.ra_ref')['description']}\")\n",
+    "print(f\"dec_ref = {dm.schema_info(path='roman.meta.wcsinfo.dec_ref')['description']}\")\n",
+    "print(f\"roll_ref = {dm.schema_info(path='roman.meta.wcsinfo.roll_ref')['description']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The \"reference pixel position\" in the descriptions is located at the center of each WFI detector (each detector has its own WCS). We can edit these values to trick the pipeline into creating a WCS slightly different from the one before. Let's make a copy of the datamodel (for comparison later)  and add a simple shift of 1 arcseccond in right ascension:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "original_ra_ref = copy.copy(dm.meta.wcsinfo.ra_ref)\n",
+    "dm.meta.wcsinfo.ra_ref += (1 / 3600)\n",
+    "\n",
+    "print(f'Original ra_ref = {original_ra_ref},\\nUpdated ra_ref = {dm.meta.wcsinfo.ra_ref}')"
    ]
   },
   {
@@ -225,15 +385,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dm.info()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "result = romancal.assign_wcs.AssignWcsStep.call(dm)"
    ]
   },
@@ -241,7 +392,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case, the output from the step is the datamodel rather than a list:"
+    "Finally, we can take a pixel position and translate it to right ascension and declination using the original and newly updated WCS objects. Let's use the center of the detector in the L2 image, which in 0-indexed pixels is (x, y) = (2043.5, 2043.5). Separations on the sky can be easily determined using `astropy.coordinates.SkyCoord` objects as follows:"
    ]
   },
   {
@@ -250,14 +401,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "type(result)"
+    "# Get SkyCoord object for new position at center of detector\n",
+    "ra, dec = result.meta.wcs(2043.5, 2043.5)\n",
+    "result_coord = SkyCoord(ra=ra, dec=dec, unit='deg')\n",
+    "result_coord\n",
+    "\n",
+    "# Get SkyCoord object for original position at center of detector\n",
+    "ra0, dec0 = original_wcs(2043.5, 2043.5)\n",
+    "original_coord = SkyCoord(ra=ra0, dec=dec0, unit='deg')\n",
+    "original_coord\n",
+    "\n",
+    "# Compute the separation between the updated and original positions\n",
+    "result_coord.separation(original_coord)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If we would like to use our own version of the distortion reference file rather than the one from CRDS, then we can use the file with the override_distortion optional parameter:"
+    "As we can see, the newly updated WCS is shifted approximately 1 arcsecond from the WCS in the L2 file that we opened. This is not exactly 1 arcsecond because the WFI pixels were not aligned with perfectly vertical and horizontal lines of right ascension and declination, respectively.\n",
+    "\n",
+    "Similar to our pipeline example above, we can also pass optional arguments to individual steps. For example, if we would like to use our own version of the distortion reference file rather than the one from CRDS, then we can use the file with the override_distortion optional parameter:"
    ]
   },
   {
@@ -275,7 +439,7 @@
    "source": [
     "Similar override parameters exist for all reference file types. More information on WFI reference file types may be found in the RDox article [CRDS for Reference Files](https://roman-docs.stsci.edu/data-handbook-home/accessing-wfi-data/crds-for-reference-files).\n",
     "\n",
-    "As before, we directed the updated datamodel to the variable \"result\" in active memory. We can access the information in the \"result\" (such as the gwcs object or data array) as in any other datamodel object. To write the result to disk, we can do so with the `save()` method. We can also pass this datamodel along to the next pipeline step and chain steps together. For more information on working with datamodels, see the [Working with ASDF](../working_with_asdf/working_with_asdf.ipynb) tutorial."
+    "As before, we directed the updated datamodel to a variable in active memory. We can also pass this datamodel along to the next pipeline step and chain steps together, and we can also save the datamodel to disk with the `.save()` method. For more information on working with datamodels, see the [Working with ASDF](../working_with_asdf/working_with_asdf.ipynb) tutorial."
    ]
   },
   {
@@ -297,8 +461,8 @@
    },
    "source": [
     "## About this Notebook\n",
-    "**Author:** Sanjib Sharma, Tyler Desjardins  \n",
-    "**Updated On:** 2025-01-10"
+    "**Author:** Tyler Desjardins, Sanjib Sharma\\\n",
+    "**Updated On:** 2025-05-26"
    ]
   },
   {
@@ -319,9 +483,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Calibration",
    "language": "python",
-   "name": "python3"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {
@@ -333,7 +497,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/content/notebooks/measuring_galaxy_shapes/measuring_galaxy_shapes.ipynb
+++ b/content/notebooks/measuring_galaxy_shapes/measuring_galaxy_shapes.ipynb
@@ -53,7 +53,7 @@
     "- *scipy.optimize* to fit our data\n",
     "- *synphot* for synthetic photometry\n",
     "- *stsynphot* to access WFI throughput information\n",
-    "- *webbpsf* to access WFI point spread functions"
+    "- *stpsf* to access WFI point spread functions"
    ]
   },
   {
@@ -82,7 +82,7 @@
     "from scipy.optimize import curve_fit\n",
     "import synphot as syn\n",
     "import stsynphot as stsyn\n",
-    "import webbpsf\n",
+    "import stpsf\n",
     "\n",
     "%matplotlib inline"
    ]
@@ -105,7 +105,7 @@
     "- Data Access and Discovery\n",
     "- Working with ASDF\n",
     "- Data Visualization\n",
-    "- WebbPSF\n",
+    "- STPSF\n",
     "- Synphot\n",
     "\n",
     "### Defining Terms\n",
@@ -311,7 +311,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Most morphological measurements require high-accuracy knowledge of the PSF. In the case of our simulated scene, we know that the PSF was generated via `webbpsf`. For simplicity, we will be working with a single PSF, but users interested in high accuracy fits will likely want to generate a PSF at the pixel location of each of the sources being fit. See the [WebbPSF tutorial](../webbpsf/webbpsf.ipynb) tutorial for more information."
+    "Most morphological measurements require high-accuracy knowledge of the PSF. In the case of our simulated scene, we know that the PSF was generated via `stpsf`. For simplicity, we will be working with a single PSF, but users interested in high accuracy fits will likely want to generate a PSF at the pixel location of each of the sources being fit. See the [STPSF tutorial](../stpsf/stpsf.ipynb) tutorial for more information."
    ]
   },
   {
@@ -320,8 +320,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Set up the WFI instrument object in WebbPSF, set the optical element, and generate a PSF.\n",
-    "wfi = webbpsf.WFI()\n",
+    "# Set up the WFI instrument object in STPSF, set the optical element, and generate a PSF.\n",
+    "wfi = stpsf.WFI()\n",
     "wfi.filter = band\n",
     "psf = wfi.calc_psf(fov_pixels=64)\n",
     "\n",
@@ -970,9 +970,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Calibration",
    "language": "python",
-   "name": "python3"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {
@@ -984,7 +984,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/content/notebooks/mosaic_pipeline/mosaic_pipeline.ipynb
+++ b/content/notebooks/mosaic_pipeline/mosaic_pipeline.ipynb
@@ -236,7 +236,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "mos_file = rdm.open('my_roman_mosaic_i2d.asdf')\n",
+    "mos_file = rdm.open('my_roman_mosaic_coadd.asdf')\n",
     "mos_file.info()"
    ]
   },
@@ -284,7 +284,7 @@
    "source": [
     "## About this Notebook\n",
     "**Author:** Tyler Desjardins\\\n",
-    "**Updated On:** 2025-01-10"
+    "**Updated On:** 2025-05-26"
    ]
   },
   {
@@ -319,7 +319,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated the data visualization tutorial for the following:
- Fixed missing grid lines on WCS matplotlib plot example
- Adjusted markdown for updated catalog (galaxy used in previous examples is now gone, switched to different source)
- Added explanation of detector artifacts in far right of WFI01 used for examples
   - Included plot of DQ array showing features are marked
   - Added RDox reference for Detector Performance article
   - Added pointer to Working with ASDF for more information on DQ arrays
- Updated catalog overlay example to only mark sources from catalog with m < 18 and that are in the overlap region of both images