### PR TITLE
Aperture Photometry Update for AAS246

### DIFF
--- a/content/notebooks/aperture_photometry/aperture_photometry.ipynb
+++ b/content/notebooks/aperture_photometry/aperture_photometry.ipynb
@@ -208,7 +208,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can convert (RA, Dec) to (x, y) positions on the WFI01 detector."
+    "We can convert (RA, Dec) to (x, y) positions on the WFI01 detector. Note that several of these positions may be NaN (Not a Number) as they fall outside the bounding box of the WCS."
    ]
   },
   {
@@ -363,8 +363,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "rad = 3  # aperture radius in pixels\n",
+    "\n",
     "star_positions = [(x, y) for y, x in zip(stars['y'].data, stars['x'].data)]\n",
-    "star_apertures = CircularAperture(positions=star_positions, r=3)"
+    "star_apertures = CircularAperture(positions=star_positions, r=rad)"
    ]
   },
   {
@@ -517,6 +519,22 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "We can also plot the encircled energy as a function of aperture radius:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stpsf.display_ee(wfi_psf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "With these settings, our encircled energy measurement is an average one for the whole detector, measured at the center of the detector, and for the default STPSF spectral energy distribution (SED), which is a 5700 K blackbody (similar to a G2V star). The variable `ee_func` above is a function that takes as its single argument the aperture radius in arcseconds and returns the percentage of the PSF contained within that aperture. The inverse of that encircled energy fraction is the correction factor that we must apply to our measurements. This is called the encircled energy correction or aperture correction. Let's calculate that now for a circular aperture with a 3-pixel radius and assuming a pixel scale of 0.11 arcseconds per pixel (i.e., radius = 0.33 arcseconds):"
    ]
   },
@@ -526,7 +544,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ee_correction = 1/ee_func(3 * 0.11)\n",
+    "ee_correction = 1/ee_func(rad * 0.11)\n",
     "print(f'Encircled energy correction = {ee_correction}')"
    ]
   },
@@ -534,7 +552,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can apply the aperture correction to our flux, and then convert the flux in Jy to maggies and AB magnitudes. For any source with a flux in maggies less than 0, we will assign a value of NaN for the AB magnitude."
+    "Now we can apply the aperture correction to our flux, and then convert the flux in Jy to maggies and AB magnitudes. For any source with a flux in maggies less than 0, we will assign a value of NaN for the AB magnitude. Recall that maggies are defined such that 1 maggie is equal to the reference flux for the AB magnitude system, which is 3,631 Jy. Thus, to convert our measurements from Jankys to maggies, we divide our fluxes by 3,631 Jy. We will also mask out any sources that have a flux of less than or equal to zero as those will not convert to magnitudes. Such sources exist where the background flux was statistically higher than the measured source flux."
    ]
   },
   {

--- a/content/notebooks/aperture_photometry/aperture_photometry.ipynb
+++ b/content/notebooks/aperture_photometry/aperture_photometry.ipynb
@@ -469,11 +469,9 @@
    "outputs": [],
    "source": [
     "zpt = meta.photometry.conversion_megajanskys\n",
-    "zpt_err = meta.photometry.conversion_megajanskys_uncertainty\n",
     "pixel_area = meta.photometry.pixel_area\n",
     "\n",
     "print(f'Zeropoint = {zpt} (MJy/sr) / (DN/s)')\n",
-    "print(f'Zeropoint uncertainty = {zpt_err} (MJy/sr) / (DN/s)')\n",
     "print(f'Nominal pixel area = {pixel_area} sr')"
    ]
   },
@@ -491,13 +489,7 @@
    "outputs": [],
    "source": [
     "flux_bkgsub = star_phot.sum - (star_bkg.median * star_apertures.area)\n",
-    "phot_tab['flux_jy'] = flux_bkgsub * zpt * 1e6 * pixel_area\n",
-    "\n",
-    "# Calculate the uncertainty from the background subtraction\n",
-    "bkgsub_err = np.sqrt(star_phot.sum_err**2 + (star_bkg.std * star_apertures.area)**2)\n",
-    "\n",
-    "# Calculate the uncertainty in the flux including the uncertainty in the zeropoint\n",
-    "phot_tab['relative_flux_err'] = ((bkgsub_err / flux_bkgsub)**2 + (zpt_err / zpt)**2)"
+    "phot_tab['flux_jy'] = flux_bkgsub * zpt * 1e6 * pixel_area"
    ]
   },
   {
@@ -562,10 +554,6 @@
     "# Convert the flux to AB magnitudes\n",
     "phot_tab['abmag'] = -2.5 * np.log10(phot_tab['flux_maggies'])\n",
     "\n",
-    "# Compute the errors. Since they are small, we can approximate these as +/- the relative error multiplied by the AB magnitude.\n",
-    "# Technically the error is asymmetric in magnitudes, but again these errors are small so we can approximate the error with a\n",
-    "# single value.\n",
-    "phot_tab['abmag_err'] =  ((1 + phot_tab['relative_flux_err']) * phot_tab['abmag']) - phot_tab['abmag']\n",
     "phot_tab[:5]"
    ]
   },
