### PR TITLE
Update S3 paths

### DIFF
--- a/content/notebooks/aperture_photometry/aperture_photometry.ipynb
+++ b/content/notebooks/aperture_photometry/aperture_photometry.ipynb
@@ -143,20 +143,17 @@
     "\n",
     "if os.path.exists('r0003201001001001004_0001_wfi01_f106_cal.asdf'):\n",
     "    f = rdm.open('r0003201001001001004_0001_wfi01_f106_cal.asdf')\n",
-    "    image = f.data.copy()\n",
-    "    wcs = copy.deepcopy(f.meta.wcs)\n",
     "else:\n",
-    "    fs = s3fs.S3FileSystem()\n",
-    "    asdf_dir_uri = 's3://roman-sci-test-data-prod-summer-beta-test/AAS_WORKSHOP/'\n",
+    "    fs = s3fs.S3FileSystem(anon=True)\n",
+    "    asdf_dir_uri = 's3://stpubdata/roman/nexus/soc_simulations/tutorial_data/'\n",
     "    asdf_file_uri = asdf_dir_uri + 'r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
-    "    with fs.open(asdf_file_uri, 'rb') as f:\n",
-    "        af = asdf.open(f)\n",
-    "        dm = rdm.open(af).copy()\n",
-    "        image = dm.data.copy()\n",
-    "        err = dm.err.copy()\n",
-    "        dq = np.bool(dm.dq.copy())\n",
-    "        meta = copy.deepcopy(dm.meta)\n",
-    "        wcs = copy.deepcopy(dm.meta.wcs)"
+    "    f = rdm.open(fs.open(asdf_file_uri, 'rb'))\n",
+    "\n",
+    "image = f.data\n",
+    "err = f.err\n",
+    "dq = np.bool(f.dq)\n",
+    "meta = f.meta\n",
+    "wcs = f.meta.wcs"
    ]
   },
   {
@@ -181,11 +178,10 @@
     "if os.path.exists('full_catalog.ecsv'):\n",
     "    cat = Table.read('full_catalog.ecsv')\n",
     "else:\n",
-    "    fs = s3fs.S3FileSystem()\n",
-    "    asdf_dir_uri = 's3://roman-sci-test-data-prod-summer-beta-test/AAS_WORKSHOP/'\n",
+    "    fs = s3fs.S3FileSystem(anon=True)\n",
+    "    asdf_dir_uri = 's3://stpubdata/roman/nexus/soc_simulations/tutorial_data/'\n",
     "    asdf_file_uri = asdf_dir_uri + 'full_catalog.ecsv'\n",
-    "    with fs.open(asdf_file_uri, 'rb') as f:\n",
-    "        cat = Table.read(f, format='ascii.ecsv')"
+    "    cat = Table.read(fs.open(asdf_file_uri, 'rb'), format='ascii.ecsv')"
    ]
   },
   {
@@ -648,7 +644,7 @@
     "## About This Notebook\n",
     "\n",
     "**Author:** John F. Wu, Tyler Desjardins\\\n",
-    "**Updated On:** 2025-05-28"
+    "**Updated On:** 2025-09-30"
    ]
   },
   {

--- a/content/notebooks/data_discovery_and_access/data_discovery_and_access.ipynb
+++ b/content/notebooks/data_discovery_and_access/data_discovery_and_access.ipynb
@@ -232,11 +232,9 @@
    "source": [
     "## Streaming from the Roman Research Nexus S3 Bucket\n",
     "\n",
-    "Though Roman data will eventually be available through MAST, we currently offer a small set of simulated data available in a separate S3 bucket. These files can be streamed in exactly the same way as the HST FITS file above. Additionally, we can browse the available files similarly to a Unix terminal. A full list of commands can be found in the `s3fs` documentation [here](https://s3fs.readthedocs.io/en/latest/api.html#).\n",
+    "Though Roman data will eventually be available through MAST, we currently offer a small set of simulated data available via an AWS Open Data Program S3 bucket. These files can be streamed in exactly the same way as the HST FITS file above. Additionally, we can browse the available files similarly to a Unix terminal. A full list of commands can be found in the `s3fs` documentation [here](https://s3fs.readthedocs.io/en/latest/api.html#).\n",
     "\n",
-    "The S3 bucket containing the data is currently only open to the public on the Nexus where we have managed the permissions so none need to be specified explicitly. Because of the required permissions, many of the below cells will not work on a private computer.\n",
-    "\n",
-    "There are currently three different data sources within the Roman Research Nexus. We can view them by performing a list command (`ls`) on the main Nexus directory."
+    "We can view the files in the S3 bucket by performing a list command (`ls`) on the main Nexus directory:"
    ]
   },
   {
@@ -247,9 +245,9 @@
    },
    "outputs": [],
    "source": [
-    "fs = s3fs.S3FileSystem()\n",
+    "fs = s3fs.S3FileSystem(anon=True)\n",
     "\n",
-    "asdf_dir_uri = 's3://roman-sci-test-data-prod-summer-beta-test/'\n",
+    "asdf_dir_uri = 's3://stpubdata/roman/nexus/soc_simulations/tutorial_data/'\n",
     "fs.ls(asdf_dir_uri)"
    ]
   },
