### PR TITLE
Update Working with ASDF for AAS246

### DIFF
--- a/content/notebooks/working_with_asdf/working_with_asdf.ipynb
+++ b/content/notebooks/working_with_asdf/working_with_asdf.ipynb
@@ -62,6 +62,7 @@
     "import numpy as np\n",
     "import asdf\n",
     "import roman_datamodels as rdm\n",
+    "from roman_datamodels.dqflags import pixel as dqflags\n",
     "import matplotlib.pyplot as plt\n",
     "import astropy.units as u\n",
     "import astropy.time\n",
@@ -84,13 +85,13 @@
     "\n",
     "There are tools to interact with ASDF files in Python, Julia, C/C++, and IDL. In this example we focus on the Python interface.\n",
     "\n",
-    "Roman ASDF files can be opened and manipulated using two main approaches: 1. Using the `roman_datamodels` library, and 2. using the `asdf` library.\n",
+    "Roman ASDF files can be opened and manipulated using two main approaches: \n",
+    "1. using the `roman_datamodels` library, and\n",
+    "2. using the `asdf` library.\n",
     "\n",
-    "Using `roman_datamodels` offers the advantage of loading different data blocks as `stnode`-based objects, providing access to their methods. In contrast, the `asdf` library loads the data blocks as they were serialized on disk. While this approach loses some of the `roman_datamodels` capabilities, it can allow more flexibility. In this notebook, we illustrate both approaches, starting with loading data via `roman_datamodels`.\n",
+    "Using `roman_datamodels` offers the advantage of loading different data blocks as `stnode`-based objects, providing access to their methods. In contrast, the `asdf` library loads the data blocks as they were serialized on disk. While this approach loses some of the `roman_datamodels` capabilities, it also provides more flexibility. In this notebook, we illustrate both approaches, starting with loading data via `roman_datamodels`.\n",
     "\n",
