### PR TITLE
Add Mast aladin demo notebook

### DIFF
--- a/content/notebooks/data_visualization/Intro_To_Mast_Aladin_Lite.ipynb
+++ b/content/notebooks/data_visualization/Intro_To_Mast_Aladin_Lite.ipynb
@@ -39,7 +39,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install git+https://github.com/spacetelescope/mast-aladin-lite.git"
+    "%pip install --upgrade git+https://github.com/spacetelescope/mast-aladin-lite.git"
    ]
   },
   {
@@ -297,7 +297,7 @@
     "## About this Notebook\n",
     "**Author:** Hatice Karatay\n",
     "\n",
-    "**Updated On:** 2025-07-22\n",
+    "**Updated On:** 2025-08-13\n",
     "***\n",
     "[Top of Page](#top)\n",
     "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "

--- a/content/notebooks/data_visualization/Intro_To_Mast_Aladin_Lite.ipynb
+++ b/content/notebooks/data_visualization/Intro_To_Mast_Aladin_Lite.ipynb
@@ -1,0 +1,334 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "248a3707",
+   "metadata": {},
+   "source": [
+    "# Introduction to MastAladinLite\n",
+    "\n",
+    "Welcome! This tutorial will walk you through the basics of using **MastAladinLite** to visualize astronomical targets in the sky.  \n",
+    "By the end of this notebook, you'll be able to:\n",
+    "\n",
+    "### Objectives\n",
+    "- Instantiate a `MastAladin` viewer to explore sky images\n",
+    "- Set the viewer to point to well-known targets (like \"M31\" or \"NGC 3628\")\n",
+    "- Customize the viewer’s field of view (`fov`) and height\n",
+    "- Query the MAST archive for science products around a target\n",
+    "- Overlay the results on your viewer\n",
+    "- Get and update the current viewer state using `get_viewport()` and `set_viewport()`\n",
+    "- Display the viewer in a separate panel using Sidecar and reposition it in JupyterLab\n",
+    "\n",
+    "---"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1125978f-56df-4005-b692-c8a21123cf03",
+   "metadata": {},
+   "source": [
+    "## Installing MastAladinLite\n",
+    "Before we get started, let’s make sure we’re using the latest version of MastAladinLite.\n",
+    "We’ll install it directly from the official GitHub repository so this tutorial reflects the most recent features and fixes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d277e3c7-2dc8-4647-9e08-92449620b281",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install git+https://github.com/spacetelescope/mast-aladin-lite.git"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6a251f06-d83d-406e-a96a-0459f6eb22e9",
+   "metadata": {
+    "vscode": {
+     "languageId": "plaintext"
+    }
+   },
+   "source": [
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9b685555-e240-4be0-8c80-300411c7596c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astroquery.mast import Observations\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from mast_aladin_lite import MastAladin\n",
+    "from sidecar import Sidecar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1b15292-ec88-4bb5-9fbf-216fc7ea1a35",
+   "metadata": {},
+   "source": [
+    "## Step 1: Creating a Sky Viewer\n",
+    "\n",
+    "To begin, we'll create a sky viewer using `MastAladin`. This viewer is an interactive widget that allows you to explore sky regions from your Jupyter notebook.\n",
+    "\n",
+    "You can customize:\n",
+    "- The **target** (center of the view) — using object names (e.g., `\"M31\"`, `\"Andromeda Galaxy\"`), or coordinates (`SkyCoord`)\n",
+    "- The **field of view** (`fov`) — how much of the sky you see, in degrees\n",
+    "- The **viewer height** — how large the widget appears on your screen\n",
+    "\n",
+    " **Try it yourself**: After running the cell below, try changing the `target`, `fov`, or `height` values to see how the viewer reacts!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0e76128-9704-40cd-a7e4-5d834e982644",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mast_aladin = MastAladin(\n",
+    "    target=\"M31\",                      # Accepts a string or SkyCoord\n",
+    "    fov=5,                             # Field of view in degrees\n",
+    "    height=500                         # Widget height in pixels\n",
+    ")\n",
+    "\n",
+    "mast_aladin"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5c225c4-db08-4515-8a76-4f2e2211e878",
+   "metadata": {},
+   "source": [
+    "# Step 2: Query MAST for Data Around a Target\n",
+    "\n",
+    "Now that we have a viewer showing a region of the sky, let's find **real science data** from the MAST (Mikulski Archive for Space Telescopes).\n",
+    "\n",
+    "We'll use the `Observations` interface from `astroquery.mast` to:\n",
+    "\n",
+    "- Specify a sky target (e.g., Andromeda Galaxy – “M31”)  \n",
+    "- Define a search radius around that target  \n",
+    "- Retrieve a table of available observations\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a7c2d3d-d88e-4928-b2c7-d26bb5024b4b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use `SkyCoord.from_name(\"M31\")` to automatically resolve the name \"M31\" into sky coordinates (RA/Dec).\n",
+    "m31 = SkyCoord.from_name(\"M31\")\n",
+    "\n",
+    "# Search within a 0.1° radius for any MAST observations\n",
+    "results = Observations.query_region(m31, radius=\"0.1 deg\")\n",
+    "\n",
+    "# Display the first few rows of the result table\n",
+    "results[:5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ce5ed5f4-d08a-4ccb-afda-9497765ad707",
+   "metadata": {},
+   "source": [
+    "## Step 3: Filter and Display Observations in the Viewer\n",
+    "\n",
+    "Now that we have a table of real MAST observations, let’s filter it down to something specific.\n",
+    "\n",
+    "In this example, we’ll select only the rows with the observation title **\"PS1 3PI Survey\"**, but you can filter the table however you like to fit your own workflow (e.g. by instrument, date, or collection).\n",
+    "\n",
+    "Once you’ve filtered the table, simply pass it into the viewer to display the selected observations as overlays."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73e254c8-ddc7-4e25-ae4a-04f02de11738",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Filter the results table by observation title\n",
+    "filtered = results[results[\"obs_title\"] == \"PS1 3PI Survey\"]\n",
+    "\n",
+    "# Add the filtered observations to the viewer\n",
+    "mast_aladin.add_table(filtered)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e9685a21-f3b5-419f-8612-06f1ef972117",
+   "metadata": {},
+   "source": [
+    "## Step 4: Save and Reuse Your Viewport Settings\n",
+    "\n",
+    "Once you’ve adjusted the viewer to focus on a region of interest, you might want to **save** that position and **return to it later** — or even share it with someone else.\n",
+    "\n",
+    "You can do this using the `get_viewport()` method. It gives you a dictionary with:\n",
+    "\n",
+    "- `center`: where the viewer is pointing (a `SkyCoord`)\n",
+    "- `fov`: the field of view (how zoomed in or out you are)\n",
+    "\n",
+    "Let’s try it out:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bff2e3f3-fad0-4296-818c-febcbdb52862",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the current viewport (center and zoom)\n",
+    "viewport = mast_aladin.aid.get_viewport()\n",
+    "viewport"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4a967234-7239-436c-912a-fced0b272b6d",
+   "metadata": {},
+   "source": [
+    "Now, let’s say you want to return to this same view later. You can pass the center value back into `set_viewport()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ea66aea7-cd79-41b7-9f6e-d99060b258e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reset the viewport using the saved center\n",
+    "mast_aladin.aid.set_viewport(center=viewport[\"center\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fff63afb-6765-402f-a031-264b48e76ced",
+   "metadata": {},
+   "source": [
+    "## Step 5: Display the Viewer in a Sidecar Panel\n",
+    "\n",
+    "To keep the notebook clean and focused, you can show the MastAladin viewer in a separate side panel using the `Sidecar` widget.\n",
+    "\n",
+    "This is especially helpful when you're working with large data tables or running long cells, the viewer stays visible while you continue to scroll and interact with other content.\n",
+    "\n",
+    "Let’s first display the viewer in a default side panel:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "644b7a1a-3223-4aef-ba85-b91884780690",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with Sidecar(title=\"Aladin Lite Viewer\"):\n",
+    "    mast_aladin = MastAladin(\n",
+    "        target=\"Cartwheel Galaxy\",\n",
+    "        fov=0.2\n",
+    "    )\n",
+    "    display(mast_aladin)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52405f01-66fc-439a-894a-b7dc57e00a53",
+   "metadata": {},
+   "source": [
+    "You can customize the position of the viewer by setting the anchor option. Available options include:\n",
+    "\n",
+    "'split-right' (default), 'split-left', 'split-top', 'split-bottom',\n",
+    "'tab-before', 'tab-after', 'right'\n",
+    "\n",
+    "Here’s how to dock the viewer at the bottom of your notebook instead:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6c4e3d2d-a074-4471-8ca3-eb326280fcae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with Sidecar(title=\"Aladin Lite Viewer\", anchor=\"split-bottom\"):\n",
+    "    mast_aladin = MastAladin(\n",
+    "        target=\"M1\",\n",
+    "        fov=3\n",
+    "    )\n",
+    "    display(mast_aladin)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0a72a31e-b4b1-4d75-a7e1-00b1706977ab",
+   "metadata": {},
+   "source": [
+    "### Summary\n",
+    "\n",
+    "- You created a viewer and pointed it at different sky locations.\n",
+    "- You queried real data from MAST.\n",
+    "- You visualized observations with overlays.\n",
+    "- You explored Sidecar options to customize your layout.\n",
+    "\n",
+    "Explore further by changing the target, trying other missions, or adjusting the field of view!\n",
+    "\n",
+    "Happy sky watching!\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "014f2a3e-2a33-4d6d-864c-b2a72796eec6",
+   "metadata": {},
+   "source": [
+    "## Additional Resources\n",
+    "\n",
+    "- [mast-aladin-lite Documentation](https://mast-aladin-lite.readthedocs.io/en/latest/index.html)\n",
+    "- [Mast Observations](https://astroquery.readthedocs.io/en/latest/api/astroquery.mast.ObservationsClass.html)\n",
+    "- [aladin-lite Documentation](https://aladin.cds.unistra.fr/AladinLite/doc/)\n",
+    "\n",
+    "## About this Notebook\n",
+    "**Author:** Hatice Karatay\n",
+    "\n",
+    "**Updated On:** 2025-07-22\n",
+    "***\n",
+    "[Top of Page](#top)\n",
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/> "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7857b8e0-c151-4c1c-af3a-e289148b4ad8",
+   "metadata": {},
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a new demo notebook showcasing the basic functionalities of `mast-aladin-lite`, including loading data, adjusting the view, and interacting with the viewer. It serves as an introductory example for users and can be expanded in future updates.