@@ -257,14 +255,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `fs.ls()` command allows us to list the contents of the URI. In the above example, the `roman-sci-test-data-prod-summer-beta-test` S3 bucket contains three directories:\n",
-    "- `AAS_WORKSHOP` contains the simulated WFI Roman Space Telescope data used in this suite of notebooks\n",
-    "- `STIPS` contains example simulated data from the Space Telescope Image Product Simulator (STIPS; Notebook link: [stips.ipynb](../stips/stips.ipynb))\n",
-    "- `OPEN_UNIVERSE` contains data from the OpenUniverse 2024 Matched Rubin and Roman Simulation preview provided by NASA/IPAC Infrared Science Archive (IRSA) at Caltech. \n",
+    "The `fs.ls()` command allows us to list the contents of the URI. In the above example, the `s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/` bucket contains numerous files for the notebook tutorials.\n",
     "\n",
-    "In the next subsection we will explore opening data files made using Roman I-Sim, which are stored in the `AAS_WORKSHOP` S3 directory. These simulations are saved in the same file formats as Roman data and are useful to help develop file ingestion pipelines. More Roman I-Sim simulated data will be made available in the future. \n",
-    "\n",
-    "In the final subsection, we will explore how to open the OpenUniverse preview data (in the `OPEN_UNIVERSE` S3 directory). The OpenUniverse collaboration has simulated extensive datasets from two core community surveys: the High Latitude Time Domain and Wide Area Surveys (HLTDS and HLWAS). Though they have only provided a preview of the full simulation suite, the data volume is still sufficient to help with the development of analysis pipelines. More OpenUniverse data will be made available in the future.\n",
+    "In the next subsection, we will explore opening data files made using the Roman image simulator \"Roman I-Sim.\" These simulations are saved in the same file formats as Roman data and are useful to help develop file ingestion pipelines. More Roman I-Sim simulated data will be made available in the future.\n",
     "\n",
     "For more information on the available data products, please visit the [Simulated Data Products](../../../markdown/simulated-data.md) documentation."
    ]
