### PR TITLE
Added notebook_data_dependencies.py symlinks

### DIFF
--- a/notebooks/aperture_photometry/notebook_data_dependencies.py
+++ b/notebooks/aperture_photometry/notebook_data_dependencies.py
@@ -1,0 +1,1 @@
+../../shared/notebook_data_dependencies.py

--- a/notebooks/pandeia/notebook_data_dependencies.py
+++ b/notebooks/pandeia/notebook_data_dependencies.py
@@ -1,0 +1,1 @@
+../../shared/notebook_data_dependencies.py


### PR DESCRIPTION
- Added notebook_data_dependencies.py symlinks to shared file for aperture_photometry and pandeia.

- Putting symlinks in relevant notebook directories is arguably better than changing PYTHONPATH since they tie the shared files directly and visibly to specific notebooks.  It also completes the "simple definition" of the environment as all of the existing mamba/pip packages plus the default of any modules/packages (symlinks) in the notebook's directory...  vs. any packages found on PYTHONPATH provided it is set.