### PR TITLE
update to STIPS notebook and references yaml file

### DIFF
--- a/notebooks/stips/requirements.txt
+++ b/notebooks/stips/requirements.txt
@@ -1,5 +1,5 @@
 stips>=2.2.2
-astropy>=7.0.1
+astropy>=7.2.0
 matplotlib>=3.10.0
 esutil>=0.6.16 # --no-cache-dir option recommended on pip install
-stsynphot 
+stsynphot>=1.4.0

--- a/notebooks/stips/stips.ipynb
+++ b/notebooks/stips/stips.ipynb
@@ -39,13 +39,93 @@
     "\n",
     "## Introduction\n",
     "\n",
-    "**STIPS**, or the Space Telescope Imaging Product Simulator, is a tool developed by STScI for simulating observations of astronomical scenes with the Roman Wide Field Instrument (WFI). Detailed documentation of the tool is available on the [RDox pages](https://roman-docs.stsci.edu/simulation-tools-handbook-home/stips-space-telescope-imaging-product-simulator). \n",
+    "**STIPS**, or the Space Telescope Imaging Product Simulator, is a tool developed by STScI for simulating observations of astronomical scenes with the Roman Wide Field Instrument (WFI). Detailed documentation of the tool is available on the [RDox pages](https://roman-docs.stsci.edu/simulation-tools-handbook-home/stips-space-telescope-imaging-product-simulator).\n",
     "\n",
     "STIPS can generate images of the entire WFI array, which consists of 18 detectors, also called Sensor Chip Assemblies (SCAs). For more information on the WFI detectors and focal plane array please see the [RDox documentation](https://roman-docs.stsci.edu/roman-instruments-home/wfi-imaging-mode-user-guide/wfi-detectors). STIPS depends on the [Pandeia Exposure time calculator](https://roman-docs.stsci.edu/simulation-tools-handbook-home/roman-wfi-exposure-time-calculator/pandeia-for-roman) and the [STPSF point spread function (PSF) generator](https://roman-docs.stsci.edu/simulation-tools-handbook-home/stpsf-for-roman) to create these simulations. Tutorial notebooks for both [Pandeia](../pandeia/pandeia.ipynb) and [STPSF](../stpsf/stpsf.ipynb) are also available. Users can choose to simulate between 1 and 18 SCAs in any of the WFI imaging filters, insert any number of point or extended sources, and specify a sky background estimate. STIPS will scale input fluxes to observed values, retrieve appropriate PSFs (interpolated to the positions of the sources), and add in additional noise terms.\n",
     "\n",
     "As described in the [Caveats to Using STIPS for Roman](https://roman-docs.stsci.edu/simulation-tools-handbook-home/stips-space-telescope-imaging-product-simulator/caveats-of-using-stips-for-roman), neither pixel saturation nor non-linearity residuals are currently supported.\n",
     "\n",
     "This notebook is a starter guide to simulating and manipulating scenes with STIPS."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reference Data\n",