@@ -588,11 +576,6 @@
     "offset = stars['abmag'] - phot_tab['abmag']\n",
     "ax.scatter(stars['abmag'], offset, s=5, color='cornflowerblue', alpha=0.3)\n",
     "\n",
-    "# Plot the median error bar in the measurements. We'll place a data point in the upper left\n",
-    "# to show the median error and label it appropriately.\n",
-    "med_err = np.nanmedian(phot_tab['abmag_err'])\n",
-    "ax.errorbar(17, 0.12, yerr=med_err, color='forestgreen', ms=5, fmt='o', capsize=5, label=f'Median Error Bar = {med_err:0.3f} AB mag')\n",
-    "\n",
     "# Compute the median offset ignoring NaNs and plot the median and a reference line at 0\n",
     "_, med, std = sigma_clipped_stats(offset[~np.isnan(offset)], sigma=5, maxiters=2)\n",
     "ax.axhline(med, c='darkorange', label=fr'Median $\\Delta m = {med:.3f}$ AB mag, Std. $\\Delta m = {std:.3f}$ AB mag', zorder=1e4)\n",
@@ -601,7 +584,7 @@
     "# Restrict the axis limits for visibility. You may need to change these if you alter the input\n",
     "# data for this tutorial.\n",
     "ax.set_xlim(21, 16.5)\n",
-    "ax.set_ylim(-0.2, 0.2)\n",
+    "ax.set_ylim(-0.5, 0.5)\n",
     "\n",
     "# Label the axes\n",
     "ax.set_xlabel(r'$m_{\\mathrm{AB, input}}$')\n",
@@ -617,7 +600,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Our measurements of stars in the image agree well with the input catalog fluxes at the level of approximately 1%. There could be several reasons why we see a small offset between the input and output magnitudes. First, we use a single value of the gain for our zeropoint, but we could do better and use a gain per pixel to convert the image from DN/s to photo-electrons per second and apply the zeropoint (with the gain removed). This would likely decrease the scatter in the plot. Secondly, we used a single aperture correction for the whole image based on the model of a star with an average SED and located at the center of the detector. A more detailed handling of the aperture correction may also decrease the scatter, and may also help bring the measurements into better alignment with the input catalog.\n",
+    "Our measurements of stars in the image agree well with the input catalog fluxes at the level of approximately 0.9%. There could be several reasons why we see a small offset between the input and output magnitudes. First, we use a single value of the gain for our zeropoint, but we could do better and use a gain per pixel to convert the image from DN/s to photo-electrons per second and apply the zeropoint (with the gain removed). This would likely decrease the scatter in the plot. Secondly, we used a single aperture correction for the whole image based on the model of a star with an average SED and located at the center of the detector. A more detailed handling of the aperture correction may also decrease the scatter, and may also help bring the measurements into better alignment with the input catalog. Finally, a more careful treatment of other systematics (e.g., interpixel capacitance) may yield even better results.\n",
     "\n",
     "A similar exercise in photometry can be repeated for the galaxies in the input catalog, but care should be taken when selecting apertures for galaxies as fixed aperture sizes will correspond to different physical sizes at the distances of galaxies. Other choices for galaxy apertures include, e.g., Kron apertures or isophotal apertures."
    ]

--- a/content/notebooks/aperture_photometry/aperture_photometry.ipynb
+++ b/content/notebooks/aperture_photometry/aperture_photometry.ipynb
@@ -52,7 +52,8 @@
     "- *roman_datamodels* opens and validates WFI data files\n",
     "- *asdf* opens WFI data files\n",
     "- *os* for checking if files exist\n",