-    "Additional information about ASDF in the context of Roman can be found in RDox: https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format.\n",
-    "\n",
-    "**Note**: This notebook assumes familiarity with Python, Python dictionaries, and Jupyter notebooks, as well as some basic familiarity with `matplotlib`, `numpy`, and `astropy`. For more information on how to visualize data in ASDF files, see the [Data Visualization notebook tutorial](../data_visualization/data_visualization.ipynb)."
+    "Additional information about Roman ASDF files can be found in the [Introduction to ASDF](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/introduction-to-asdf) article on RDox."
    ]
   },
   {
@@ -115,7 +116,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "All Roman data products conform to one of the data models described by the [`roman_datamodels`](https://roman-datamodels.readthedocs.io/en/latest/) package. This package wraps the `asdf` library and provides utilities to read and save data conforming to the official data models. We illustrate how to use `roman_datamodels` to load data from an ASDF file containing simulated Roman data."
+    "All Roman data products conform to one of the datamodels described by the [`roman_datamodels`](https://roman-datamodels.readthedocs.io/en/latest/) package. This package wraps the `asdf` library and provides utilities to read and save data conforming to the official data models. We illustrate how to use `roman_datamodels` to load data from an ASDF file containing simulated Roman data."
    ]
   },
   {
@@ -138,7 +139,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "A high-level summary of the file can be retrieved by using the `info()` method:"
+    "Notice that we used the `asdf.open()` command to open the byte stream, and then passed that object to `roman_datamodels.open()`. This is necessary at present as `roman_datamodels` does not allow for reading of a byte stream in this manner.\n",
+    "\n",
+    "A high-level summary of the file can be retrieved by using the `info()` method. We have limited the number of rows printed to 30, but if you want to see all rows, you can change that number to your liking or to `None` in order to see all rows. There is a similar option for `max_cols` if you want to change the horizontal cutoff per line. The default number of rows and columns is 24 and 120, respectively."
    ]
   },
   {
@@ -154,18 +157,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We have limited the number of rows printed to 30, but if you want to see all rows, you can change that number to your liking or to `None` in order to see all nodes."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Note that, by default, the `open()` method does not load the data in memory unless told to do so explicitly, which makes opening ASDF files a quick operation. \n",
     "\n",
-    "At this point, we have information about the shape and type of the different data blocks, but we don't have access to the data until we load them. We can either load the data blocks by instantiating them or by setting `lazy_load = False`.\n",
-    "\n",
-    "An ASDF object can be used, effectively, like a nested dictionary. Each block can be explored via the `.keys()` attribute. "
+    "At this point, we have information about the names and types of the different data blocks, but we don't have access to the data until we load them, which we can do by using them. For example:"
    ]
   },
   {
@@ -174,14 +168,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pprint(f.keys())"
+    "f.data"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For a level-2 image, the list of blocks includes:"
+    "An ASDF object can be used, effectively, like a nested dictionary. Each block can be explored via the `.keys()` attribute. For example, we can retrieve the list of keys in a Level 2 calibrated rate image file as:"
    ]
   },
   {
@@ -198,7 +192,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We focus on the `data` block, containing the science image of interest."
+    "We can also find all of the keys within one of these blocks, such as the metadata. Note that here we are using the dot syntax notation (i.e., `f.meta`) to retrieve the metadata. You can also use brackets to subscript the datamodel (e.g., `f['meta']`). Dot syntax is allowed by datamodel objects in `roman_datamodels`, whereas ASDF objects (shown later in the tutorial) can only use the bracket subscript notation."
    ]
   },
   {
@@ -207,29 +201,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img = f['data']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type(img)"
+    "for key in f.meta.keys():\n",
+    "    print(key)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that Roman images are expressed as `numpy.ndarray` objects. The units are available in the schema descriptions for the arrays, but quickly the data arrays are:\n",
-    "\n",
-    "- Level 1 (L1; uncalibrated ramp cubes) are in units of Data Numbers (DN)\n",
-    "- Level 2 (L2; calibrated rate images) are in units of DNs per second\n",
-    "- Level 3 (L3; mosaic co-adds) are in units of megaJanskys per steradian\n",
-    "\n",
-    "Error arrays are in the same units as data, and variance arrays are the same units squared (e.g., DN^2 / s^2)."
+    "We focus on the data block, containing the science image of interest. First, how do we know which array in the file is the primary data array? It could have any name, for example \"data\" or \"science.\" If we are not sure, we can ask the file itself:"
    ]
   },
   {
@@ -238,10 +218,64 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print('Exploring the values of `img`: ', img)\n",
-    "print('Exploring the data type of `img.value`: ', type(img))\n",
-    "print('Exploring the units of `img`: ', img)\n",
-    "print('Exploring the type of `img.units: ', type(img))"
+    "f.get_primary_array_name()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The creators of the datamodel have told us explicitly that the primary array name in this case is \"data.\" This may not be true for all Roman WFI ASDF files (e.g., calibration reference files), so it is always worth checking if you are not sure. Next, let's look at the type of the `data` block:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(f.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that Roman images are expressed as `numpy.ndarray` objects. The units are available in the schema descriptions for the arrays (see below), but quickly the data arrays are:\n",
+    "\n",
+    "- Level 1 (L1; uncalibrated 3-D ramp cubes) are in units of Data Numbers (DN)\n",
+    "- Level 2 (L2; calibrated 2-D rate images) are in units of DNs per second (DN/s)\n",
+    "- Level 3 (L3; 2-D mosaic co-adds) are in units of megaJanskys per steradian (MJy/sr)\n",
+    "\n",
+    "Error arrays are in the same units as data, and variance arrays are the same units squared (e.g., DN^2 / s^2).\n",
+    "\n",
+    "Let's take a look at the size of our image and some sample values in a small 3x3 cutout from the bottom-left corner of the array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Size of f.data: ', f.data.shape)\n",
+    "print('\\nExploring the values of f.data: \\n', f.data[:3, :3])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since we have image data, let's also take a quick look at what the image actually contains. This is quite simple, and a more detailed explanation about visualizing Roman ASDF files can be found in the [Data Visualization](../data_visualization/data_visualization.ipynb) tutorial. Below is a 1,000 x 1,000 pixel section of the data array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.imshow(f.data[:1000, :1000], vmin=0, vmax=2, origin='lower');"
    ]
   },
   {
@@ -257,17 +291,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(12, 6), layout='tight')\n",
-    "plt.hist(img.flatten(), histtype='step', range=(-0.6, 0.6), bins=300);\n",
-    "plt.xlabel(f'Pixel value [{img}]', fontsize=16)\n",
-    "plt.ylabel('Pixels/bin', fontsize=16);"
+    "fig, ax = plt.subplots(figsize=(12, 6), layout='tight')\n",
+    "ax.hist(f.data.flatten(), histtype='step', range=(-0.2, 1.7), bins=200);\n",
+    "ax.set_xlabel('Pixel Value', fontsize=14)\n",
+    "ax.set_ylabel('N / 1000', fontsize=14)\n",
+    "ax.tick_params(axis='both', labelsize=14);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can explore other data blocks, for example, the data quality (DQ) flags. These flags are summarized [here](https://roman-pipeline.readthedocs.io/en/latest/roman/references_general/references_general.html#data-quality-flags). Let's take a look at DQ values, which are the bitwise sum of all DQ bits flagged during data processing."
+    "We can explore other data blocks such as the data quality (DQ) array. The values of the DQ array are the bitwise sum of the individual flags representing specific effects. These flags are defined in the [RomanCal documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/references_general/references_general.html#data-quality-flags). These can also be retrieved from `roman_datamodels.dqflags.pixel()`. As a reminder, we aliased `roman_datamodels.dqflags.pixel()` in our import statement at the start of the tutorial as `dqflags()`. Let's start by making a list of all of the unique values in the DQ array:"
    ]
   },
   {
@@ -276,31 +311,62 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "unique_dq = np.unique(f['dq'])"
+    "unique_dq = np.unique(f.dq)\n",
+    "print(unique_dq)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have the list of unique DQ values, we can decompose the values into individual flags and print the number of pixels with each unique DQ value:"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
-    "unique_dq"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for uu in unique_dq:\n",
+    "size = np.size(f.dq)\n",
+    "\n",
+    "# Number of good pixels\n",
+    "npix = np.shape(f.dq[f.dq==0])[0]\n",
+    "print(\"------------\")\n",
+    "print(f'Flag 0 (affected pixels = {npix}; {npix / size:.2%}))')\n",
+    "print(f'0: {str(dqflags(0)).split('.')[1]}')\n",
+    "\n",
+    "# Pixels with non-zero DQ flags\n",
+    "for uu in unique_dq[1:]:\n",
     "    br = np.binary_repr(uu)\n",
+    "    npix = np.shape(f.dq[f.dq==uu])[0]\n",
     "    print(\"------------\")\n",
-    "    print('Flag', uu)\n",
+    "    print(f'Flag {uu} (affected pixels = {npix}; {npix / size:.2%})')\n",
     "    for ii, cc in enumerate(br[::-1]):\n",
     "        if int(cc)==1:\n",
-    "            print('Bits on:', ii, 2**ii)"
+    "            print(f'{2**ii}: {str(dqflags(2**ii)).split('.')[1]}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If we want to get a report of how many pixels are impacted by specific DQ flags (e.g., all saturated pixels) regardless of other flags set, we can do that, too using the Python `&` operator (bitwise AND):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bit = 2\n",
+    "definition = str(dqflags(bit)).split('.')[1]\n",
+    "n_pix = np.sum(f.dq.flatten() & bit)\n",
+    "print(f'Bit value {bit} corresponds to {definition}')\n",
+    "print(f'Number of {definition} pixels: {n_pix:,} ({n_pix / f.dq.size:.2%})')"
    ]
   },
   {
@@ -318,32 +384,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "meta = f['meta']  # This way we get a dictionary"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "meta = f['meta']\n",
     "type(meta)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "meta # Expect a long-ish output here"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We retrieved the `meta` datablock as a dictionary, which contains a collection of dictionaries. We iterate over its keys to see what they contain:"
+    "As we can see, `meta` is a dictionary type object. What if instead of using the bracket notation we use the dot notation discussed previously?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = f.meta\n",
+    "type(meta)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Suddenly it's a `roman_datamodels.stnode._node.DNode` object! Despite this difference in object type, we can treat both this and a dictionary the same in most ways. However, an advantage of the dot syntax and the `roman_datamodels.stnode._node.DNode` object is that we retain information about the schema, which we lose if we convert the metadata to a dictionary object. We previously showed how to get the list of keys in the metadata, but as a reminder let's do it again here for easy reference:"
    ]
   },
   {
@@ -360,9 +426,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As shown above, the `meta` data block contains a lot of useful metadata information. Two of the most typical keys, for example, are the `wcs` key, containing information about the World Coordinate System (see below), and also the `photometry` key, containing information about how to transform units from instrumental (DN / sec) to physical (MJy / sr).\n",
+    "Printing the whole of the metadata is quite long, so we will instead print a small subsection:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(meta.instrument)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As shown above, the `meta` data block contains a lot of useful metadata information. Two of the most typical keys, for example, are the `wcs` key, containing information about the World Coordinate System (WCS; see below), and also the `photometry` key, containing information about how to transform units from instrumental (DN/s) to physical (MJy/sr).\n",
     "\n",
-    "We continue going deeper in the metadata tree. In this case, we select the `instrument` key."
+    "Let's take a look at the schema information for `meta.instrument`. Note that this can be quite difficult to read, but is very rich in information about the contents, data types, allowed values, and mapping to other information (e.g., the storage location of a metadata field in the MAST Archive Catalog database) for every component of Roman WFI ASDF files."
    ]
   },
   {
@@ -371,15 +453,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for key in meta['instrument'].keys():\n",
-    "    print(key)"
+    "pprint(meta.instrument.get_schema())"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, if you have opened the file with `roman_datamodels`, you can retrieve the data blocks as `stnode._node.DNode` objects:"
+    "We can also use this to get the description of a specific metadata field:"
    ]
   },
   {
@@ -388,23 +469,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "meta2 = f.meta"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type(meta2)"
+    "print(meta.instrument.get_schema()['properties']['detector']['description'])"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "And you can go deeper in the metadata tree as shown below:"
+    "This can be alternatively written as:"
    ]
   },
   {
@@ -413,32 +485,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ins = meta2.instrument"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "type(ins)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The advantage of this latest approach is that you have access to the schema of each node."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pprint(ins.get_schema())"
+    "print(f.schema_info(path='roman.meta.instrument.detector'))"
    ]
   },
   {
@@ -452,7 +499,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another feature in WFI ASDF metadata is the storage of times as `astropy.time.Time` objects, which provide numerous convenient methods for converting to different reference systems and formats. Here we illustrate a few examples. For a more comprehensive view of `astropy.time` please check the documentation in https://docs.astropy.org/en/stable/time/."
+    "Another feature in WFI ASDF metadata is the storage of times as `astropy.time.Time` objects, which provide numerous convenient methods for converting to different reference systems and formats. Here we illustrate a few examples. For a more comprehensive view of `astropy.time` please check the [astropy.time](https://docs.astropy.org/en/stable/time/) documentation. Note that, unless otherwise noted, WFI times are stored in Coordinated Universal Time (UTC), which is indicated in the schema descriptions for any time-related fields. However, be sure to check the field descriptions if you are unsure."
    ]
   },
   {
@@ -461,7 +508,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "start_time = meta2['exposure']['start_time']\n",
+    "start_time = meta.exposure.start_time\n",
     "print('Start time of the exposure:', start_time, '; datatype:', type(start_time))"
    ]
   },
