### PR TITLE
Update Copyright year to 2026

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@
 # Book settings
 title                       : STScI Roman Notebooks  # The title of the book. Will be placed in the left navbar.
 author                      : STScI  # The author of the book
-copyright                   : "2024"  # Copyright year to be placed in the footer
+copyright                   : "2026"  # Copyright year to be placed in the footer
 logo                        : stsci_logo2.png  # A path to the book logo
 
 # Force re-execution of notebooks on each build.


### PR DESCRIPTION
The Copyright date in the GitHub Readme footer was incorrect. Fixing it with this change.