### PR TITLE
Added symlinks to shared module notebook_data_dependencies.py

### DIFF
--- a/notebooks/aperture_photometry/notebook_data_dependencies.py
+++ b/notebooks/aperture_photometry/notebook_data_dependencies.py
@@ -1,0 +1,1 @@
+../../shared/notebook_data_dependencies.py

--- a/notebooks/pandeia/notebook_data_dependencies.py
+++ b/notebooks/pandeia/notebook_data_dependencies.py
@@ -1,0 +1,1 @@
+../../shared/notebook_data_dependencies.py

--- a/notebooks/romanisim/notebook_data_dependencies.py
+++ b/notebooks/romanisim/notebook_data_dependencies.py
@@ -1,0 +1,1 @@
+../../shared/notebook_data_dependencies.py


### PR DESCRIPTION
Adds symlinks to shared/notebook_data_dependencies for those notebooks that explicitly import it.  These should be more robust than PYTHONPATH and explicitly identifies extra code these notebooks need to work correctly.