@@ -275,7 +268,7 @@
    "source": [
     "### Opening Roman I-Sim Data\n",
     "\n",
-    "Diving into the `AAS_WORKSHOP` directory, we find several different files:\n",
+    "Diving into the S3 bucket, we find several different files:\n",
     "- `*_uncal.asdf`: Level 1 (L1; ucalibrated ramp cube) files.\n",
     "- `*_cal.asdf`: Level 2 (L2; calibrated rate image) files.\n",
     "- `*_coadd.asdf`: Level 3 (L3; resampled image) files.\n",
@@ -287,11 +280,7 @@
     "\n",
     "**Note:** Archival file names for the mosaic images (L3 products) are still being finalized. The L3 file in the S3 bucket has a generic file name (`my_roman_mosaic_coadd.asdf`) that does not follow any naming convention.\n",
     "\n",
-    "Below, we use `roman_datamodels` to read the ASDF file corresponding to a dense region. To simplify the workflow, we are providing a URI to the data. Once the data will be available through MAST during operations, users will need to retrieve the URIs using astroquery or DAAPI.\n",
-    "\n",
-    "The file naming convention for Roman is quite elaborate as each includes all the relevant information about the observation. Please see the [Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products) Roman documentation page for more information on the file naming conventions.\n",
-    "\n",
-    "**Note:** In the cell below, we read in the ASDF file from the S3 bucket first using `asdf.open()` and then passing that `AsdfFile` object to the `roman_datamodels.open()` function. This is due to a recently discovered bug when reading files from S3 with `roman_datamodels`, and we expect this to be fixed soon. For now, please use `asdf.open()` when reading from S3 and then pass the object to `roman_datamodels`."
+    "Below, we use `roman_datamodels` to read the ASDF file corresponding to a dense region. To simplify the workflow, we are providing a URI to the data. Once the data will be available through MAST during operations, users will need to retrieve the URIs using astroquery."
    ]
   },
   {
@@ -300,13 +289,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "asdf_file_uri = asdf_dir_uri + 'AAS_WORKSHOP/r0003201001001001004_0001_wfi11_f106_cal.asdf'\n",
+    "asdf_file_uri = asdf_dir_uri + 'r0003201001001001004_0001_wfi11_f106_cal.asdf'\n",
     "\n",
     "with fs.open(asdf_file_uri, 'rb') as f:\n",
-    "    af = asdf.open(f)\n",
-    "    dm = rdm.open(af)\n",
-    "    \n",
-    "print(dm.info())"
+    "    dm = rdm.open(f)\n",
+    "    dm.info()"
    ]
   },
   {
@@ -342,60 +329,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For convenience, we have converted all the simulated \"calibrated\" images from FITS to ASDF files and are hosting them on the Research Nexus's S3 bucket. In addition to the original data, the ASDF files include two new features:\n",
-    "1. The WCS information from the FITS metadata has been unpacked and saved as a `gwcs.WCS` object in `asdf_file['roman']['wcs']`.\n",
-    "2. Source catalogs have been queried, and all point sources, galaxies, and transients within the detector's field of view are included as `astropy.table.Table` objects, stored directly in the ASDF files. Below, we print the galaxy catalog.\n",
-    "\n",
-    "Next we show an example of accessing the same file that was previously opened as a FITS file. You may receive a warning about the Essential Routines for Fundamental Astronomy (ERFA) and a \"dubious year.\" This is because UTC times that predate the definition of the scale or that are too far in the future may not be completely trustworthy due to leap seconds. This warning can be safely ignored."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "s3bucket = 's3://roman-sci-test-data-prod-summer-beta-test/OPEN_UNIVERSE/WAS/simple_model'\n",
-    "band = 'F184'\n",
-    "hpix = '15297'\n",
-    "sensor = 11\n",
-    "s3fpath = s3bucket+f'/{band}/{hpix}/roman_was_{band}_{hpix}_wfi{sensor:02d}_simple.asdf'\n",
-    "\n",
-    "fs = s3fs.S3FileSystem()\n",
-    "with fs.open(s3fpath, 'rb') as file_path:\n",
-    "    asdf_file = asdf.open(file_path)\n",
-    "print(asdf_file.info())"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Notice the difference in file information when printing between FITS and ASDF. ASDF provides more detailed information, organized in a hierarchical structure, compared to FITS's native format. Additionally, the `asdf_file` object can be indexed like a Python dictionary to access its contents.\n",
-    "\n",
-    "Below, we print the pre-prepared source catalog of galaxies:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(asdf_file['roman']['catalogs']['galaxies'])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now that we have loaded Roman data into a datamodel, please review the [Working with ASDF](../working_with_asdf/working_with_asdf.ipynb) notebook to explore how to use it."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "***"
    ]
   },
@@ -407,9 +340,7 @@
     "\n",
     "Downloading Roman data products is not recommended due to their large file sizes and the high volume expected from the mission's survey nature. Instead, users are encouraged to adopt workflows that utilize the file streaming services described above for an optimal experience.\n",
     "\n",
