### PR TITLE
Update synphot for AAS246

### DIFF
--- a/content/notebooks/synphot/synphot.ipynb
+++ b/content/notebooks/synphot/synphot.ipynb
@@ -43,7 +43,7 @@
     "- *numpy* for data array creation and manipulation\n",
     "- *synphot* for synthetic photometry\n",
     "- *stsynphot* for access to HST, Roman, and other transmission curves\n",
-    "- *webbpsf* for access to Roman and JWST transmission curves (optional)"
+    "- *stpsf* for access to Roman and JWST transmission curves (optional)"
    ]
   },
   {
@@ -96,7 +96,7 @@
    },
    "source": [
     "## Loading data\n",
-    "Data are loaded from Flexible Image Transport System (FITS) binary tables using functions within `stsynphot`. Data may also be loaded as NumPy NDArray objects, or for the Roman WFI and James Webb Space Telescope (JWST) instruments may be retrieved from `webbpsf`. Note that Roman WFI throughput information in `stsynphot` and `stpsf` produce identical results. JWST instrument throughputs are currently only available via `stpsf`. \n",
+    "Data are loaded from Flexible Image Transport System (FITS) binary tables using functions within `stsynphot`. Data may also be loaded as NumPy NDArray objects, or for the Roman WFI and James Webb Space Telescope (JWST) instruments may be retrieved from `stpsf`. Note that Roman WFI throughput information in `stsynphot` and `stpsf` produce identical results. JWST instrument throughputs are currently only available via `stpsf`. \n",
     "\n",
     "**IMPORTANT NOTE:** Roman WFI throughputs from `stsynphot` and `stpsf` are currently for a single detector and combine the entire optical chain. Updates to the transmission information are expected as part of the ground testing campaign of both the WFI and the integrated observatory and eventually on-orbit commissioning. Newer throughput curves per detector (including, e.g., variations in average detector quantum efficiency) are available at the [Roman Technical Information Repository](https://github.com/RomanSpaceTelescope/roman-technical-information/), and will be made available in the future using WFI calibration reference files. Simulations using [Roman I-Sim](../romanisim/romanisim.ipynb) use zeropoints per detector derived from the throughput curves in the technical information repository. You can use the throughput curves from the repository in the examples below by reading in the file and creating a `synphot.SpectralElement` object with an `astropy.models.Empirical1D` model.\n",
     "\n",
@@ -456,9 +456,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Roman Calibration",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "roman-cal"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -470,7 +470,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.9"
+   "version": "3.12.10"
   }
  },
  "nbformat": 4,

--- a/content/notebooks/synphot/synphot.ipynb
+++ b/content/notebooks/synphot/synphot.ipynb
@@ -65,7 +65,7 @@
     "\n",
     "import synphot as syn\n",
     "import stsynphot as stsyn\n",
