### PR TITLE
added matplolib to requirements file

### DIFF
--- a/notebooks/ground_test_analysis/requirements.txt
+++ b/notebooks/ground_test_analysis/requirements.txt
@@ -9,3 +9,4 @@ gwcs>=1.0.3
 s3fs>=2025.5.1
 crds==13.1.15
 scipy>=1.17.1
+matplotlib>=3.10.0


### PR DESCRIPTION
The requirements.txt file for the ground_spectra_extraction was missing the matplotlib package. Added with this PR