### PR TITLE
Minor fix to Pandeia notebook

### DIFF
--- a/content/notebooks/pandeia/pandeia.ipynb
+++ b/content/notebooks/pandeia/pandeia.ipynb
@@ -389,8 +389,8 @@
     "    mag : float\n",
     "        AB Magnitude of source\n",
     "    bracket : tuple, default (1, 1000)\n",
-    "        Range of magnitudes to test\n",
-    "    xtold: float, default 0.1\n",
+    "        Range of number of exposures to test\n",
+    "    xtol: float, default 0.1\n",
     "        Target tolerance for minimizer\n",
     " \n",
     "    Returns\n",
@@ -423,7 +423,7 @@
     "    if report['scalar']['sn'] > sn:\n",
     "        nexp = 1\n",
     "    else:\n",
-    "        res = minimize_scalar(_nexp2sn_, bracket=bracket, bounds=bracket,\n",
+    "        res = minimize_scalar(_nexp2sn_, bounds=bracket,\n",
     "                              args=(calc, sn), method='bounded',\n",
     "                              options={'xatol': xtol})\n",
     "        \n",
@@ -440,6 +440,9 @@
     "        # 2) make code consistent with the above if clause\n",
     "        if report['scalar']['sn'] < sn:\n",
     "            nexp += 1\n",
+    "            calc['configuration']['detector']['nexp'] = nexp\n",
+    "            report = perform_calculation(calc)\n",
+    "            exptime = report['scalar']['total_exposure_time']\n",
     "             \n",
     "    exptime = report['scalar']['total_exposure_time']\n",
     "         \n",
@@ -464,9 +467,9 @@
     "sn = 20.\n",
     "mag = 26.84\n",
     " \n",
-    "nexp, etc, exptime = compute_nexp(FILTER, sn, mag)\n",
-    "print(f'number of exposures: {nexp}')\n",
-    "print(f'actual S/N reached: {etc[\"scalar\"][\"sn\"]:.2f}')\n",
+    "nexp, report, exptime = compute_nexp(FILTER, sn, mag)\n",
+    "print(f'Number of exposures: {nexp}')\n",
+    "print(f'Actual S/N reached: {report[\"scalar\"][\"sn\"]:.2f}')\n",
     "print(f'Exposure time: {exptime:.2f}')"
    ]
   },
@@ -705,7 +708,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Pandeia changes:

1. In docstring for`compute_nexp`, `bracket` keyword is for the range of _exposures_ to test, not magnitude. Also, xtold --> xtol.
2. In `minimize_scalar` , `bracket` argument is not needed for `method = 'bounded'`.
3. Minor thing, but I would make the variable names that store the outputs from `compute_nexp` match those that it returns, to avoid confusion. For example, everywhere in the notebook, we call the ETC output `report`, but in this particular call, it returns `etc` . I missed that name change and it took me a little bit to figure it out.
4. If we do if r`eport['scalar']['sn'] < sn: nexp += 1` then we need to run the Pandeia calculation again to get an updated total exposure time, otherwise we’re one exposure time short.