-    "However, in specific science cases, downloading files may be necessary. To do so, you can use the URIs along with the `S3FileSystem.get` function (documentation available [here](https://s3fs.readthedocs.io/en/latest/api.html#s3fs.core.S3FileSystem.get)). The code snippet below demonstrates how to download data to your personal instance of the Research Nexus.\n",
-    "\n",
-    "**NOTE**: The preliminary, simulated Roman data hosted on the Nexus are currently inaccessible outside the platform. However, MAST data can be downloaded to your private computer by using `anon=True` when initializing `S3FileSystem`."
+    "However, in specific science cases, downloading files may be necessary. To do so, you can use the URIs along with the `S3FileSystem.get` function (documentation available [here](https://s3fs.readthedocs.io/en/latest/api.html#s3fs.core.S3FileSystem.get)). The code snippet below demonstrates how to download data to your personal instance of the Research Nexus."
    ]
   },
   {
@@ -461,8 +392,8 @@
     "## About this Notebook\n",
     "The data streaming information from this notebook largely builds off of the TIKE data-acces notebook by Thomas Dutkiewicz.\n",
     "\n",
-    "**Author:** Will C. Schultz  \n",
-    "**Updated On:** 2025-01-09"
+    "**Author:** Will C. Schultz, Tyler Desjardins \\\n",
+    "**Updated On:** 2025-09-30"
    ]
   },
   {
@@ -483,9 +414,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Calibration",
    "language": "python",
-   "name": "python3"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {
@@ -497,7 +428,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.10"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/content/notebooks/data_visualization/data_visualization.ipynb
+++ b/content/notebooks/data_visualization/data_visualization.ipynb
@@ -120,13 +120,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "asdf_dir_uri = 's3://roman-sci-test-data-prod-summer-beta-test/'\n",
-    "fs = s3fs.S3FileSystem()\n",
+    "asdf_dir_uri = 's3://stpubdata/roman/nexus/soc_simulations/tutorial_data/'\n",
+    "fs = s3fs.S3FileSystem(anon=True)\n",
     "\n",
-    "asdf_file_uri = asdf_dir_uri + 'AAS_WORKSHOP/r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
-    "with fs.open(asdf_file_uri, 'rb') as f:\n",
-    "    af = asdf.open(f)\n",
-    "    file = rdm.open(af).copy()"
+    "asdf_file_uri = asdf_dir_uri + 'r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
+    "file = rdm.open(fs.open(asdf_file_uri, 'rb'))"
    ]
   },
   {
@@ -307,16 +305,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "asdf_dir_uri = 's3://roman-sci-test-data-prod-summer-beta-test/'\n",
-    "fs = s3fs.S3FileSystem()\n",
+    "asdf_dir_uri = 's3://stpubdata/roman/nexus/soc_simulations/tutorial_data/'\n",
+    "fs = s3fs.S3FileSystem(anon=True)\n",
     "\n",
-    "asdf_file_uri = asdf_dir_uri + 'AAS_WORKSHOP/r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
-    "with fs.open(asdf_file_uri, 'rb') as f:\n",
-    "    af = asdf.open(f)\n",
-    "    file = rdm.open(af)\n",
-    "    wcs1 = copy.copy(file.meta.wcs)\n",
-    "    imviz.load_data(file, data_label='WFI01_POS1')\n",
-    "    # imviz.load_data(file, ext='dq', data_label='WFI01 DQ')\n",
+    "asdf_file_uri = asdf_dir_uri + 'r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
+    "file = rdm.open(fs.open(asdf_file_uri, 'rb'))\n",
+    "wcs1 = file.meta.wcs\n",
+    "imviz.load_data(file, data_label='WFI01_POS1')\n",
+    "# imviz.load_data(file, ext='dq', data_label='WFI01 DQ')\n",
     "\n",
     "time.sleep(10)"
    ]
@@ -357,12 +353,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "asdf_file_uri = asdf_dir_uri + 'AAS_WORKSHOP/r0003201001001001004_0002_wfi01_f106_cal.asdf'\n",
-    "with fs.open(asdf_file_uri, 'rb') as f:\n",
-    "    af = asdf.open(f)\n",
-    "    file = rdm.open(af)\n",
-    "    wcs2 = copy.copy(file.meta.wcs)\n",
-    "    imviz.load_data(file, data_label='WFI01_POS2')\n",
+    "asdf_file_uri = asdf_dir_uri + 'r0003201001001001004_0002_wfi01_f106_cal.asdf'\n",
+    "f2 = fs.open(asdf_file_uri, 'rb'):\n",
+    "file2 = rdm.open(f2)\n",
+    "wcs2 = file2.meta.wcs\n",
+    "imviz.load_data(file2, data_label='WFI01_POS2')\n",
     "\n",
     "viewer = imviz.default_viewer\n",
     "viewer.stretch_options\n",
