### PR TITLE
Catalog database access notebook

### DIFF
--- a/notebooks/catalog_database_access/catalog_database_access.ipynb
+++ b/notebooks/catalog_database_access/catalog_database_access.ipynb
@@ -34,16 +34,48 @@
     "\n",
     "To run this notebook, please select the \"Roman Research Nexus\" kernel at the top right of your window.\n",
     "\n",
-    "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it.\n",
+    "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "This notebook demonstrates how to access and query Roman catalogs held at the [Mikulski Archive for Space Telescopes (MAST)](https://archive.stsci.edu/), through (1) [astroquery](https://astroquery.readthedocs.io/en/latest/index.html) as well as (2) advanced query patterns using [Astronomical Data Query Language (ADQL)](http://www.ivoa.net/documents/latest/ADQL.html) queries via a [Table Access Protocol (TAP)](http://www.ivoa.net/documents/TAP/) service at MAST.\n",
     "\n",
+    "MAST will provide access to a range of Roman catalog products \n",
+    "(such as [multiband photometric source catalogs](https://roman-docs.stsci.edu/data-handbook/wfi-data-levels-and-products#WFIDataLevelsandProducts-Level4) as detected from WFI imaging; \n",
+    "[spectral catalogs](https://roman-docs.ipac.caltech.edu/data-handbook/roman-wfi-data-pipelines/roman-wide-field-spectroscopy-pipelines/science-data-pipelines) derived from WFI grism and prism spectroscopy; \n",
+    "[microlensing event variability and light curve catalogs](https://roman-docs.ipac.caltech.edu/data-handbook/roman-wfi-data-pipelines/galactic-bulge-survey-pipelines#GalacticBulgeSurveyPipelines-SummaryofDataProducts); \n",
+    "and [Project Infrastructure team created catalogs](https://assets.science.nasa.gov/content/dam/science/missions/rst/science/Roman_PIT_Data_Products_User_Documentation_18feb2026.pdf)). \n",
+    "This notebook demonstrates methods of querying these catalogs from MAST databases, enabling efficient filtering and sample selection across both spatial location and miriad other properties.\n",
+    "\n",
+    "### Defining terms\n",
+    "- *SQL*: Structured Query Language, a programming language used for relational databases.\n",
+    "- [*ADQL*](http://www.ivoa.net/documents/latest/ADQL.html): Astronomical Data Query Language, a SQL-like programming language that includes functionality for spatial searches.\n",
+    "- [*TAP*](http://www.ivoa.net/documents/TAP/): Table Access Protocol, an International Virtual Observatory standard for providing programmatic access to catalogs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "******"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Imports\n",
     "Here we import the required packages for our catalog database access examples including:\n",
-    "- *astroquery.mast Catalogs* for accessing and querying Roman catalogs\n",
-    "- *pyvo* for accessing and querying catalogs via MAST's TAP service (Table Access Protocol)\n",
-    "- *astropy.coordinates SkyCoord* for defining sky coordinates\n",
-    "- *astropy.units* to specify angular units\n",
-    "- *matplotlib.pyplot* for simple data visualization\n",
-    "- *numpy* for array comparisons"
+    "- [*astroquery.mast Catalogs*](https://astroquery.readthedocs.io/en/latest/mast/mast_catalog.html) for accessing and querying Roman catalogs\n",
+    "- [*pyvo*](https://pyvo.readthedocs.io/) for accessing and querying catalogs via MAST's TAP service (Table Access Protocol)\n",
+    "- [*astropy.coordinates SkyCoord*](https://docs.astropy.org/en/stable/coordinates/skycoord.html) for defining sky coordinates\n",
+    "- [*astropy.units*](https://docs.astropy.org/en/stable/units/index.html) to specify angular units\n",
+    "- [*matplotlib.pyplot*](https://matplotlib.org/stable/api/pyplot_summary.html) for simple data visualization\n",
+    "- [*numpy*](https://numpy.org/doc/stable/) for array comparisons"
    ]
   },
   {
@@ -59,33 +91,7 @@
     "import astropy.units as u\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "# # suppress unimportant unit warnings from many TAP services\n",
-    "# import warnings\n",
-    "# warnings.filterwarnings(\"ignore\", module=\"pyvo.io.vosi.vodataservice\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "******"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Introduction\n",
-    "This notebook demonstrates how to access and query Roman catalogs held at MAST, through (1) astroquery as well as (2) advanced query patterns using Astronomical Data Query Language (ADQL) queries via a Table Access Protocol (TAP) service at MAST.\n",
-    "\n",
-    "MAST will provide access to a range of Roman catalog products (such as multiband photometric source catalogs as detected from WFI imaging; spectral metadata catalogs derived from WFI grism and prism spectroscopy; and microlensing event variability and light curve catalogs). This notebook demonstrates methods of querying these catalogs from MAST databases, enabling efficient filtering and sample selection across both spatial location and miriad other properties.\n",
-    "\n",
-    "### Defining terms\n",
-    "- *SQL*: Structured Query Language, a programming language used for relational databases.\n",
-    "- *ADQL*: Astronomical Data Query Language, a SQL-like programming language that includes functionality for spatial searches.\n",
-    "- *TAP*: Table Access Protocol, an International Virtual Observatory standard for providing programmatic access to catalogs."
+    "import numpy as np"
    ]
   },
   {
@@ -109,7 +115,7 @@
    "source": [
     "### Obtaining information about Roman Catalogs\n",
     "\n",
-    "Roman catalogs are Level 4 (L4) extracted products, and are produced by multiple Roman data pipelines. For full details about the data processing and detailed contents of Roman catalogs, please see [RDox](https://roman-docs.stsci.edu/data-handbook/wfi-data-levels-and-products#WFIDataLevelsandProducts-Level4-ExtractedDataLevel4).\n",
+    "Roman catalogs are [Level 4 (L4) extracted products](https://roman-docs.stsci.edu/data-handbook/wfi-data-levels-and-products#WFIDataLevelsandProducts-Level4-ExtractedDataLevel4), and are produced by multiple Roman data pipelines. For full details about the data processing and detailed contents of Roman catalogs, please see [RDox](https://roman-docs.stsci.edu/data-handbook/roman-wfi-data-pipelines).\n",
     "\n",
     "In the future, user-contributed catalogs (L5) are anticipated to be made available through similar methods; these will be documented separately."
    ]
@@ -121,18 +127,30 @@
     "### Querying Roman Catalogs using `astroquery`\n",
     "To begin, we will query Roman catalogs using `astroquery`. \n",
     "\n",
-    "For demonstration purposes (as Roman catalogs are not yet available), our example will query the PanSTARRS DR2 catalog near NGC 6535. In addition to a cone search, we will also filter to select only bright, blue stars. \n",
+    "For demonstration purposes (as Roman catalogs are not yet available), our example will query the PanSTARRS DR2 catalog near NGC 6535. \n",
+    "This PanSTARRS example provides an overview of the access methods that will be available for Roman catalogs (`astroquery`, and `ADQL/TAP` below). In particular, both PanSTARRS and Roman (will) have large numbers of rows, which requires database queries for access; it is infeasible to load the full tables into memory for analysis. \n",
+    "\n",
+    "In addition to a cone search, we will also filter to select only bright, blue stars. \n",
     "The specific selection criteria we will apply are:\n",
     "* Located within 1.5 arcminutes of the NGC 6535\n",
     "* Are point sources (not extended objects)\n",
-    "* Detected flux in the `g`, `i`, `y` bands (quality cuts)\n",
-    "* Have `i` band magnitudes brighter than 18\n",
-    "* Have `g-y` colors less than 0.8  (the bluest, reddest filters for PanSTARRS)\n",
+    "* Detected flux in the $g$, $i$, $y$ bands (quality cuts)\n",
+    "* Have $i$ band magnitudes brighter than 18\n",
+    "* Have $g-y$ colors less than 0.8  (the bluest, reddest filters for PanSTARRS)\n",
     "\n",
-    "From the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs), \n",
-    "we see the `MeanObject` table contains the relevant photometric information (note: `astroquery` provides the join of `MeanObject` and `ObjectThin` tables, to provide position information).\n",
+    "Though the specifics of the PanSTARRS and forthcoming Roman catalogs differ (in terms of filters, specific columns stemming from different processing pipelines, etc.), similar queries combining spatial, point vs. resolved source, and multiband color/magnitude criteria will be possible with Roman WFI multiband catalogs.\n",
     "\n",
-    "With `astroquery`, we can directly filter for some of these constraints, but will need to post-process the returned results to apply other constraints."
+    "Based on the `astroquery.mast` PanSTARRS [catalog information](https://catalogs.mast.stsci.edu/docs/panstarrs.html) and the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs), \n",
+    "we will use the `MeanObject` catalog provided by `astroquery.mast`. This table provides relevant photometric information in the columns `gMeanPSFMag`, `iMeanPSFMag`, `yMeanPSFMag` (magnitudes optimized for point sources), and `iMeanKronMag` (used to distinguish between point and resolved sources), as well as position information (`raMean`, `decMean`).\n",
+    "\n",
+    "Also, with `astroquery`, we can directly filter for some of these constraints. However, we will need to post-process the returned results to apply other constraints."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We first obtain the sky coordinates for NGC 6535."
    ]
   },
   {
@@ -144,6 +162,21 @@
     "# Resolve the position of NGC 6535\n",
     "c0 = SkyCoord.from_name(\"NGC 6535\")\n",
     "c0"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We then extract photometric and position data (by selecting specific columns to return) for all objects \n",
+    "in the `MeanObject` catalog that are within a 1.5 arcminute radius around NGC 6535. \n",
+    "We also include constraints to limit the results to only objects with measured magnitudes for `gMeanPSFMag`, `iMeanPSFMag`, `yMeanPSFMag`, `iMeanKronMag`.\n",
+    "\n",
+    "Next we apply post-processing constraints to refine our sample.\n",
+    "\n",
+    "As we are interested only in stars, we compare the Kron and PSF magnitudes in the $i$ band. Stars (point sources) typically have `iMeanPSFMAG-iMeanKronMag <= 0.05` (as shown in the [PanSTARRS documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812369/How+to+separate+stars+and+galaxies#Howtoseparatestarsandgalaxies-PSF-Kron)).\n",
+    "\n",
+    "Lastly, we apply the color and magnitude cuts, and then display the table with our final sample."
    ]
   },
   {
@@ -192,8 +225,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will quickly visualize our results by plotting a \n",
-    "$g-y$ vs $i$ color-magnitude diagram."
+    "We visualize our results by plotting a $g-y$ vs $i$ color-magnitude diagram. \n",
+    "\n",
+    "The selected bright, blue stars are shown as large red points, while all stars within 1.5 arcminutes of NGC 6535 are shown in gray for comparison."
    ]
   },
   {
@@ -234,32 +268,11 @@
    "metadata": {},
    "source": [
     "### Querying Roman Catalogs using MAST's TAP service using `pyvo`\n",
-    "It is also possible to access Roman catalogs via a TAP service at MAST, by submitting queries written in ADQL. A benefit of constructing queries in the SQL-like language ADQL is that we can specify advanced query patters, such as comparison constraints and derived constraints (i.e., as needed to apply the star/resolved and color criteria in this example), directly in the query. This makes it possible get the sample of interest in one query, avoiding a two step process where we load a larger sample into memory and then perform final cuts in our notebook.\n",
+    "It is also possible to access Roman catalogs via a TAP service at MAST, by submitting queries written in [ADQL](http://www.ivoa.net/documents/latest/ADQL.html). A benefit of constructing queries in the SQL-like language ADQL is that we can specify advanced query patters, such as comparison constraints and derived constraints (i.e., as needed to apply the star/resolved and color criteria in this example), directly in the query. This makes it possible get the sample of interest in one query, avoiding a two step process where we load a larger sample into memory and then perform final cuts in our notebook.\n",
     "\n",
     "For this second demonstration, we will apply the same selection criteria as above to select bright, blue stars near NGC 6535 from the PanSTARRS DR2 catalog.\n",
     "\n",
-    "First, we connect to the MAST PanSTARRS DR2 TAP service.\n",
-    "<!-- \n",
-    "We will now repeat the same \n",
-    "\n",
-    "\n",
-    "\n",
-    "directly get results on our objects of interest, and \n",
-    "\n",
-    "To begin, we will query Roman catalogs using `astroquery`. \n",
-    "\n",
-    "For demonstration purposes (as Roman catalogs are not yet available), our example will query the PanSTARRS DR2 catalog near NGC 6535. In addition to a cone search, we will also filter to select only bright, blue stars. \n",
-    "The specific selection criteria we will apply are:\n",
-    "* Located within 1.5 arcminutes of the NGC 6535\n",
-    "* Are point sources (not extended objects)\n",
-    "* Detected flux in the `g`, `i`, `y` bands (quality cuts)\n",
-    "* Have `i` band magnitudes brighter than 18\n",
-    "* Have `g-y` colors less than 0.8  (the bluest, reddest filters for PanSTARRS)\n",
-    "\n",
-    "From the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs), \n",
-    "we see the `MeanObject` table contains the relevant photometric information (note: `astroquery` provides the join of `MeanObject` and `ObjectThin` tables, to provide position information).\n",
-    "\n",
-    "With `astroquery`, we can directly filter for some of these constraints, but will need to post-process the returned results for some others. -->"
+    "First, we connect to the MAST PanSTARRS DR2 TAP service.\n"
    ]
   },
   {
@@ -282,33 +295,35 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "# # Note: it is possible to use the TAP service to directly access catalog/table \n",
-    "# # schemas, which describe the tables and columns. \n",
-    "# # An example of this is provided here, commented out as we have pre-identified \n",
-    "# # the relevent columns from the documentation\n",
+    "Note that it is possible to use the TAP service to directly access catalog/table \n",
+    "schemas, which describe the tables and columns. \n",
+    "An example of this is provided here, commented out as we have pre-identified \n",
+    "the relevent columns from the documentation\n",
     "\n",
-    "# # An overview description of methods, capabilities, and \n",
-    "# # maximum result set sizes is available via:\n",
-    "# TAP_service.describe()\n",
+    "An overview description of methods, capabilities, and \n",
+    "maximum result set sizes is available via:\n",
+    "```python\n",
+    "TAP_service.describe()\n",
+    "```\n",
     "\n",
-    "# # Additionally, the `pyvo` TAPService class objects contain \n",
-    "# # metadata information about the full catalog schema, including tables and columns.\n",
-    "# # It's possible to iterate through the tables and print column names \n",
-    "# # as in this code snipppet:\n",
-    "# TAP_tables = TAP_service.tables\n",
-    "# for tablename in TAP_tables.keys():\n",
-    "#     # This can be refined by table name to print columns only for subsets of tables.\n",
-    "#     if (tablename.startswith(\"ps1_dr2.mean_object\")):  # Include only PS1 tables \n",
-    "#         ####\n",
-    "#         # The table descriptions only include an overview, so this also prints the column names\n",
-    "#         TAP_tables[tablename].describe() \n",
-    "#         print(\"Columns={}\".format(sorted([k.name for k in TAP_tables[tablename].columns])))\n",
-    "#         print(\"----\")"
+    "Additionally, the `pyvo` TAPService class objects contain \n",
+    "metadata information about the full catalog schema, including tables and columns.\n",
+    "It's possible to iterate through the tables and print column names \n",
+    "as in this code snippet (here, only printing columns for the `mean_object` table).\n",
+    "```python\n",
+    "TAP_tables = TAP_service.tables\n",
+    "for tablename in TAP_tables.keys():\n",
+    "    # This can be refined by table name to print columns only for subsets of tables.\n",
+    "    if (tablename.startswith(\"ps1_dr2.mean_object\")):  # Include only PS1 tables \n",
+    "        ####\n",
+    "        # The table descriptions only include an overview, so this also prints the column names\n",
+    "        TAP_tables[tablename].describe() \n",
+    "        print(\"Columns={}\".format(sorted([k.name for k in TAP_tables[tablename].columns])))\n",
+    "        print(\"----\")\n",
+    "```"
    ]
   },
   {
@@ -316,50 +331,19 @@
    "metadata": {},
    "source": [
     "We now construct our query, including the color/magnitude constraints and \n",
-    "star/extended object separation. Note that for ADQL, the cone search radius must be expressed in degrees.\n",
-    "\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Query MAST for matching observations in \n",
-    "# the PanSTARRS DR2 Mean catalog\n",
-    "catalog_data = Catalogs.query_criteria(\n",
-    "    catalog=\"Panstarrs\",\n",
-    "    data_release=\"dr2\",\n",
-    "    table=\"mean\",\n",
-    "    coordinates=c0,\n",
-    "    radius = 1.5*u.arcmin,\n",
-    "    columns=[\"objID\", \"raMean\",\"decMean\",\n",
-    "             \"gMeanPSFMag\",\"iMeanPSFMag\",\"yMeanPSFMag\",\n",
-    "             \"iMeanKronMag\"],    # List of columns to return\n",
-    "    gMeanPSFMag=[(\"gt\",-999)],   # mag > -999; missing magnitudes are -999\n",
-    "    iMeanPSFMag=[(\"gt\",-999)],   # mag > -999; missing magnitudes are -999\n",
-    "    yMeanPSFMag=[(\"gt\",-999)],   # mag > -999; missing magnitudes are -999\n",
-    "    iMeanKronMag=[(\"gt\",-999)],  # mag > -999; missing magnitudes are -999\n",
-    ")\n",
+    "star/extended object separation. As an overview, our query is constructed as follows.\n",
     "\n",
-    "# Post-process cuts:\n",
-    "# 1. Distinguish stars from extended objects using\n",
-    "#    difference of PSF, Kron magnitudes\n",
-    "catalog_data = catalog_data[\n",
-    "    (catalog_data['iMeanPSFMag'] - catalog_data['iMeanKronMag']) <= 0.05\n",
-    "]\n",
+    "We specify the table, `mean_object`, with the \"FROM\" statement.\n",
+    "The subset of columns to be returned (`objid`, `ramean`, `decmean`, `gmeanpsfmag`, `imeanpsfmag`, `ymeanpsfmag`, `imeankronmag`) are specified with the \"SELECT\" statement.\n",
+    "We then specify the query constraints in the \"WHERE\" statement, with multiple constraints linked using \"AND\". \n",
+    "This includes:\n",
+    "* the cone search (as in the \"CONTAINS(...)\" clause; note that for ADQL, the radius must be expressed in degrees), \n",
+    "* requiring the $g$, $i$, $y$ mean PSF magnitudes and $i$ mean Kron magnitude to be present (cutting objects that have any of these values missing),\n",
+    "* the PanSTARRS-specific cut to select stars (`imeanpsfmag - imeankronmag <= 0.05`), and \n",
+    "* the $g-y$ color and $i$ magnitude cuts.\n",
     "\n",
-    "# 2. Apply color, magnitude cuts\n",
-    "# Copy original catalog for reference:\n",
-    "catalog_data_all = catalog_data.copy()\n",
-    "catalog_data = catalog_data[\n",
-    "    ((catalog_data['gMeanPSFMag'] - catalog_data['yMeanPSFMag']) < 0.8) \n",
-    "    & (catalog_data['iMeanPSFMag'] < 18)\n",
-    "]\n",
     "\n",
-    "# Final sample selection\n",
-    "catalog_data"
+    "We then submit this query to the TAP service, and retrieve and display the table with the query results."
    ]
   },
   {
@@ -394,7 +378,10 @@
     "job = TAP_service.run_async(adql_query)\n",
     "\n",
     "# Retrieve results:\n",
-    "results_tap = job.to_table()"
+    "results_tap = job.to_table()\n",
+    "\n",
+    "# Final sample selection\n",
+    "results_tap"
    ]
   },
   {
@@ -403,7 +390,10 @@
    "source": [
     "By leveraging the advanced usage patterns possible with AQDL, this single TAP query returns the same results as our two-step `astroquery` example where we first queried and then applied the final cuts.\n",
     "\n",
-    "(For this simple example, applying such cuts in memory are not prohibitive, but for cases where the selected sample may be large, performing all cuts server-side can be much more performant.)"
+    "(For this simple example, applying such cuts in memory are not prohibitive, but for cases where the selected sample may be large, performing all cuts server-side can be much more performant.)\n",
+    "\n",
+    "\n",
+    "We confirm that both methods yield the same set of objects by sorting the two result tables by object ID, and checking that all object IDs are the same."
    ]
   },
   {
@@ -480,7 +470,7 @@
     "The information about TAP access is based on the TIKE MAST PanSTARRS DR2 TAP notebook by Rick White & Theresa Dower, with edits from T. Dutkiewicz. \n",
     "\n",
     "**Author:**  Sedona Price\\\n",
-    "**Updated On:** 2026-03-20"
+    "**Updated On:** 2026-04-08"
    ]
   },
   {
@@ -519,7 +509,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.3"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/catalog_database_access/catalog_database_access.ipynb
+++ b/notebooks/catalog_database_access/catalog_database_access.ipynb
@@ -268,7 +268,7 @@
    "metadata": {},
    "source": [
     "### Querying Roman Catalogs using MAST's TAP service using `pyvo`\n",
-    "It is also possible to access Roman catalogs via a TAP service at MAST, by submitting queries written in [ADQL](http://www.ivoa.net/documents/latest/ADQL.html). A benefit of constructing queries in the SQL-like language ADQL is that we can specify advanced query patters, such as comparison constraints and derived constraints (i.e., as needed to apply the star/resolved and color criteria in this example), directly in the query. This makes it possible get the sample of interest in one query, avoiding a two step process where we load a larger sample into memory and then perform final cuts in our notebook.\n",
+    "It is also possible to access Roman catalogs via a TAP service at MAST, by submitting queries written in [ADQL](http://www.ivoa.net/documents/latest/ADQL.html). A benefit of constructing queries in the SQL-like language ADQL is that we can specify advanced query patterns, such as comparison constraints and derived constraints (i.e., as needed to apply the star/resolved and color criteria in this example), directly in the query. This makes it possible get the sample of interest in one query, avoiding a two step process where we load a larger sample into memory and then perform final cuts in our notebook.\n",
     "\n",
     "For this second demonstration, we will apply the same selection criteria as above to select bright, blue stars near NGC 6535 from the PanSTARRS DR2 catalog.\n",
     "\n",
@@ -478,15 +478,16 @@
    "metadata": {},
    "source": [
     "<table width=\"100%\" style=\"border:none; border-collapse:collapse;\">\n",
+    "\n",
     "  <tr style=\"border:none;\">\n",
     "    <td style=\"border:none; width:180px; white-space:nowrap;\">\n",
-    "       <a href=\"#top\" style=\"text-decoration:none; color:#0066cc;\">↑ Top of page</a> \n",
+    "       <a href=\"#top\" style=\"text-decoration:none; color:#0066cc;\"> Top of page</a>\n",
     "    </td>\n",
     "    <td style=\"border:none; text-align:center;\">\n",
-    "       <img src=\"../../roman_logo.png\" width=\"50\">\n",
+    "        <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/roman_logo.png\" alt=\"roman_logo\" width=\"50px\">\n",
     "    </td>\n",
     "    <td style=\"border:none; text-align:right;\">\n",
-    "       <img src=\"../../stsci_logo2.png\" width=\"90\">\n",
+    "       <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/stsci_logo2.png\" width=\"90\">\n",
     "    </td>\n",
     "  </tr>\n",
     "</table>"
@@ -495,9 +496,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Research Nexus",
    "language": "python",
-   "name": "python3"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {
@@ -509,7 +510,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/catalog_database_access/catalog_database_access.ipynb
+++ b/notebooks/catalog_database_access/catalog_database_access.ipynb
@@ -1,0 +1,536 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "# Roman Research Nexus Catalog Database access"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "******"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Kernel Information and Read-Only Status\n",
+    "\n",
+    "To run this notebook, please select the \"Roman Research Nexus\" kernel at the top right of your window.\n",
+    "\n",
+    "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it.\n",
+    "\n",
+    "## Imports\n",
+    "Here we import the required packages for our catalog database access examples including:\n",
+    "- *astroquery.mast Catalogs* for accessing and querying Roman catalogs\n",
+    "- *pyvo* for accessing and querying catalogs via MAST's TAP service (Table Access Protocol)\n",
+    "- *astropy.coordinates SkyCoord* for defining sky coordinates\n",
+    "- *astropy.units* to specify angular units\n",
+    "- *matplotlib.pyplot* for simple data visualization\n",
+    "- *numpy* for array comparisons"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from astroquery.mast import Catalogs\n",
+    "import pyvo as vo\n",
+    "\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "import astropy.units as u\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "# # suppress unimportant unit warnings from many TAP services\n",
+    "# import warnings\n",
+    "# warnings.filterwarnings(\"ignore\", module=\"pyvo.io.vosi.vodataservice\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "******"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "This notebook demonstrates how to access and query Roman catalogs held at MAST, through (1) astroquery as well as (2) advanced query patterns using Astronomical Data Query Language (ADQL) queries via a Table Access Protocol (TAP) service at MAST.\n",
+    "\n",
+    "MAST will provide access to a range of Roman catalog products (such as multiband photometric source catalogs as detected from WFI imaging; spectral metadata catalogs derived from WFI grism and prism spectroscopy; and microlensing event variability and light curve catalogs). This notebook demonstrates methods of querying these catalogs from MAST databases, enabling efficient filtering and sample selection across both spatial location and miriad other properties.\n",
+    "\n",
+    "### Defining terms\n",
+    "- *SQL*: Structured Query Language, a programming language used for relational databases.\n",
+    "- *ADQL*: Astronomical Data Query Language, a SQL-like programming language that includes functionality for spatial searches.\n",
+    "- *TAP*: Table Access Protocol, an International Virtual Observatory standard for providing programmatic access to catalogs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "******"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Accessing Roman Catalogs\n",
+    "In this section, we will demonstrate how to obtain information about the catalog schemas (covering descriptions of tables, as well as column units, datatypes, and descriptions), and then methods of connecting to and querying Roman catalogs."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Obtaining information about Roman Catalogs\n",
+    "\n",
+    "Roman catalogs are Level 4 (L4) extracted products, and are produced by multiple Roman data pipelines. For full details about the data processing and detailed contents of Roman catalogs, please see [RDox](https://roman-docs.stsci.edu/data-handbook/wfi-data-levels-and-products#WFIDataLevelsandProducts-Level4-ExtractedDataLevel4).\n",
+    "\n",
+    "In the future, user-contributed catalogs (L5) are anticipated to be made available through similar methods; these will be documented separately."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-warning\" style=\"color:black; background-color:#ffc5c5; border-color:red;\">\n",
+    "    <b style=\"color:red\">Future:</b> Add pointers to integrated schema browser (and also the direct URL access) when available.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Querying Roman Catalogs using `astroquery`\n",
+    "To begin, we will query Roman catalogs using `astroquery`. \n",
+    "\n",
+    "For demonstration purposes (as Roman catalogs are not yet available), our example will query the PanSTARRS DR2 catalog near NGC 6535. In addition to a cone search, we will also filter to select only bright, blue stars. \n",
+    "The specific selection criteria we will apply are:\n",
+    "* Located within 1.5 arcminutes of the NGC 6535\n",
+    "* Are point sources (not extended objects)\n",
+    "* Detected flux in the `g`, `i`, `y` bands (quality cuts)\n",
+    "* Have `i` band magnitudes brighter than 18\n",
+    "* Have `g-y` colors less than 0.8  (the bluest, reddest filters for PanSTARRS)\n",
+    "\n",
+    "From the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs), \n",
+    "we see the `MeanObject` table contains the relevant photometric information (note: `astroquery` provides the join of `MeanObject` and `ObjectThin` tables, to provide position information).\n",
+    "\n",
+    "With `astroquery`, we can directly filter for some of these constraints, but will need to post-process the returned results to apply other constraints."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Resolve the position of NGC 6535\n",
+    "c0 = SkyCoord.from_name(\"NGC 6535\")\n",
+    "c0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query MAST for matching observations in \n",
+    "# the PanSTARRS DR2 Mean catalog\n",
+    "results_aq = Catalogs.query_criteria(\n",
+    "    catalog=\"Panstarrs\",\n",
+    "    data_release=\"dr2\",\n",
+    "    table=\"mean\",\n",
+    "    coordinates=c0,\n",
+    "    radius = 1.5*u.arcmin,\n",
+    "    columns=[\"objID\", \"raMean\",\"decMean\",\n",
+    "             \"gMeanPSFMag\",\"iMeanPSFMag\",\"yMeanPSFMag\",\n",
+    "             \"iMeanKronMag\"],    # List of columns to return\n",
+    "    gMeanPSFMag=[(\"gt\",-999)],   # mag > -999; missing magnitudes are -999\n",
+    "    iMeanPSFMag=[(\"gt\",-999)],   # mag > -999; missing magnitudes are -999\n",
+    "    yMeanPSFMag=[(\"gt\",-999)],   # mag > -999; missing magnitudes are -999\n",
+    "    iMeanKronMag=[(\"gt\",-999)],  # mag > -999; missing magnitudes are -999\n",
+    ")\n",
+    "\n",
+    "# Post-process cuts:\n",
+    "# 1. Distinguish stars from extended objects using\n",
+    "#    difference of PSF, Kron magnitudes\n",
+    "results_aq = results_aq[\n",
+    "    (results_aq['iMeanPSFMag'] - results_aq['iMeanKronMag']) <= 0.05\n",
+    "]\n",
+    "\n",
+    "# 2. Apply color, magnitude cuts\n",
+    "# Copy original catalog for reference:\n",
+    "results_aq_all = results_aq.copy()\n",
+    "results_aq = results_aq[\n",
+    "    ((results_aq['gMeanPSFMag'] - results_aq['yMeanPSFMag']) < 0.8) \n",
+    "    & (results_aq['iMeanPSFMag'] < 18)\n",
+    "]\n",
+    "\n",
+    "# Final sample selection\n",
+    "results_aq"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will quickly visualize our results by plotting a \n",
+    "$g-y$ vs $i$ color-magnitude diagram."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "f, ax = plt.subplots()\n",
+    "f.set_size_inches((5,5))\n",
+    "\n",
+    "# Stars meeting the color/magnitude cuts\n",
+    "ax.scatter(\n",
+    "    results_aq['gMeanPSFMag']-results_aq['yMeanPSFMag'],\n",
+    "    results_aq['iMeanPSFMag'], \n",
+    "    s=15,lw=0, color='red',\n",
+    "    label='Bright blue stars',\n",
+    ")\n",
+    "\n",
+    "# Plot the full set of stars for comparison\n",
+    "ax.scatter(\n",
+    "    results_aq_all['gMeanPSFMag']-results_aq_all['yMeanPSFMag'],\n",
+    "    results_aq_all['iMeanPSFMag'], \n",
+    "    s=5,lw=0,zorder=-1, color='gray',\n",
+    "    label='All stars in region',\n",
+    ")\n",
+    "\n",
+    "ax.legend()\n",
+    "\n",
+    "ax.set_xlabel(\"g-y, PSF Mag\")\n",
+    "ax.set_ylabel(\"i, PSF Mag\")\n",
+    "\n",
+    "ax.set_ylim(ax.get_ylim()[::-1])    # Invert for correct magnitude order"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Querying Roman Catalogs using MAST's TAP service using `pyvo`\n",
+    "It is also possible to access Roman catalogs via a TAP service at MAST, by submitting queries written in ADQL. A benefit of constructing queries in the SQL-like language ADQL is that we can specify advanced query patters, such as comparison constraints and derived constraints (i.e., as needed to apply the star/resolved and color criteria in this example), directly in the query. This makes it possible get the sample of interest in one query, avoiding a two step process where we load a larger sample into memory and then perform final cuts in our notebook.\n",
+    "\n",
+    "For this second demonstration, we will apply the same selection criteria as above to select bright, blue stars near NGC 6535 from the PanSTARRS DR2 catalog.\n",
+    "\n",
+    "First, we connect to the MAST PanSTARRS DR2 TAP service.\n",
+    "<!-- \n",
+    "We will now repeat the same \n",
+    "\n",
+    "\n",
+    "\n",
+    "directly get results on our objects of interest, and \n",
+    "\n",
+    "To begin, we will query Roman catalogs using `astroquery`. \n",
+    "\n",
+    "For demonstration purposes (as Roman catalogs are not yet available), our example will query the PanSTARRS DR2 catalog near NGC 6535. In addition to a cone search, we will also filter to select only bright, blue stars. \n",
+    "The specific selection criteria we will apply are:\n",
+    "* Located within 1.5 arcminutes of the NGC 6535\n",
+    "* Are point sources (not extended objects)\n",
+    "* Detected flux in the `g`, `i`, `y` bands (quality cuts)\n",
+    "* Have `i` band magnitudes brighter than 18\n",
+    "* Have `g-y` colors less than 0.8  (the bluest, reddest filters for PanSTARRS)\n",
+    "\n",
+    "From the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs), \n",
+    "we see the `MeanObject` table contains the relevant photometric information (note: `astroquery` provides the join of `MeanObject` and `ObjectThin` tables, to provide position information).\n",
+    "\n",
+    "With `astroquery`, we can directly filter for some of these constraints, but will need to post-process the returned results for some others. -->"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use `pyvo` to connect to the MAST PanSTARRS TAP service:\n",
+    "TAP_service = vo.dal.TAPService(\n",
+    "    \"https://mast.stsci.edu/vo-tap/api/v0.1/ps1_dr2/\"\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Again, we will access the mean object catalog (`mean_object` here; see the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs)), which contains all the columns we will need."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# # Note: it is possible to use the TAP service to directly access catalog/table \n",
+    "# # schemas, which describe the tables and columns. \n",
+    "# # An example of this is provided here, commented out as we have pre-identified \n",
+    "# # the relevent columns from the documentation\n",
+    "\n",
+    "# # An overview description of methods, capabilities, and \n",
+    "# # maximum result set sizes is available via:\n",
+    "# TAP_service.describe()\n",
+    "\n",
+    "# # Additionally, the `pyvo` TAPService class objects contain \n",
+    "# # metadata information about the full catalog schema, including tables and columns.\n",
+    "# # It's possible to iterate through the tables and print column names \n",
+    "# # as in this code snipppet:\n",
+    "# TAP_tables = TAP_service.tables\n",
+    "# for tablename in TAP_tables.keys():\n",
+    "#     # This can be refined by table name to print columns only for subsets of tables.\n",
+    "#     if (tablename.startswith(\"ps1_dr2.mean_object\")):  # Include only PS1 tables \n",
+    "#         ####\n",
+    "#         # The table descriptions only include an overview, so this also prints the column names\n",
+    "#         TAP_tables[tablename].describe() \n",
+    "#         print(\"Columns={}\".format(sorted([k.name for k in TAP_tables[tablename].columns])))\n",
+    "#         print(\"----\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now construct our query, including the color/magnitude constraints and \n",
+    "star/extended object separation. Note that for ADQL, the cone search radius must be expressed in degrees.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query MAST for matching observations in \n",
+    "# the PanSTARRS DR2 Mean catalog\n",
+    "catalog_data = Catalogs.query_criteria(\n",
+    "    catalog=\"Panstarrs\",\n",
+    "    data_release=\"dr2\",\n",
+    "    table=\"mean\",\n",
+    "    coordinates=c0,\n",
+    "    radius = 1.5*u.arcmin,\n",
+    "    columns=[\"objID\", \"raMean\",\"decMean\",\n",
+    "             \"gMeanPSFMag\",\"iMeanPSFMag\",\"yMeanPSFMag\",\n",
+    "             \"iMeanKronMag\"],    # List of columns to return\n",
+    "    gMeanPSFMag=[(\"gt\",-999)],   # mag > -999; missing magnitudes are -999\n",
+    "    iMeanPSFMag=[(\"gt\",-999)],   # mag > -999; missing magnitudes are -999\n",
+    "    yMeanPSFMag=[(\"gt\",-999)],   # mag > -999; missing magnitudes are -999\n",
+    "    iMeanKronMag=[(\"gt\",-999)],  # mag > -999; missing magnitudes are -999\n",
+    ")\n",
+    "\n",
+    "# Post-process cuts:\n",
+    "# 1. Distinguish stars from extended objects using\n",
+    "#    difference of PSF, Kron magnitudes\n",
+    "catalog_data = catalog_data[\n",
+    "    (catalog_data['iMeanPSFMag'] - catalog_data['iMeanKronMag']) <= 0.05\n",
+    "]\n",
+    "\n",
+    "# 2. Apply color, magnitude cuts\n",
+    "# Copy original catalog for reference:\n",
+    "catalog_data_all = catalog_data.copy()\n",
+    "catalog_data = catalog_data[\n",
+    "    ((catalog_data['gMeanPSFMag'] - catalog_data['yMeanPSFMag']) < 0.8) \n",
+    "    & (catalog_data['iMeanPSFMag'] < 18)\n",
+    "]\n",
+    "\n",
+    "# Final sample selection\n",
+    "catalog_data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Query MAST for matching observations in \n",
+    "# the PanSTARRS DR2 mean catalog\n",
+    "\n",
+    "# Note: ADQL comments are preceded by \"--\"\n",
+    "adql_query = f\"\"\"\n",
+    "SELECT objid, ramean, decmean, \n",
+    "    gmeanpsfmag, imeanpsfmag, ymeanpsfmag, \n",
+    "    imeankronmag\n",
+    "FROM mean_object\n",
+    "WHERE CONTAINS(\n",
+    "    POINT('ICRS', ramean, decmean),\n",
+    "    CIRCLE('ICRS',{c0.ra.deg}, {c0.dec.deg}, {(1.5*u.arcmin).to_value(u.deg)})          \n",
+    ")=1                                       -- 1.5 arcmin around NGC 6535\n",
+    "AND gmeanpsfmag > -999                    -- mag > -999; missing magnitudes are -999\n",
+    "AND imeanpsfmag > -999                    -- mag > -999; missing magnitudes are -999\n",
+    "AND ymeanpsfmag > -999                    -- mag > -999; missing magnitudes are -999\n",
+    "AND imeankronmag > -999                   -- mag > -999; missing magnitudes are -999\n",
+    "AND (imeanpsfmag - imeankronmag) <= 0.05  -- distinguish stars from extended objects\n",
+    "AND (gmeanpsfmag-ymeanpsfmag) < 0.8       -- color cut\n",
+    "AND imeanpsfmag < 18                      -- magnitude cut\n",
+    "\"\"\"\n",
+    "\n",
+    "# Submit query to the MAST TAP service:\n",
+    "job = TAP_service.run_async(adql_query)\n",
+    "\n",
+    "# Retrieve results:\n",
+    "results_tap = job.to_table()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "By leveraging the advanced usage patterns possible with AQDL, this single TAP query returns the same results as our two-step `astroquery` example where we first queried and then applied the final cuts.\n",
+    "\n",
+    "(For this simple example, applying such cuts in memory are not prohibitive, but for cases where the selected sample may be large, performing all cuts server-side can be much more performant.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sort both by objid\n",
+    "results_aq.sort('objID')\n",
+    "results_tap.sort('objid')\n",
+    "# Check the ID lists are the same:\n",
+    "print(np.all(results_aq['objID'] == results_tap['objid']))"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "*********\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Additional Resources\n",
+    "Additional information can be found at the following links:\n",
+    "\n",
+    "### Other RRN notebooks\n",
+    "- [Data Discovery and Access:](../data_discovery_and_access/data_discovery_and_access.ipynb) The next step in this workflow, covering how to search for and access (particularly cloud streaming access) of file-based Roman products.\n",
+    "\n",
+    "### MAST notebooks\n",
+    "- [MAST Table Access Protocol PanSTARRS 1 DR2 Demo](https://spacetelescope.github.io/mast_notebooks/notebooks/PanSTARRS/PS1_DR2_TAP/PS1_DR2_TAP.html), providing a more in-depth tutorial about constructing ADQL queries and using MAST TAP services.\n",
+    "\n",
+    "### Other resources\n",
+    "- [RDox Level 4 Product Documentation](https://roman-docs.stsci.edu/data-handbook/wfi-data-levels-and-products#WFIDataLevelsandProducts-Level4-ExtractedDataLevel4), including catalog products.\n",
+    "- [`astroquery.mast.Catalogs` search documentation](https://astroquery.readthedocs.io/en/latest/mast/mast_catalog.html)\n",
+    "- [Documentation for `pyvo`](https://pyvo.readthedocs.io/en/latest/index.html), a package to retrieve astronomical data available from archives that support standard IVOA virtual observatory service protocols.\n",
+    "- [Documentation on ADQL](http://www.ivoa.net/documents/latest/ADQL.html), covering the specifications of this IVOA standard for querying astronomical data in tabular format, with geometric search support.\n",
+    "- [Documentation on TAP](http://www.ivoa.net/documents/TAP/), the IVOA standard for RESTful web service access to tabular data.\n",
+    "- [Full list of TAP services at MAST](https://mast.stsci.edu/vo-tap)\n",
+    "\n",
+    "\n",
+    "### Citations and acknowledgements\n",
+    "* [Citing `astropy`](https://www.astropy.org/acknowledging.html)\n",
+    "* [Acknowledging PanSTARRS](https://archive.stsci.edu/publishing/mission-acknowledgements#section-895d38a0-86b3-4143-b521-6cc3312701f9)\n",
+    "* [Acknowledging MAST](https://archive.stsci.edu/gsc/mast_data_use.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "******"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "slideshow": {
+     "slide_type": "slide"
+    }
+   },
+   "source": [
+    "## About this Notebook\n",
+    "The information about TAP access is based on the TIKE MAST PanSTARRS DR2 TAP notebook by Rick White & Theresa Dower, with edits from T. Dutkiewicz. \n",
+    "\n",
+    "**Author:**  Sedona Price\\\n",
+    "**Updated On:** 2026-03-20"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<table width=\"100%\" style=\"border:none; border-collapse:collapse;\">\n",
+    "  <tr style=\"border:none;\">\n",
+    "    <td style=\"border:none; width:180px; white-space:nowrap;\">\n",
+    "       <a href=\"#top\" style=\"text-decoration:none; color:#0066cc;\">↑ Top of page</a> \n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:center;\">\n",
+    "       <img src=\"../../roman_logo.png\" width=\"50\">\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:right;\">\n",
+    "       <img src=\"../../stsci_logo2.png\" width=\"90\">\n",
+    "    </td>\n",
+    "  </tr>\n",
+    "</table>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/notebooks/catalog_database_access/catalog_database_access.ipynb
+++ b/notebooks/catalog_database_access/catalog_database_access.ipynb
@@ -118,15 +118,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-warning\" style=\"color:black; background-color:#ffc5c5; border-color:red;\">\n",
-    "    <b style=\"color:red\">Future:</b> Add pointers to integrated schema browser (and also the direct URL access) when available.\n",
-    "</div>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Querying Roman Catalogs using `astroquery`\n",
     "To begin, we will query Roman catalogs using `astroquery`. \n",
     "\n",

--- a/notebooks/catalog_database_access/requirements.txt
+++ b/notebooks/catalog_database_access/requirements.txt
@@ -1,3 +1,4 @@
 astropy >= 7.0.1
 astroquery >= 0.4.11
 pyvo >= 1.8
+matplotlib>=3.10.0

--- a/notebooks/catalog_database_access/requirements.txt
+++ b/notebooks/catalog_database_access/requirements.txt
@@ -1,0 +1,3 @@
+astropy >= 7.0.1
+astroquery >= 0.4.11
+pyvo >= 1.8


### PR DESCRIPTION
This PR contains a complete version of the notebook "Catalog database access", designed for the proposed revision of the "Working with WFI data" RRN workflow.

This notebook covers a simple example of how to query Roman catalogs at MAST using (1) astroquery, and (2) the Table Access Protocol service via a query written in ADQL.

As Roman catalogs are not yet available, this example instead uses PanSTARRS DR2 to select bright blue stars near NGC 6535, to provide a general overview of the MAST catalog access tools which will be used for Roman catalogs.

Anticipated future updates to the narrative will include:
- Adding pointers to the integrated catalog schema browser, when that service and RRN functionality has been launched.
- Updating and expanding pointers to RDox as more catalog-specific information becomes available.
- Updating the end of the notebook to link to the next workflow step (to both conform with the standard format and to update the next notebook name (if it changes).