-    "#import webbpsf"
+    "import stpsf"
    ]
   },
   {
@@ -96,9 +96,40 @@
    },
    "source": [
     "## Loading data\n",
-    "Data are loaded from Flexible Image Transport System (FITS) binary tables using functions within `stsynphot`. Data may also be loaded as NumPy NDArray objects, or for the Roman WFI and James Webb Space Telescope (JWST) instruments may be retrieved from `webbpsf`. Note that Roman WFI throughput information in `stsynphot` and `webbpsf` produce identical results. JWST instrument throughputs are currently only available via `webbpsf`. \n",
+    "Data are loaded from Flexible Image Transport System (FITS) binary tables using functions within `stsynphot`. Data may also be loaded as NumPy NDArray objects, or for the Roman WFI and James Webb Space Telescope (JWST) instruments may be retrieved from `webbpsf`. Note that Roman WFI throughput information in `stsynphot` and `stpsf` produce identical results. JWST instrument throughputs are currently only available via `stpsf`. \n",
     "\n",
-    "**NOTE:** Roman WFI throughputs are currently for a single detector and combine the entire optical chain. Updates to the transmission information are expected as part of the ground testing campaign of both the WFI and the integrated observatory."
+    "**IMPORTANT NOTE:** Roman WFI throughputs from `stsynphot` and `stpsf` are currently for a single detector and combine the entire optical chain. Updates to the transmission information are expected as part of the ground testing campaign of both the WFI and the integrated observatory and eventually on-orbit commissioning. Newer throughput curves per detector (including, e.g., variations in average detector quantum efficiency) are available at the [Roman Technical Information Repository](https://github.com/RomanSpaceTelescope/roman-technical-information/), and will be made available in the future using WFI calibration reference files. Simulations using [Roman I-Sim](../romanisim/romanisim.ipynb) use zeropoints per detector derived from the throughput curves in the technical information repository. You can use the throughput curves from the repository in the examples below by reading in the file and creating a `synphot.SpectralElement` object with an `astropy.models.Empirical1D` model.\n",
+    "\n",
+    "For example, let's pretend we have a very simple bandpass that only has three samples in wavelength:\n",
+    "```\n",
+    "wavelength = [1, 1.1., 1.2] microns\n",
+    "throughput = [0.0, 0.75, 0.0]\n",
+    "```\n",
+    "We can create our `synphot.SpectralElement` object as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set up the bandpass information\n",
+    "wavelength = np.array([1, 1.1, 1.2]) * u.micron\n",
+    "throughput = np.array([0, 0.75, 0])\n",
+    "\n",
+    "# Create the bandass as a synphot.SpectralElement object\n",
+    "bandpass = syn.SpectralElement(syn.models.Empirical1D, points=wavelength, lookup_table=throughput)\n",
+    "\n",
+    "# Evaluate the bandpass at 1.05 micron\n",
+    "bandpass(1.05 * u.micron)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is important to note that the curves in the Roman Technical Information Repository are **effective area** curves rather than unitless throughput. The only modification required to use effective area curves in the examples below is to set the collecting area of the telescope to 1 m<sup>2</sup> in any function that requires the collecting area (e.g., when computing instrumental count rate)."
    ]
   },
   {
@@ -111,11 +142,9 @@
     "\n",
     "There are two approaches to retrieving WFI throughput information. Here we will show both methods of loading the throughput information. All the remaining steps in the tutorial are independent from the specific loading method.\n",
     "\n",
-    "#### Retrieving WFI Throughputs from WebbPSF\n",
+    "#### Retrieving WFI Throughputs from STPSF\n",
     "\n",
-    "To retrieve the optical element throughput information from `webbpsf`, we set up the WFI object, and use the method _get_synphot_bandpass, which takes the optical element name as the only argument. In the example below, we load the throughput information for the F129 imaging filter. This new Python object behaves as a callable function that takes as input the wavelength or frequency of interest, and will return the throughput at that wavelength or frequency.\n",
-    "\n",
-    "Note that we have commented out the lines in the following cell as this is optional for Roman, but is required for JWST."
+    "To retrieve the optical element throughput information from `stpsf`, we set up the WFI object, and use the method _get_synphot_bandpass, which takes the optical element name as the only argument. In the example below, we load the throughput information for the F129 imaging filter. This new Python object behaves as a callable function that takes as input the wavelength or frequency of interest and returns the throughput at that wavelength or frequency."
    ]
   },
   {
@@ -125,9 +154,9 @@
    "outputs": [],
    "source": [
     "# Set up the Roman WFI object and retrieve the throughput of a filter\n",
-    "#roman = webbpsf.WFI()\n",
-    "#wfi_f129 = roman._get_synphot_bandpass('F129')\n",
-    "#print(wfi_f129(1.29 * u.micron))"
+    "roman = stpsf.WFI()\n",
+    "wfi_f129 = roman._get_synphot_bandpass('F129')\n",
+    "print(wfi_f129(1.29 * u.micron))"
    ]
   },
   {
@@ -184,7 +213,7 @@
     "    ax.fill_between(waves[clean].value, band(waves[clean]).value, alpha=0.5, color=colors[i])\n",
     " \n",
     "# Set plot axis labels, ranges, and add grid lines\n",
-    "ax.set_xlabel('Wavelength ($\\mu$m)')\n",
+    "ax.set_xlabel(r'Wavelength ($\\mu$m)')\n",
     "ax.set_ylabel('Throughput')\n",
     "ax.set_ylim(0, 1.05)\n",
     "ax.set_xlim(0.4, 2.5)\n",
@@ -406,7 +435,7 @@
     "## About this Notebook\n",
     "\n",
     "**Author:** Tyler Desjardins  \n",
-    "**Updated On:** 2024-05-07"
+    "**Updated On:** 2025-05-26"
    ]
   },
   {
@@ -427,9 +456,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Calibration",
    "language": "python",
-   "name": "python3"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {
@@ -441,7 +470,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Adds caveat to tutorial about per detector throughput curves, which are available from the Roman Technical Information Repository and indicates these will be available from SOC products in the future. Also adds clarification that zeropoints in Roman I-Sim simulations do use the per detector curves.