@@ -469,7 +516,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can convert this start time to MJD very easily:"
+    "We can convert the format of this start time to a modified Julian date (MJD) very easily:"
    ]
   },
   {
@@ -485,7 +532,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can use `Time` objects and operate with them. For example, we can get the exposure length by just subtracting the start time from the end time:"
+    "If instead we want to convert the scale of the time (i.e., from UTC to International Atomic Time (TAI)), we can do that, too:"
    ]
   },
   {
@@ -494,8 +541,40 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "end_time = meta2['exposure']['end_time']\n",
-    "exp_len = end_time - start_time"
+    "start_time.tai"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that the time changed by 37 seconds when we converted from UTC to TAI. This offset is expected and is part of the TAI definition. We can combine the scale change with the format change as well:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_time.tai.mjd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use `Time` objects and operate with them. For example, if we want to know the difference in time between the start and end times of the exposure (this creates a `astropy.time.TimeDelta` object):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "end_time = meta.exposure.end_time\n",
+    "exp_delta = end_time - start_time"
    ]
   },
   {
@@ -511,9 +590,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print('Exposure length in seconds:', exp_len.to(u.s))\n",
-    "print('Exposure length in days:', exp_len.to(u.day))\n",
-    "print('Exposure length in years:', exp_len.to(u.year))"
+    "print('Exposure length in seconds:', exp_delta.to(u.s))\n",
+    "print('Exposure length in days:', exp_delta.to(u.day))\n",
+    "print('Exposure length in years:', exp_delta.to(u.year))"
    ]
   },
   {
@@ -531,15 +610,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gwcs = f['meta']['wcs']\n",
-    "pprint(gwcs)"
+    "gwcs = f.meta.wcs\n",
+    "print(type(gwcs))"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The WCS can be retrieved as a `gwcs` object, which is built upon and is compatible with `astropy.wcs` utilities."
+    "If we use the pretty-print (`pprint()`) function, we can see the full contents of the WCS object."
    ]
   },
   {
@@ -548,7 +627,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(type(gwcs))"
+    "pprint(gwcs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If instead we use the `print()` function, we get a summary of the transforms available:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(gwcs)"
    ]
   },
   {
@@ -557,9 +652,9 @@
    "source": [
     "The `gwcs` object can be used to convert between image pixel and sky coordinates.\n",
     "\n",
-    "**Note:** the `gwcs` object uses Python zero-indexing, therefore the center of the first pixel in Python is (0, 0), while in the formal definition of the WFI science coordinate system the center of the bottom-left pixel is (1, 1). More information about the Roman coordinate systems can be found [here](https://roman-docs.stsci.edu/simulation-tools-handbook-home/simulation-development-utilities/pysiaf-for-roman).\n",
+    "**Important note:** the `gwcs` object uses Python 0-indexing, therefore the center of the first pixel in Python is (0, 0), while the formal definition of the WFI science coordinate system uses FITS-style 1-indexing (i.e., the center of the bottom-left pixel is (1, 1)). More information about the Roman coordinate systems can be found in the [PySIAF for Roman](https://roman-docs.stsci.edu/simulation-tools-handbook-home/simulation-development-utilities/pysiaf-for-roman) article on RDox. **All** archived L1-4 data products (e.g., WCS transforms, catalogs, etc.) will use the Python 0-indexed system.\n",
     "\n",
-    "In this example, let's convert the central pixel position of the detector to the corresponding right ascension and declination on the sky. The center of the L2 image array in the science coordinate frame is (x, y) = (2044.5, 2044.5) pixels (note that the 4-pixel reference border was removed during processing). Recall that we must subtract 1 from both axes to convert to Python's zero-indexed system: "
+    "In this example, let's convert the central pixel position of the detector to the corresponding right ascension and declination on the sky. The center of the L2 image array in the zero-indexed science coordinate frame is (x, y) = (2043.5, 2043.5) pixels. Note that the 4-pixel reference border was removed during processing, and thus the total L2 image size is 4088 rows x 4088 columns. Since the center of the first pixel in Python is (0, 0) and the array size is even, the center of the detector is (x, y) = (2043.5, 2043.5). Also note that GWCS assumes inputs in the order (x, y) and not the Pythonic form (y, x)."
    ]
   },
   {
@@ -608,7 +703,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Reading Roman data using the basic ASDF library\n",
+    "## Reading Roman data using the ASDF library\n",
     "\n",
     "We now illustrate how to read Roman WFI data using the basic `asdf` library.\n",
     "\n",
@@ -640,7 +735,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "pprint(f.tree) # This cell will print a lot of information, please feel free to skim or skip"
@@ -655,7 +752,7 @@
     "* `history`: It contains metadata information about the extensions used to create the file.\n",
     "* `roman`: This block contains Roman data and metadata.\n",
     "\n",
-    "Within the `roman` block, the `data` block contains the data, which corresponds to an uncalibrated ramp in Level 1 products, a calibrated rate image in Level 2 products, and a mosaic image in Level 3 products.\n",
+    "Within the `roman` block, the `data` block contains the data, which corresponds to an uncalibrated ramp in L1 products, a calibrated rate image in L2 products, and a mosaic image in L3 products.\n",
     "\n",
     "Other interesting data blocks are: \n",
     "- `meta`: metadata information\n",
@@ -664,16 +761,7 @@
     "\n",
     "For more information about these data blocks and Level 2 data products, please visit the [RDox pages on data levels and products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products#DataLevelsandProducts-level2).\n",
     "\n",
-    "We further showcase the usage of the `asdf` basic library below using a Level 1 file."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Exploring Level 1 Data\n",
-    "\n",
-    "In the previous section we illustrated how to use `asdf` to read a Level 2 image, which trims away the reference pixels and the 33rd amplifier (reference pixel) data. In this section, we will demonstrate some examples of using Level 1 data."
+    "We further showcase the usage of the `asdf` basic library below using a L1 file."
    ]
   },
   {
@@ -701,7 +789,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Loading the data follows exactly the same procedure as above. Comparing the data structures, we notice an extra data block: `amp33`, which contains the data from the 33rd amplifier. Additionally, the Level 1 arrays have sizes (4096, 4096) pixels, different from the previous Level 2 image size of (4088, 4088) pixels. On top of that, our `data` array is now a 3-D datacube rather than a 2-D image, in units of DN rather than DN / sec.\n",
+    "Loading the data follows exactly the same procedure as above. When working with L1 data, notice that the `data` block is now a cube of size (N, 4096, 4096), where N is the number of resultants up-the-ramp. A resultant is either a single read or the arithmetic mean of multiple reads of the WFI detectors. The L1 data array also contains the 4-pixel reference pixel border that is trimmed during processing from L1 to L2. As previously mentioned, the L1 `data` array is in units of DN.\n",
     "\n",
     "Let's plot the value of a single pixel up-the-ramp:"
    ]
