### PR TITLE
updated synphot to correct a bug in calculation

### DIFF
--- a/notebooks/synphot/synphot.ipynb
+++ b/notebooks/synphot/synphot.ipynb
@@ -349,7 +349,7 @@
     "print(f'\\t{obs_spec.effstim(syn.units.VEGAMAG, vegaspec=syn.SourceSpectrum.from_file(syn.conf.vega_file))}')\n",
     "print(f'\\t{obs_spec.effstim(u.ABmag)}')\n",
     "print(f'\\t{obs_spec.effstim(u.Jy)}')\n",
-    "print(f'\\t{obs_spec.countrate(area=np.pi * (2.4 * u.m)**2)}')"
+    "print(f'\\t{obs_spec.countrate(area=np.pi * (1.2 * u.m)**2)}')"
    ]
   },
   {
@@ -488,7 +488,7 @@
     "## About this Notebook\n",
     "\n",
     "**Author:** Tyler Desjardins and Rosa Diaz<br>\n",
-    "**Updated On:** 2025-10-29"
+    "**Updated On:** 2026-05-26"
    ]
   },
   {


### PR DESCRIPTION
A user reported an issue in our documentation which was also in the synphot notebook. Corrected  the area calculation to use the correct values.