-    "- *s3fs* streams data from Simple Storage Service (S3) buckets on Amazon Web Services (AWS)"
+    "- *s3fs* streams data from Simple Storage Service (S3) buckets on Amazon Web Services (AWS)\n",
+    "- *stpsf* for retrieving the encircled energy profile of stars"
    ]
   },
   {
@@ -66,14 +67,17 @@
    "outputs": [],
    "source": [
     "from astropy.table import Table\n",
+    "from astropy.stats import SigmaClip, sigma_clipped_stats\n",
     "import asdf\n",
+    "import crds\n",
     "import copy\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
-    "from photutils.aperture import CircularAperture, aperture_photometry\n",
+    "from photutils.aperture import CircularAperture, CircularAnnulus, aperture_photometry, ApertureStats\n",
     "import roman_datamodels as rdm\n",
     "import os\n",
-    "import s3fs"
+    "import s3fs\n",
+    "import stpsf"
    ]
   },
   {
@@ -91,7 +95,9 @@
     "- **Sources detected at other wavelengths.** If a source is detected in a given bandpass, and the source size is expected to be the same across wavelengths, then it can be useful to define one aperture and measure the source fluxes across multiple filters.\n",
     "- **Time-series evolution of sources.** If a source brightness is decreasing over time, then we can use earlier observations obtained when the source was bright to specify an aperture and extract the flux in a time series.\n",
     "\n",
-    "Here, we cover a simple example using the `photutils` package to extract fluxes from a catalog of known sources (stars and galaxies)."
+    "Here, we cover a simple example using the `photutils` package to extract fluxes from a catalog of known sources.\n",
+    "\n",
+    "Please note that the WFI calibration is currently measured from ground test data, and changes are expected after launch. "
    ]
   },
   {
@@ -113,7 +119,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "slideshow": {
@@ -123,7 +128,7 @@
    "source": [
     "### Image Data\n",
     "\n",
-    "In this tutorial, we use a Level 2 (L2; calibrated rate image) WFI data file that is the result of RomanCal processing of a Level 1 (L1; uncalibrated ramp cube) simulated file created with Roman I-Sim. If you have already worked through the tutorials \"Simulating WFI Imaging Data with Roman I-Sim\" and \"Calibrating WFI Exposures with RomanCal,\" then you may already have these files saved locally. If not, then these files are also stored in the RRN S3 bucket. For more information on how to access these data, see the Data Discovery and Access tutorial.\n",
+    "In this tutorial, we use a Level 2 (L2; calibrated rate image) WFI data file that is the result of RomanCal processing of a Level 1 (L1; uncalibrated ramp cube) simulated file created with Roman I-Sim. If you have already worked through the tutorials \"Simulating WFI Imaging Data with Roman I-Sim\" and \"Calibrating WFI Exposures with RomanCal,\" then you may already have these files saved locally. If not, then these files are also stored in the Nexus S3 bucket. For more information on how to access these data, see the [Data Discovery and Access](../data_discovery_and_access/data_discovery_and_access.ipynb) tutorial.\n",
     "\n",
     "As a reminder, the file we are using is a L2 file meaning that the data were processed to flag and/or correct for detector-level effects (e.g., saturation, classic non-linearity, etc.), and that the ramp was fitted into a count rate image in units of Data Numbers (DN) per second."
    ]
@@ -146,8 +151,11 @@
     "    asdf_file_uri = asdf_dir_uri + 'r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
     "    with fs.open(asdf_file_uri, 'rb') as f:\n",
     "        af = asdf.open(f)\n",
-    "        dm = rdm.open(af)\n",
+    "        dm = rdm.open(af).copy()\n",
     "        image = dm.data.copy()\n",
+    "        err = dm.err.copy()\n",
+    "        dq = np.bool(dm.dq.copy())\n",
+    "        meta = copy.deepcopy(dm.meta)\n",
     "        wcs = copy.deepcopy(dm.meta.wcs)"
    ]
   },
