### PR TITLE
Add back JDaviz to requirements file for data visualization

### DIFF
--- a/notebooks/aperture_photometry/aperture_photometry.ipynb
+++ b/notebooks/aperture_photometry/aperture_photometry.ipynb
@@ -497,9 +497,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "columns = ('id', 'xcentroid', 'ycentroid', 'sum', 'sum_err')\n",
+    "columns = ('id', 'x_centroid', 'y_centroid', 'sum', 'sum_err')\n",
     "star_phot = ApertureStats(image, star_apertures, error=err)\n",
-    "phot_tab = star_phot.to_table(columns)\n",
+    "phot_tab = star_phot.to_table(columns=columns)\n",
     "phot_tab[:5]"
    ]
   },
@@ -516,10 +516,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "columns = ('id', 'xcentroid', 'ycentroid', 'median', 'std')\n",
+    "columns = ('id', 'x_centroid', 'y_centroid', 'median', 'std')\n",
     "sigclip = SigmaClip(sigma=3.0, maxiters=5)\n",
     "star_bkg = ApertureStats(image, star_bkg_apertures, sigma_clip=sigclip, mask=dq)\n",
-    "star_bkg.to_table(columns)[:5]"
+    "star_bkg.to_table(columns=columns)[:5]"
    ]
   },
   {

--- a/notebooks/data_visualization/data_visualization.ipynb
+++ b/notebooks/data_visualization/data_visualization.ipynb
@@ -263,9 +263,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Research Nexus",
    "language": "python",
-   "name": "python3"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {
@@ -277,7 +277,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.12"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/data_visualization/requirements.txt
+++ b/notebooks/data_visualization/requirements.txt
@@ -6,3 +6,4 @@ gwcs>=1.0.3
 s3fs>=2025.5.1
 matplotlib>=3.10.0
 numpy>=2.2.3
+jdaviz>=4.5.2,<5.0


### PR DESCRIPTION
Adding back JDaviz to the requirements to eventually add this part of the data_visualization back.

This also includes 

- Updated the aperture photometry notebook to fix the issues found by Tyler.
- Updated the Kernel name to Roman Research Nexus