### PR TITLE
Added notebook_data_dependencies link for stips notebook

### DIFF
--- a/notebooks/stips/notebook_data_dependencies.py
+++ b/notebooks/stips/notebook_data_dependencies.py
@@ -1,0 +1,1 @@
+../../shared/notebook_data_dependencies.py


### PR DESCRIPTION
Adds symlink to shared/noetbook_data_dependencies.py module to stips notebook dir.