### PR TITLE
Updates to add separate dir for PSFs

### DIFF
--- a/markdown/local-run.md
+++ b/markdown/local-run.md
@@ -69,8 +69,8 @@ this cell should be run before the first code cell in the notebook. This is in p
 
 The other variables you might need to set are:
 
-- `pandeia_refdata` when using `pandeia`
--  `PYSYN_CDBS` when using `synphot`
+- `pandeia_refdata` and `PSF_DIR` when using `pandeia`
+- `PYSYN_CDBS` when using `synphot`
 - `stips_data` when using `stips`
 
 ### To force re-download:

--- a/refdata_dependencies.yaml
+++ b/refdata_dependencies.yaml
@@ -10,13 +10,20 @@
 # For Nexus setup, the install_path value can be overridden to point
 # to a shared data path (instead of $HOME).
 install_files:
-  pandeia:
-    version: 2025.9
+  pandeia_data:
+    version: 2026.1
     data_url: 
       - https://stsci.box.com/shared/static/0qjvuqwkurhx1xd13i63j760cosep9wh.gz
     environment_variable: pandeia_refdata
     install_path: ${HOME}/refdata/
-    data_path: pandeia_data-2025.9-roman
+    data_path: pandeia_data-2026.1-roman
+  pandeia_psf:
+    version: 2026.1
+    data_url: 
+      - https://stsci.box.com/shared/static/5qkyvr5steg2fo2zxbqj2jxcmbmz1c4w.gz
+    environment_variable: PSF_DIR
+    install_path: ${HOME}/refdata/
+    data_path: pandeia_psf-2026.1-roman
   stpsf:
     version: 2.1.0
     data_url:


### PR DESCRIPTION
Pandeia release 2026.1 separated the PDFs from main reference data. This requires to update the yaml file to add this new directory and update  theP andeia version. 

This also updates Markdown file local-run.md to include this change.