@@ -493,9 +488,8 @@
    "outputs": [],
    "source": [
     "# Read in catalog data from S3\n",
-    "cat_uri = asdf_dir_uri + 'AAS_WORKSHOP/full_catalog.ecsv'\n",
-    "with fs.open(cat_uri, 'rb') as f:\n",
-    "    tab = Table.read(f, format='ascii.ecsv')"
+    "cat_uri = asdf_dir_uri + 'full_catalog.ecsv'\n",
+    "tab = Table.read(fs.open(cat_uri, 'rb'), format='ascii.ecsv')"
    ]
   },
   {
@@ -597,7 +591,7 @@
    "source": [
     "## About this Notebook\n",
     "**Author:** Tyler Desjardins, Brett Morris  \n",
-    "**Updated On:** 2025-05-26"
+    "**Updated On:** 2025-09-30"
    ]
   },
   {

--- a/content/notebooks/grism_spectral_extraction/grism_spectral_extraction.ipynb
+++ b/content/notebooks/grism_spectral_extraction/grism_spectral_extraction.ipynb
@@ -150,29 +150,24 @@
    },
    "outputs": [],
    "source": [
-    "fs = s3fs.S3FileSystem()\n",
-    "asdf_dir_uri = 's3://roman-sci-test-data-prod-summer-beta-test/AAS_WORKSHOP/'\n",
+    "fs = s3fs.S3FileSystem(anon=True)\n",
+    "asdf_dir_uri = 's3://stpubdata/roman/nexus/soc_simulations/tutorial_data/'\n",
     "\n",
     "# Read in the direct image\n",
     "asdf_file_uri = asdf_dir_uri + 'r0007601002004013001_0001_wfi01_f158_cal.asdf'\n",
-    "with fs.open(asdf_file_uri, 'rb') as f:\n",
-    "    af = asdf.open(f)\n",
-    "    direct_asdf = rdm.open(af)\n",
-    "    direct_img = direct_asdf.data.copy()\n",
+    "direct_asdf = rdm.open(fs.open(asdf_file_uri, 'rb'))\n",
+    "direct_img = direct_asdf.data\n",
     "\n",
     "# Read in the grism image\n",
     "asdf_file_uri = asdf_dir_uri + 'r0007601002004013002_0001_wfi01_grism_cal.asdf'\n",
-    "with fs.open(asdf_file_uri, 'rb') as f:\n",
-    "    af = asdf.open(f)\n",
-    "    grism_asdf = rdm.open(af)\n",
-    "    grism_img = grism_asdf.data.copy()\n",
-    "    grism_err = grism_asdf.err.copy()\n",
+    "grism_asdf = rdm.open(fs.open(asdf_file_uri, 'rb'))\n",
+    "grism_img = grism_asdf.data\n",
+    "grism_err = grism_asdf.err\n",
     "\n",
     "# Read in the catalog\n",
     "asdf_file_uri = asdf_dir_uri + 'r0007601002004013001_0001_catalog.fits'\n",
-    "with fs.open(asdf_file_uri, 'rb') as f:\n",
-    "    hdu = fits.open(f)\n",
-    "    catalog = Table(hdu[1].data.copy())"
+    "hdu = fits.open(asdf_file_uri, fsspec_kwargs={'anon':True})\n",
+    "catalog = Table(hdu[1].data)"
    ]
   },
   {
@@ -809,25 +804,17 @@
     "## About this Notebook\n",
     "\n",
     "**Author:** Vihang Mehta\\\n",
-    "**Updated On:** 2024-12-17\n",
+    "**Updated On:** 2025-09-30\n",
     "\n",
     "---"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "68b7d798-3ab6-4dc7-9faa-0be97e8458da",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Calibration",
    "language": "python",
-   "name": "python3"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {
@@ -839,7 +826,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.11"
+   "version": "3.12.9"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
Update S3 paths to point to open data bucket.

Update data discovery and access to remove references to old S3 files not in the ODB.

Update aperture photometry and grism notebooks to not have the workaround for roman_datamodels bug (fixed) for reading from S3.