@@ -157,7 +165,7 @@
    "source": [
     "### Source Catalog\n",
     "\n",
-    "We also have access to a source catalog that was used to simulate the WFI image. It contains stars and galaxies, which are labeled as `PSF` and `SER` under the column `type`. Source fluxes are available in all WFI filters (`F062`, `F087`, `F106`, `F129`, `F146`, `F158`, `F184`, `F213`) and are sampled from a lognormal distribution. Note that fluxes are all given in *maggies*, which are defined as ${\\rm maggie} \\equiv 10^{-0.4 m_{AB}}$, for an AB apparent magnitude $m_{AB}$. \n",
+    "We also have access to a source catalog that was used to simulate the WFI image. It contains stars and galaxies, which are labeled as \"PSF\" and \"SER\" under the column `type`. Source fluxes are available in all WFI filters (F062, F087, F106, F129, F146, F158, F184, and F213) and are sampled from a lognormal distribution. Note that fluxes are all given in *maggies*, which are defined as ${\\rm maggie} \\equiv 10^{-0.4 m_{AB}}$, for an AB apparent magnitude $m_{AB}$. \n",
     "\n",
     "For galaxies, morphological parameters like `n` (Sersic index), `half_light_radius`, `pa` (position angle), and `ba` (axis ratio) are also provided in the catalog. These are sampled according to fiducial (and likely unrealistic) distributions."
    ]
@@ -209,7 +217,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x_cat, y_cat = wcs.world_to_array_index_values(cat[\"ra\"], cat[\"dec\"])"
+    "x_cat, y_cat = wcs.invert(cat[\"ra\"].data, cat[\"dec\"].data)\n",
+    "cat['x'] = x_cat\n",
+    "cat['y'] = y_cat"
    ]
   },
   {
@@ -225,11 +235,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "on_detector_mask = (x_cat >= 0) & (x_cat <= 4095) & (y_cat >= 0) & (y_cat <= 4095)\n",
-    "print(f\"Number of sources on detector: {sum(on_detector_mask)}\")\n",
+    "mask = (np.isfinite(x_cat) & np.isfinite(y_cat))\n",
+    "print(f\"Number of sources on detector: {sum(mask)}\")\n",
     "\n",
-    "stars = cat[on_detector_mask & (cat[\"type\"] == \"PSF\")]\n",
-    "galaxies = cat[on_detector_mask & (cat[\"type\"] == \"SER\")]\n",
+    "stars = cat[mask & (cat[\"type\"] == \"PSF\")]\n",
+    "galaxies = cat[mask & (cat[\"type\"] == \"SER\")]\n",
     "print(f\"Number of stars: {len(stars)}\\nNumber of galaxies: {len(galaxies)}\")"
    ]
   },
