### PR TITLE
Add reference data dependencies for specific packages

### DIFF
--- a/refdata_dependencies.yaml
+++ b/refdata_dependencies.yaml
@@ -1,0 +1,36 @@
+pandeia:
+  version: 2025.9
+  data_url: 
+    - https://stsci.box.com/shared/static/0qjvuqwkurhx1xd13i63j760cosep9wh.gz"
+  environment_variable: pandeia_refdata
+  install_path: ${HOME}/refdata/
+  data_path: pandeia_data-2025.9-roman
+stpsf:
+  version: 2.1.0
+  data_url:
+    - https://stsci.box.com/shared/static/kqfolg2bfzqc4mjkgmujo06d3iaymahv.gz
+  environment_variable: STPSF_PATH
+  install_path: ${HOME}/refdata/
+  data_path: stpsf-data
+stips:
+  version: 2.3.0
+  data_url:
+    - https://stsci.box.com/shared/static/761vz7zav7pux03fg0hhqq7z2uw8nmqw.tgz
+  environment_variable: stips_data
+  install_path: ${HOME}/refdata/
+  data_path: stips_data
+synphot:
+  version: 1.6.0
+  data_url:
+    - https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_everything_multi_v18_sed.tar
+    - https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_star-galaxy-models_multi_v3_synphot2.tar
+    - https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_castelli-kurucz-2004-atlas_multi_v2_synphot3.tar
+    - https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_kurucz-1993-atlas_multi_v2_synphot4.tar
+    - https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_pheonix-models_multi_v3_synphot5.tar
+    - https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_calibration-spectra_multi_v13_synphot6.tar
+    - https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_jwst_multi_etc-models_multi_v1_synphot7.tar
+    - https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_modewave_multi_v1_synphot8.tar
+    - https://archive.stsci.edu/hlsps/reference-atlases/hlsp_reference-atlases_hst_multi_other-spectra_multi_v2_sed.tar
+  environment_variable: PYSYN_CDBS
+  install_path: ${HOME}/refdata/
+  data_path: grp/redcat/trds/


### PR DESCRIPTION
This PR adds a YAML file that defines reference data dependencies for the following packages:
- pandeia
- STIPS
- STPSF
- synphot

A python file is being prepared alongside notebooks that use these packages that will check the YAML file, pull in the dependency information, check that the environment variables are set up and if not it will download the reference data. Uploading the YAML file to GitHub is necessary first to get the URL of the file to act as a central source for all notebooks. This avoids the need to update a YAML file for each notebook.