+    "\n",
+    "The cell below will check to ensure ancillary reference files for `stips` and `pandeia` packages are installed. If not, it will download the ancillary reference files and install them under your home directory (i.e., `${HOME}/refdata/`).\n",
+    "\n",
+    "### Local Run Settings\n",
+    "\n",
+    "If you want to run the notebook in your local machine, refer to the information in [local installation](../../markdown/local-run.md) instructions before proceeding with the notebook. The instructions provide inportant information about setting up your environment, installing dependnecies, and adding to your working directory scripts to help with the reference data installation.\n",
+    "\n",
+    "Depending on which (if any) reference data are missing, this cell may take several minutes to execute.\n",
+    "\n",
+    "### On the Roman Research Nexus\n",
+    "\n",
+    "If you are working on the Nexus, then the ancillary reference data are pre-installed and this cell will execute instantly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import importlib.util\n",
+    "\n",
+    "try:\n",
+    "    import notebook_data_dependencies as ndd\n",
+    "    local_script = True  # Set to true when script is available locally\n",
+    "except ImportError:\n",
+    "    local_script = False\n",
+    "\n",
+    "# If running locally and script not in working dir,\n",
+    "# first get the directory with the script\n",
+    "if not local_script:\n",
+    "    notebook_dir = os.getcwd()\n",
+    "    shared_path = os.path.abspath(\n",
+    "        os.path.join(notebook_dir, '..', '..', 'shared', 'notebook_data_dependencies.py')\n",
+    "    )\n",
+    "\n",
+    "    if os.path.exists(shared_path):\n",
+    "        print(f\"Loading notebook_data_dependencies from shared location: {shared_path}\")\n",
+    "        spec = importlib.util.spec_from_file_location(\"notebook_data_dependencies\", shared_path)\n",
+    "        ndd = importlib.util.module_from_spec(spec)\n",
+    "        sys.modules['notebook_data_dependencies'] = ndd  # Optional: makes subsequent imports work\n",
+    "        spec.loader.exec_module(ndd)\n",
+    "    else:\n",
+    "        raise FileNotFoundError(f\"Local install script not found at {shared_path}\")\n",
+    "\n",
+    "    # If working locally we first need to get the data used by some packages.\n",
+    "    # Here the environment variables for the reference data\n",
+    "    required = {\n",
+    "        \"stips_data\": \"stips\",\n",
+    "        \"STPSF_PATH\":\"stpsf\",\n",
+    "        \"pandeia_refdata\": \"pandeia_data\",\n",
+    "        \"PSF_DIR\":\"pandeia_psf\",\n",
+    "    }\n",
+    "\n",
+    "    # Now let's retrieve the data for these packages\n",
+    "    result = {}\n",
+    "    for var, pkg in required.items():\n",
+    "        if not os.getenv(var):\n",
+    "            print(f\"Running local data dependency installation for {var} ({pkg}) …\")\n",
+    "            result |= ndd.install_files(packages=pkg)\n",
+    "\n",
+    "        # Update environment variables (if necessary) and print reference data paths\n",
+    "        print('Reference data paths set to:')\n",
+    "        for k, v in result.items():\n",
+    "            if not v['pre_installed']:\n",
+    "                os.environ[k] = v['path']\n",
+    "                print(os.environ[k])\n",
+    "            print(f\"\\t{k} = {v['path']}\")\n",
+    "\n",
+    "else:\n",
+    "    print(\"Running on RNN — data already available, skipping local install.\")"
    ]
   },
   {
@@ -63,8 +143,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
     "import matplotlib as mpl\n",
     "import matplotlib.pyplot as plt\n",
     "import stips\n",
@@ -940,9 +1018,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Roman Research Nexus",
+   "display_name": "stips",
    "language": "python",
-   "name": "roman-cal"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -954,7 +1032,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.11"
+   "version": "3.13.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/stips/stips.ipynb
+++ b/notebooks/stips/stips.ipynb
@@ -58,7 +58,7 @@
     "\n",
     "### Local Run Settings\n",
     "\n",
-    "If you want to run the notebook in your local machine, refer to the information in [local installation](../../markdown/local-run.md) instructions before proceeding with the notebook. The instructions provide inportant information about setting up your environment, installing dependnecies, and adding to your working directory scripts to help with the reference data installation.\n",
+    "If you want to run the notebook in your local machine, refer to the information in [local installation](../../markdown/local-run.md) instructions before proceeding with the notebook. The instructions provide important information about setting up your environment, installing dependencies, and adding to your working directory scripts to help with the reference data installation.\n",
     "\n",
     "Depending on which (if any) reference data are missing, this cell may take several minutes to execute.\n",
     "\n",

--- a/notebooks/stips/stips.ipynb
+++ b/notebooks/stips/stips.ipynb
@@ -1018,9 +1018,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "stips",
+   "display_name": "Roman Research Nexus",
    "language": "python",
-   "name": "python3"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {
@@ -1032,7 +1032,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/refdata_dependencies.yaml
+++ b/refdata_dependencies.yaml
@@ -58,5 +58,5 @@ install_files:
 # followed by a value.
 other_variables:
   CRDS_SERVER_URL: https://roman-crds.stsci.edu
-  CRDS_CONTEXT: roman_0041.pmap
+  CRDS_CONTEXT: roman_0048.pmap
   CRDS_PATH: ${HOME}/crds_cache    # Nexus CRDS caches are local for now


### PR DESCRIPTION
The STIPS notebook was missing the cell that retrieved the reference data  for STIPS, STPSF, and Pandeia. Added it and the notebook now runs fine.

Some notebooks started crashing after upgrading the image to use the RomanCal 0.22. This happens because the context used in RRN does no have new type of files that the new version uses. Updated the yaml file that provides the context to use in the RRN image. In this case is roman_0048.pmap