@@ -723,9 +811,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Level 1 datacube contains all the uncalibrated resultants that, after processing, yield the Level 2 rate images.\n",
+    "The L1 data array contains all the uncalibrated resultants that, after processing, yield the L2 rate images.\n",
     "\n",
-    "We can pass the and `AsdfObject` to `roman_datamodels.open` as well:"
+    "The ASDF tree shows another section of the file called `romanisim` that contains information about the simulation that created the L1 file. This section is not part of the datamodel definition in `roman_datamodels`, therefore it cannot be accessed with the dot notation. Instead, we can access it, and any other additional information not stored by the datamodel definition, using the ASDF tree and bracket notation:"
    ]
   },
   {
@@ -734,25 +822,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_rdm = rdm.open(g)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(type(data_rdm))"
+    "g.tree['romanisim']"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`roman_datamodels` understood our Level 1 data and identified it as a `ScienceRaw` model, which we explore further below.\n",
-    "\n",
-    "Once more, we can use the general `.info()` method to gather information about the data."
+    "Similarly, we can access the previously mentioned history section of the file using the ASDF tree and bracket notation to find some package version information that may be useful to us. This includes, for example, the `roman_datamodels` version used to create the file."
    ]
   },
   {
@@ -761,26 +838,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "data_rdm.info()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "for key in data_rdm.keys():\n",
-    "    print(key)"
+    "g.tree['history']"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that despite the key `roman` being shown by the `.info()` method, the only keys displayed in the `ScienceRaw` object are those inside the `roman` group. This is because `data_rdm` is no longer an `AsdfObject`, but a `ScienceRawModel` object.!\n",
-    "\n",
-    "We can still retrieve its data blocks easily by instantiating its corresponding attributes/nodes or by using the keys as dictionary keys. The former method will yield the corresponding `roman_datamodels` node, whereas the latter will yield a dictionary."
+    "During Roman development, you may have an outdated version of a file that does not conform to the installed version of `roman_datamodels`, but you may want to open the file anyway. This may be to just get something out of the file that you need, or you may want to try manually fixing the file to conform to the latest schema. In any case, you can still open the file with `asdf.open()` if you disable the schema validation like so:"
    ]
   },
   {
@@ -789,7 +854,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "type(data_rdm.meta), type(data_rdm['meta'])"
+    "asdf_file_uri_l1 = asdf_dir_uri + 'AAS_WORKSHOP/r0003201001001001004_0001_wfi01_f106_uncal.asdf'\n",
+    "\n",
+    "with fs.open(asdf_file_uri_l1, 'rb') as fb:\n",
+    "    with asdf.config_context() as cfg:\n",
+    "        cfg.validate_on_read = False\n",
+    "        af = asdf.open(fb)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that if your file does not conform to the installed version of `roman_datamodels`, then you will need to leave it as an `AsdfFile` object and not try to pass it to `roman_datamodels.open()`."
    ]
   },
   {
@@ -816,9 +893,9 @@
    "source": [
     "## About this Notebook\n",
     "\n",
-    "**Author:** Javier Sánchez, Andra Stroe, William Schultz  \n",
+    "**Author:** Javier Sánchez, William Schultz, Tyler Desjardins \n",
     "\n",
-    "**Updated On:** 2025-01-09"
+    "**Updated On:** 2025-05-26"
    ]
   },
   {
@@ -853,7 +930,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/content/notebooks/working_with_asdf/working_with_asdf.ipynb
+++ b/content/notebooks/working_with_asdf/working_with_asdf.ipynb
@@ -282,7 +282,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As with array data stored in other file types, we can perform analyses on the arrays in memory. For example, we can check the image content by building a 1-D historgram of the its values:"
+    "As with array data stored in other file types, we can perform analyses on the arrays in memory. For example, we can check the image content by building a 1-D histogram of the its values:"
    ]
   },
   {
@@ -444,7 +444,7 @@
    "source": [
     "As shown above, the `meta` data block contains a lot of useful metadata information. Two of the most typical keys, for example, are the `wcs` key, containing information about the World Coordinate System (WCS; see below), and also the `photometry` key, containing information about how to transform units from instrumental (DN/s) to physical (MJy/sr).\n",
     "\n",
-    "Let's take a look at the schema information for `meta.instrument`. Note that this can be quite difficult to read, but is very rich in information about the contents, data types, allowed values, and mapping to other information (e.g., the storage location of a metadata field in the MAST Archive Catalog database) for every component of Roman WFI ASDF files."
+    "Let's take a look at the schema information for `meta.instrument`. Note that this can be quite difficult to read, but is very rich in information about the contents, data types, allowed values, and mapping to other information (e.g., the storage location of a metadata field in the MAST Archive Catalog database) for every component of Roman WFI ASDF files. Also notice that we use the `pprint()` function (instead of `print()`) to better display the text."
    ]
   },
   {


### PR DESCRIPTION
Summary of changes:

- Moved roman_datamodels examples and dot notation to the first half of the notebook, followed by ASDF library use in the second half
- Added much more information on working with DQ arrays
- Added information on how to get schema descriptions
- Added more examples of working with astropy.time.Time objects
- Included notes on how to override schema validation during Roman development to open old files if necessary
- Cleaned up markdown cells to use terminology (e.g., L1 after first use of Level 1) consistent with other notebooks
- Deemphasized the L1 examples as being unique and instead used them as part of the ASDF library usage discussion