@@ -237,7 +247,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Note that there are two orders of magnitude more stars than galaxies. We can now plot the distribution of source fluxes using a histogram. "
+    "We can now plot the distribution of source fluxes using a histogram. We will plot the flux from the input catalog in units of AB magnitudes. Recall that the input catalog is in units of maggies. The transformation from maggies to AB magnitudes is given by:\n",
+    "\n",
+    "$m_{\\mathrm{AB}} = -2.5 \\times \\log_{10}(f_{\\mathrm{maggies}})$"
    ]
   },
   {
@@ -246,12 +258,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots()\n",
-    "ax.hist(np.log10(stars[\"F106\"].value), bins=50, range=[-10, -5], log=True, label=\"Stars\")\n",
-    "ax.hist(np.log10(galaxies[\"F106\"].value), bins=50, range=[-10, -5], log=True, label=\"Galaxies\")\n",
+    "stars['abmag'] = -2.5 * np.log10(stars['F106'])\n",
+    "galaxies['abmag'] = -2.5 * np.log10(galaxies['F106'])\n",
     "\n",
-    "ax.set_xlabel(\"$\\log_{10}$(F106 flux [maggies])\")\n",
-    "ax.set_ylabel(\"Number of sources\")\n",
+    "fig, ax = plt.subplots()\n",
+    "ax.hist(stars['abmag'], bins=50, range=[16, 24], log=True, label='Stars')\n",
+    "ax.hist(galaxies['abmag'], bins=50, range=[16, 24], log=True, label='Galaxies')\n",
+    "\n",
+    "ax.set_xlabel(r'$m_{\\mathrm{AB, F106}}$')\n",
+    "ax.set_ylabel('Number of Sources')\n",
+    "ax.xaxis.set_inverted(True)\n",
     "ax.legend()\n",
     "\n",
     "ax.grid(alpha=0.3)"
@@ -263,7 +279,68 @@
    "source": [
     "## Forced Aperture Photometry\n",
     "\n",
-    "Forced aperture photometry is the process of using predefined source positions to place apertures and measure the flux within them. We use the source catalog information provided above for this. If source positions are unavailable, you will need to perform source detection first to determine their locations (see [Additional Resources](#Additional-Resources))."
+    "Forced aperture photometry uses predefined source positions to place apertures and measure the flux within them. We use the source catalog information provided above for this. If source positions are unavailable, you will need to perform source detection first to determine their locations (see [Additional Resources](#Additional-Resources)).\n",
+    "\n",
+    "### Correcting for Pixel Area\n",
+    "\n",
+    "First, we need to correct our data for geometric distortion, which causes pixels to have different areas projected on the sky. The WFI distortion is described by a 2-D polynomial, and the area of each pixel is given by the determinant of the Jacobian matrix of this polynomial. A reference file, called the Pixel Area Map (PAM), provides the area per pixel of each WFI detector normalized to the nominal pixel area. The nominal pixel area is the pixel area at the tangent point about which the distortion polynomial is defined.\n",
+    "\n",
+    "First, we can use the `crds` Python package to request the best pixel area map reference file that matches our observation. In this case, CRDS needs to know the instrument name (WFI), detector name (WFI01), and the start time of the exposure. We can pull all of this information out of the metadata of the L2 file. Note that we need to specify the start time as a string, so we use `meta.exposure.start_time.isot` to convert the `astropy.time.Time` object in the metadata to an ISOT string (i.e., it has the format YYYY-MM-DDTHH:MM:SS.SSS). We also specify that the observatory is \"roman\" and that we want the \"area\" reference file type:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "crds_result = crds.getreferences({'ROMAN.META.INSTRUMENT.DETECTOR': meta.instrument.detector,\n",
+    "                             'ROMAN.META.INSTRUMENT.NAME': meta.instrument.name,\n",
+    "                             'ROMAN.META.EXPOSURE.START_TIME': meta.exposure.start_time.isot}, observatory='roman', reftypes=['area'])\n",
+    "\n",
+    "print(crds_result)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that a dictionary is returned. The keys of the dictionary are the reference file types (e.g., \"area\"), and the values are the path to the correct file in your local CRDS cache. If the file is not in your cache, then the `crds.getreferences()` function will download the file to your local cache. At this time, CRDS does not support streaming reference files into memory from the CRDS server, but work is ongoing to adapt CRDS to cloud applications.\n",
+    "\n",
+    "Next, let's take a look at the pixel area map that we now have:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pam = rdm.open(crds_result['area'])\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "img = ax.imshow(pam.data, origin='lower')\n",
+    "ax.set_xlabel('X science coordinate (pixels)')\n",
+    "ax.set_ylabel('Y science coordinate (pixels)')\n",
+    "ax.set_title(f'Pixel Area Map for {pam.meta.instrument.detector}')\n",
+    "plt.colorbar(img);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's multiply the science data and the uncertainty array by the PAM to adjust for the relative sizes of the pixels on the sky:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image *= pam.data\n",
+    "err *= pam.data"
    ]
   },
   {
@@ -277,7 +354,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From the catalogs, we now know the positions of every selected star and galaxy. We can define set aperture radii in units of pixels; we choose radii of 3 pixels for stars and 5 pixels for galaxies."
+    "For simplicity, we will focus on the stars from this point. From the catalogs, we now know the positions of every star. We can define set aperture radii in units of pixels; we choose radii of 3 pixels:"
    ]
   },
   {
@@ -286,18 +363,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "star_positions = [(y, x) for x, y in zip(*wcs.world_to_array_index_values(stars[\"ra\"], stars[\"dec\"]))]\n",
-    "star_apertures = CircularAperture(positions=star_positions, r=3)\n",
-    "\n",
-    "galaxy_positions = [(y, x) for x, y in zip(*wcs.world_to_array_index_values(galaxies[\"ra\"], galaxies[\"dec\"]))]\n",
-    "galaxy_apertures = CircularAperture(positions=galaxy_positions, r=5)"
+    "star_positions = [(x, y) for y, x in zip(stars['y'].data, stars['x'].data)]\n",
+    "star_apertures = CircularAperture(positions=star_positions, r=3)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Source Visualization"
+    "Let's create annulus apertures with $r_{in} = 20$ pixels and $r_{out} = 25$ pixels to measure local sky background values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "star_bkg_apertures = CircularAnnulus(positions=star_positions, r_in=20, r_out=25)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Source Visualization\n",
+    "\n",
+    "Let's plot our apertures on a subsection of the image to visually confirm that we have placed our apertures correctly. There may be a few small, fuzzy galaxies in the image that are not marked since we are focusing on stars. Similarly, there may be several small features that are detector imperfections that are also not marked, but those will be masked in the data quality array."
    ]
   },
   {
@@ -309,17 +401,17 @@
     "fig, ax = plt.subplots(figsize=(9, 9))\n",
     "\n",
     "# show the simulated image\n",
-    "ax.imshow(image, origin='lower', vmin=0, vmax=12, cmap=\"gray_r\", )\n",
+    "ax.imshow(image, origin='lower', vmin=0, vmax=12, cmap='gray_r')\n",
     "\n",
     "# plot circles over bright galaxies and stars\n",
-    "star_apertures.plot(color=\"C0\")\n",
-    "galaxy_apertures.plot(color=\"C1\")\n",
+    "star_apertures.plot(color='cornflowerblue')\n",
+    "star_bkg_apertures.plot(color='cornflowerblue', ls=':')\n",
     "\n",
     "# zoom in on 1/16th of the image\n",
     "ax.set_xlim(1024, 1536)\n",
     "ax.set_ylim(1024, 1536)\n",
     "\n",
-    "plt.axis(\"off\")\n",
+    "plt.axis('off')\n",
     "plt.show()"
    ]
   },
@@ -329,7 +421,7 @@
    "source": [
     "### Aperture Photometry with Photutils\n",
     "\n",
-    "We can now perform aperture photometry on the selected sources. Note that the input catalog contained all the sources in the region observed with the WFI, but not all the sources in the catalog fall necessarily on a WFI detector. In this case, the aperture photometry will have a value of NaN."
+    "We can now perform aperture photometry on the selected sources. First we measure the photometry in a circular aperture on each source:"
    ]
   },
   {
@@ -338,25 +430,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "star_phot = aperture_photometry(image, star_apertures)\n",
-    "star_phot"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "galaxy_phot = aperture_photometry(image, galaxy_apertures)\n",
-    "galaxy_phot"
+    "columns = ('id', 'xcentroid', 'ycentroid', 'sum', 'sum_err')\n",
+    "star_phot = ApertureStats(image, star_apertures, error=err)\n",
+    "phot_tab = star_phot.to_table(columns)\n",
+    "phot_tab[:5]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's evaluate our results by plotting the measured fluxes versus fluxes in the simulated catalog. The blue points show the stars and follow a much tighter relation with respect to the extended sources, which is expected given their compact sizes and smaller apertures. On the other hand, galaxies require larger apertures, but in some cases (especially for brighter galaxies), they still lose flux and/or are contaminated by nearby sources, a problem that is often more noticeable for fainter galaxies."
+    "And now let's do the same for the background annuli using the ApertureStats class. We will use the median of the pixels within the annulus as our estimate of the sky background **per pixel**. We will need to adjust this to the area of the star circular apertures (after accounting for the masked pixels)."
    ]
   },
   {
@@ -365,28 +449,177 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, ax = plt.subplots(figsize=(5, 5))\n",
-    "ax.scatter(stars[\"F106\"], star_phot[\"aperture_sum\"], s=5, c=\"C0\", label=\"Stars\", alpha=0.5)\n",
-    "ax.scatter(galaxies[\"F106\"], galaxy_phot[\"aperture_sum\"], s=5, c=\"C1\", label=\"Galaxies\", alpha=0.5)\n",
+    "columns = ('id', 'xcentroid', 'ycentroid', 'median', 'std')\n",
+    "sigclip = SigmaClip(sigma=3.0, maxiters=5)\n",
+    "star_bkg = ApertureStats(image, star_bkg_apertures, sigma_clip=sigclip, mask=dq)\n",
+    "star_bkg.to_table(columns)[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For our next steps, we will need the nominal pixel area in steradians (sr) and the zeropoint in megaJanskys per steradian (MJy/sr), both of which can be retrieved from the L2 metadata. Note that the pre-launch zeropoint is based on the unit response of the throughput curve of the integrated optical system (i.e., including all of the mirror reflectivities, optical element transmission, and detector quantum efficiency). The zeropoint also includes a factor of the median measured gain of the detector. The pre-launch zeropoint uncertainty is based solely on the standard deviation of the measured gain. After launch, these values will be updated using on-orbit observations of spectrophotometric standard stars and the photometric touchstone fields."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "zpt = meta.photometry.conversion_megajanskys\n",
+    "zpt_err = meta.photometry.conversion_megajanskys_uncertainty\n",
+    "pixel_area = meta.photometry.pixel_area\n",
     "\n",
-    "# Set log scale on both axes\n",
-    "ax.set_xscale(\"log\")\n",
-    "ax.set_yscale(\"log\")\n",
+    "print(f'Zeropoint = {zpt} (MJy/sr) / (DN/s)')\n",
+    "print(f'Zeropoint uncertainty = {zpt_err} (MJy/sr) / (DN/s)')\n",
+    "print(f'Nominal pixel area = {pixel_area} sr')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we subtract the sky background values from the source fluxes and propagate the uncertainty in the background into the total uncertainty:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flux_bkgsub = star_phot.sum - (star_bkg.median * star_apertures.area)\n",
+    "phot_tab['flux_jy'] = flux_bkgsub * zpt * 1e6 * pixel_area\n",
+    "\n",
+    "# Calculate the uncertainty from the background subtraction\n",
+    "bkgsub_err = np.sqrt(star_phot.sum_err**2 + (star_bkg.std * star_apertures.area)**2)\n",
+    "\n",
+    "# Calculate the uncertainty in the flux including the uncertainty in the zeropoint\n",
+    "phot_tab['relative_flux_err'] = ((bkgsub_err / flux_bkgsub)**2 + (zpt_err / zpt)**2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We also need to correct our fluxes for the fraction of the starlight that falls outside of the aperture. The amount of light within the aperture as a function of the total light within a hypothetical infinite aperture is called the encircled energy and can be either measured from the image data using a series of apertures or can be determined from STPSF. In the future, a reference file in CRDS will also provide this information. For now, let's use STPSF:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wfi = stpsf.WFI()\n",
+    "wfi.filter = meta.instrument.optical_element\n",
+    "wfi.detector = f'SCA{meta.instrument.detector[-2:]}'\n",
+    "wfi.detector_position = (2043.5, 2043.5)\n",
+    "wfi_psf = wfi.calc_psf()\n",
+    "ee_func = stpsf.measure_ee(wfi_psf)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "With these settings, our encircled energy measurement is an average one for the whole detector, measured at the center of the detector, and for the default STPSF spectral energy distribution (SED), which is a 5700 K blackbody (similar to a G2V star). The variable `ee_func` above is a function that takes as its single argument the aperture radius in arcseconds and returns the percentage of the PSF contained within that aperture. The inverse of that encircled energy fraction is the correction factor that we must apply to our measurements. This is called the encircled energy correction or aperture correction. Let's calculate that now for a circular aperture with a 3-pixel radius and assuming a pixel scale of 0.11 arcseconds per pixel (i.e., radius = 0.33 arcseconds):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ee_correction = 1/ee_func(3 * 0.11)\n",
+    "print(f'Encircled energy correction = {ee_correction}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can apply the aperture correction to our flux, and then convert the flux in Jy to maggies and AB magnitudes. For any source with a flux in maggies less than 0, we will assign a value of NaN for the AB magnitude."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "phot_tab['flux_jy'] *= ee_correction\n",
+    "phot_tab['flux_maggies'] = phot_tab['flux_jy'] / 3631\n",
+    "\n",
+    "# Mask out things with flux <= 0\n",
+    "mask = phot_tab['flux_maggies'] <= 0\n",
+    "phot_tab['flux_maggies'][mask] = np.nan\n",
+    "phot_tab['flux_jy'][mask] = np.nan\n",
+    "\n",
+    "# Convert the flux to AB magnitudes\n",
+    "phot_tab['abmag'] = -2.5 * np.log10(phot_tab['flux_maggies'])\n",
+    "\n",
+    "# Compute the errors. Since they are small, we can approximate these as +/- the relative error multiplied by the AB magnitude.\n",
+    "# Technically the error is asymmetric in magnitudes, but again these errors are small so we can approximate the error with a\n",
+    "# single value.\n",
+    "phot_tab['abmag_err'] =  ((1 + phot_tab['relative_flux_err']) * phot_tab['abmag']) - phot_tab['abmag']\n",
+    "phot_tab[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's evaluate our results by plotting the difference between the simulated catalog and measured AB magnitudes. The blue points show the photometry of the stars, while the orange line shows the median offset between the input catalog and the measurements. The labeled uncertainty on the median is the standard deviation of the distribution. We also include a black line at an offset of 0 AB magnitudes as a reference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(7, 7))\n",
+    "\n",
+    "# Compute the offset between the input catalogs (stars) and measured (phot_tab) AB magnitudes and plot them\n",
+    "offset = stars['abmag'] - phot_tab['abmag']\n",
+    "ax.scatter(stars['abmag'], offset, s=5, color='cornflowerblue', alpha=0.3)\n",
+    "\n",
+    "# Plot the median error bar in the measurements. We'll place a data point in the upper left\n",
+    "# to show the median error and label it appropriately.\n",
+    "med_err = np.nanmedian(phot_tab['abmag_err'])\n",
+    "ax.errorbar(17, 0.12, yerr=med_err, color='forestgreen', ms=5, fmt='o', capsize=5, label=f'Median Error Bar = {med_err:0.3f} AB mag')\n",
+    "\n",
+    "# Compute the median offset ignoring NaNs and plot the median and a reference line at 0\n",
+    "_, med, std = sigma_clipped_stats(offset[~np.isnan(offset)], sigma=5, maxiters=2)\n",
+    "ax.axhline(med, c='darkorange', label=fr'Median $\\Delta m = {med:.3f}$ AB mag, Std. $\\Delta m = {std:.3f}$ AB mag', zorder=1e4)\n",
+    "ax.axhline(0, color='black', zorder=-100)\n",
+    "\n",
+    "# Restrict the axis limits for visibility. You may need to change these if you alter the input\n",
+    "# data for this tutorial.\n",
+    "ax.set_xlim(21, 16.5)\n",
+    "ax.set_ylim(-0.2, 0.2)\n",
     "\n",
     "# Label the axes\n",
-    "ax.set_xlabel(\"F106 true flux (maggies)\")\n",
-    "ax.set_ylabel(\"F106 Aperture flux (DN/s)\")\n",
-    "ax.legend(loc=\"lower right\", fontsize=12)\n",
+    "ax.set_xlabel(r'$m_{\\mathrm{AB, input}}$')\n",
+    "ax.set_ylabel(r'$m_{\\mathrm{AB, input}} - m_{\\mathrm{AB, measured}}$')\n",
+    "ax.legend(loc='lower right', fontsize=10)\n",
     "\n",
     "# Overplot a reference grid\n",
-    "ax.grid(alpha=0.3)"
+    "ax.grid(alpha=0.1)\n",
+    "plt.savefig('photometry.png')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In addition to what we expected, we observe a distribution of stars with very low measured fluxes of around 20 DN/s across a wide range of input catalog fluxes. These sources were skipped in the Roman I-Sim simulation. As a result, although they appear in the input catalog, there is no corresponding source at those positions in the simulated image, meaning we are measuring sky background levels instead."
+    "Our measurements of stars in the image agree well with the input catalog fluxes at the level of approximately 1%. There could be several reasons why we see a small offset between the input and output magnitudes. First, we use a single value of the gain for our zeropoint, but we could do better and use a gain per pixel to convert the image from DN/s to photo-electrons per second and apply the zeropoint (with the gain removed). This would likely decrease the scatter in the plot. Secondly, we used a single aperture correction for the whole image based on the model of a star with an average SED and located at the center of the detector. A more detailed handling of the aperture correction may also decrease the scatter, and may also help bring the measurements into better alignment with the input catalog.\n",
+    "\n",
+    "A similar exercise in photometry can be repeated for the galaxies in the input catalog, but care should be taken when selecting apertures for galaxies as fixed aperture sizes will correspond to different physical sizes at the distances of galaxies. Other choices for galaxy apertures include, e.g., Kron apertures or isophotal apertures."
    ]
   },
   {
@@ -413,7 +646,7 @@
     "## About This Notebook\n",
     "\n",
     "**Author:** John F. Wu, Tyler Desjardins\\\n",
-    "**Updated On:** 2025-01-10"
+    "**Updated On:** 2025-05-28"
    ]
   },
   {
@@ -434,9 +667,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Calibration",
    "language": "python",
-   "name": "python3"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {
@@ -448,7 +681,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.8"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/content/notebooks/aperture_photometry/requirements.txt
+++ b/content/notebooks/aperture_photometry/requirements.txt
@@ -3,3 +3,9 @@ astropy
 photutils
 roman_datamodels
 s3fs
+crds
+copy
+matplotlib
+numpy
+os
+stpsf


### PR DESCRIPTION
This updates the aperture photometry notebook significantly:
- Adds information on pixel area maps and how to get them from CRDS
- Removes galaxy photometry from example and focuses on stars 
- Shows how to use zeropoints to convert from instrumental to physical units
- Validates that the Roman I-Sim input catalog and measured magnitudes agree