### PR TITLE
Adding CRDS notebooks

### DIFF
--- a/notebooks/crds_reference_files/area_reffile.ipynb
+++ b/notebooks/crds_reference_files/area_reffile.ipynb
@@ -5,7 +5,7 @@
    "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
    "metadata": {},
    "source": [
-    "# Understanding the Roman WFI Dark Current Reference File "
+    "# Understanding the Roman WFI Pixel Area Reference File"
    ]
   },
   {
@@ -27,9 +27,11 @@
    "metadata": {},
    "source": [
     "## Introduction\n",
-    "The purpose of this notebook is to understand the content and purpose of the **Dark Current** (`DARK`) reference file.\n",
+    "The purpose of this notebook is to understand the content and purpose of the **Pixel Area** (`AREA`) reference file.\n",
     "\n",
-    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)"
+    "The AREA reference file provides the pixel area in steradians for each pixel. It is used during photometric calibration?????????? to correctly convert surface brightness to flux, especially important for extended sources. ??????\n",
+    "\n",
+    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)."
    ]
   },
   {
@@ -112,13 +114,9 @@
    "id": "11b5ca61-dfe0-4031-8f4d-172f4a135b52",
    "metadata": {},
    "source": [
-    "### Darks \n",
+    "### Pixel Area Reference File\n",
     "\n",
-    "The DARK reference file is selected based on the WFI mode (imaging or spectroscopy) used to obtain the science data. During the `romancal.dark_current.DarkCurrentStep()` step, the dark current is subtracted on a pixel-by-pixel and resultant-by-resultant basis. Pixels that are undefined in the dark reference file will not be subtracted from the science data.\n",
-    "\n",
-    "The dark reference files are created from dark calibration datasets.  A set of dark files are sigma clipped, and stacked resultant-by-resultant to create a super dark.\n",
-    "\n",
-    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/dark_current/index.html) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook-home/roman-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-dark_current) for dark current subtraction.\n"
+    "The AREA reference file contains the solid angle (in steradians) subtended by each pixel. It is used in the photometric calibration step to properly handle extended sources."
    ]
   },
   {
@@ -167,11 +165,10 @@
     "\n",
     "As you run the exposure pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, retrieve those from `crds` Python API and feed these to the Exposure Level or Mosaic Pipeline, see the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb) for more details. \n",
     "\n",
-    "For the dark files in particular, the keywords that will identify the best reference file to use are:\n",
+    "For the area reference files in particular, the keywords that will identify the best reference file to use are:\n",
     "\n",
     "- ROMAN.META.INSTRUMENT.NAME\n",
     "- ROMAN.META.INSTRUMENT.DETECTOR\n",
-    "- ROMAN.META.EXPOSURE.TYPE\n",
     "- ROMAN.META.EXPOSURE.START_TIME\n",
     "\n",
     "These keywords may be combined into a single dictionary to find and download the file using `crds.getreferences()`.  "
@@ -186,11 +183,10 @@
    "source": [
     "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
     "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
-    "        'ROMAN.META.EXPOSURE.TYPE': 'WFI_IMAGE',\n",
     "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
     "       }\n",
     "\n",
-    "ref_files = crds.getreferences(meta, reftypes=['dark'], observatory='roman')\n",
+    "ref_files = crds.getreferences(meta, reftypes=['area'], observatory='roman')\n",
     "ref_files"
    ]
   },
@@ -211,8 +207,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dark = rdm.open(ref_files['dark'])\n",
-    "dark.info()"
+    "area = rdm.open(ref_files['area'])\n",
+    "area.info()"
    ]
   },
   {
@@ -220,31 +216,7 @@
    "id": "021a3635-5642-48b8-9c96-f4a6f9d758ee",
    "metadata": {},
    "source": [
-    "We see that the dark reference file contains metadata plus several arrays:\n",
-    "- The `data` array contains a cube of dark values up-the-ramp. This is used in the current version of the Exposure Pipeline, however changes are being made towards a dark rate subtraction post-ramp-fitting. \n",
-    "- The `dark_slope` array contains the dark rate per pixel\n",
-    "- The `dark_slope_error` contains the uncertainty in the dark rate. \n",
-    "- The `dq` array is present to flag effects in the dark current (such as hot pixels)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "868eed54-c552-4324-bae3-4622ef81c4a9",
-   "metadata": {},
-   "source": [
-    "Let's take a look at the dark for this detector. First, lets check the shape of the data array:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "30f444a2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"dark.data shape:\", dark.data.shape)\n",
-    "print(\"dark.dq shape:\", dark.dq.shape)\n",
-    "print(\"dark.dark_slope shape:\", getattr(dark, 'dark_slope', None).shape if hasattr(dark, 'dark_slope') else \"No dark_slope\")"
+    "The AREA reference file is typically a 2D array with pixel solid angle values in steradians."
    ]
   },
   {
@@ -252,7 +224,35 @@
    "id": "b4f0262f",
    "metadata": {},
    "source": [
+    "### Basic Statistics\n",
+    "\n",
     "Now lets get some basic statistics on the cube (or a representative slice)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73bd5d09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Area array shape:\", area.data.shape)\n",
+    "print(\"\\nPixel area statistics (steradians):\")\n",
+    "print(f\"  Min: {area.data.min():.2e}\")\n",
+    "print(f\"  Max: {area.data.max():.2e}\")\n",
+    "print(f\"  Mean: {area.data.mean():.2e}\")\n",
+    "print(f\"  Median: {np.median(area.data):.2e}\")\n",
+    "print(f\"  Std: {area.data.std():.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a805ab5e",
+   "metadata": {},
+   "source": [
+    "### Visualization\n",
+    "\n",
+    "Let's check this reference file"
    ]
   },
   {
@@ -262,104 +262,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Quick stats on saturation thresholds\n",
-    "data = dark.data\n",
-    "print(\"\\nDark threshold stats:\")\n",
-    "print(\"  Min:\", data.min(), \"Max:\", data.max())\n",
-    "print(\"  Mean:\", data.mean(), \"Median:\", np.median(data))\n",
-    "print(\"  Std:\", data.std())\n",
+    "fig, ax = plt.subplots(figsize=(10, 8))\n",
     "\n",
-    "# DQ stats (reuse/adapt from your MASK statistics code)\n",
-    "dq = dark.dq\n",
-    "total = dq.size\n",
-    "flagged = np.sum(dq > 0)\n",
-    "print(f\"\\nDQ: {flagged:,} / {total:,} pixels flagged ({flagged/total*100:.3f}%)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "44fec9cb",
-   "metadata": {},
-   "source": [
-    "Note that in this case the pre-launch darks are all zero, so the plot will be rather flat."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "437d9346",
-   "metadata": {},
-   "source": [
-    "Let's get a quick histogram of a slice:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2c76715a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Select a slice of the data for histogram plotting\n",
-    "data_slice = dark.data[3:10]\n",
-    "\n",
-    "plt.figure(figsize=(8,5))\n",
-    "plt.hist(data_slice.flatten(), bins=100, range=(data_slice.min(), np.percentile(data_slice, 99.5)), log=True)\n",
-    "plt.xlabel('Dark Current Value')\n",
-    "plt.ylabel('Pixel Count (log)')\n",
-    "plt.title('Pixel Value Distribution (slice)')\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9b893996",
-   "metadata": {},
-   "source": [
-    "Note: In flight data the dark current will be non-zero and these visualizations\n",
-    "will show clear structure (hot pixels, gradients, etc.).\n",
-    "\n",
-    "Now let's check the dark image"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f732d453-7394-4fec-b0e9-e9111a243e63",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, axs = plt.subplots(1, 3, figsize=(18, 6))  # Add a third panel for dark_slope if available\n",
-    "\n",
-    "slice_idx = 10  # You can change this index to visualize a different slice of the dark current data\n",
-    "data_slice = dark.data[slice_idx]\n",
-    "\n",
-    "my_cmap = copy.copy(cm.get_cmap('nipy_spectral'))\n",
+    "my_cmap = copy.copy(cm.get_cmap('viridis'))\n",
     "my_cmap.set_bad('black')\n",
     "\n",
-    "norm = simple_norm(data_slice, stretch='sqrt', percent=99.5, min_percent=0.5)\n",
+    "norm = simple_norm(area.data, stretch='linear', percent=99.5)\n",
+    "im = ax.imshow(area.data, cmap=my_cmap, norm=norm, origin='lower')\n",
+    "ax.set_title('Pixel Area Map (steradians)')\n",
+    "ax.set_xlabel('Science X (pixels)')\n",
+    "ax.set_ylabel('Science Y (pixels)')\n",
     "\n",
-    "im0 = axs[0].imshow(data_slice, cmap=my_cmap, norm=norm, origin='lower')\n",
-    "divider = make_axes_locatable(axs[0])\n",
+    "divider = make_axes_locatable(ax)\n",
     "cax = divider.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
-    "fig.colorbar(im0, cax=cax, label='DN/s or electrons')\n",
-    "axs[0].set_title(f'Dark Current (slice {slice_idx})')\n",
-    "\n",
-    "# DQ panel\n",
-    "axs[1].imshow(np.bool_(dark.dq), cmap='binary_r', origin='lower')\n",
-    "axs[1].set_title('Dark Current DQ Flags')\n",
-    "\n",
-    "# dark_slope (rate image) \n",
-    "if hasattr(dark, 'dark_slope') and dark.dark_slope is not None:\n",
-    "    slope_norm = simple_norm(dark.dark_slope, stretch='sqrt', percent=99)\n",
-    "    im2 = axs[2].imshow(dark.dark_slope, cmap=my_cmap, norm=slope_norm, origin='lower')\n",
-    "    divider2 = make_axes_locatable(axs[2])\n",
-    "    cax2 = divider2.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
-    "    fig.colorbar(im2, cax=cax2, label='DN/s or electrons')\n",
-    "    axs[2].set_title('Dark Slope (Rate)')\n",
-    "\n",
-    "for ax in axs:\n",
-    "    ax.set_xlabel('Science X (pixels)')\n",
-    "    ax.set_ylabel('Science Y (pixels)')\n",
+    "fig.colorbar(im, cax=cax, label='Pixel Area (sr)')\n",
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
@@ -371,7 +287,7 @@
    "metadata": {},
    "source": [
     "## About this Notebook\n",
-    "**Author:** T. Desjardins & R. Diaz\n",
+    "**Author:** R. Diaz\n",
     "\n",
     "**Updated On:** 2026-07-06"
    ]
@@ -400,9 +316,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Roman Research Nexus 2026.2",
+   "display_name": "roman_cal",
    "language": "python",
-   "name": "roman_cal"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/crds_reference_files/bad_pixels_mask_reffile.ipynb
+++ b/notebooks/crds_reference_files/bad_pixels_mask_reffile.ipynb
@@ -163,58 +163,15 @@
    "source": [
     "### Retrieving Reference Files\n",
     "\n",
-    "As you run the `RomanCal` pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, these can be retrieved through the `crds` Python API and the ELP run with those files (more on that later). Let's begin with how to access reference files from CRDS.\n",
+    "As you run the exposure pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, retrieve those from `crds` Python API and feed these to the Exposure Level or Mosaic Pipeline, see the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb) for more details. \n",
     "\n",
-    "First, let's start by looking at the `crds.getrecommendations()` function. This function returns a dictionary of file names that match the criteria that you supply. Selection criteria are specified in a dictionary of key-value pairs. Each Roman WFI metadata keyword in the dictionary is all-caps and always begins with \"ROMAN.META.\". The remaining parts of the string correspond to the metadata keyword locations in the science data file schema. Different reference file types require different combinations of science metadata to match to the reference files. In general, all reference file types will require the instrument name (\"INSTRUMENT.NAME\") and start time (\"EXPOSURE.START_TIME\"). Most file types require the detector name (\"INSTRUMENT.DETECTOR\"), and some file types require the exposure type (\"EXPOSURE.TYPE\") or optical element (\"INSTRUMENT.OPTICAL_ELEMENT\").\n",
-    "\n",
-    "For the mask files in particular, the required keywords are:\n",
+    "For the mask files in particular, the keywords that will identify the best reference file to use are:\n",
     "- mask\n",
     "    - ROMAN.META.INSTRUMENT.NAME\n",
     "    - ROMAN.META.INSTRUMENT.DETECTOR\n",
     "    - ROMAN.META.EXPOSURE.START_TIME\n",
-    "\n",
-    "These keywords may be combined into a single dictionary to find multiple reference file types using `crds.getreferences()`. For example, if you would like to find the name of the dark and flat reference files used by the pipeline, you could run the following example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b8f3dc8a-bcb3-4948-8d6d-0ccf99c2ac6a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
-    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
-    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
-    "       }\n",
-    "\n",
-    "ref_files = crds.getrecommendations(meta, reftypes=['mask'], observatory='roman')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "99ec8fd5-c73a-488a-86ad-52d032dd543c",
-   "metadata": {},
-   "source": [
-    "The `ref_files` variable now contains a dictionary for the MASK reference file. This is the reference file that correspond to a science observation taken at midnight UTC on January 1, 2026 in the WFI imaging mode with optical element F158 and detector WFI01. Let's take a look at the names of the files CRDS returned:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "db5933f4-2af7-4106-b2ab-a89b7a8fd7f3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ref_files"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2916910d-6152-4db7-abfd-e69a3d3e8eac",
-   "metadata": {},
-   "source": [
-    "We can also use `crds.getreferences()` to accomplish the same thing; however, `getreferences()` goes one step further beyond `getrecommendations()` and will download the reference files if they are not already in your local cache. Using the same example as above:"
+    "    \n",
+    "These keywords may be combined into a single dictionary to find and download the file using `crds.getreferences()`.  "
    ]
   },
   {
@@ -229,24 +186,7 @@
     "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
     "       }\n",
     "\n",
-    "ref_files = crds.getreferences(meta, reftypes=['mask'], observatory='roman')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a60dab9f-c70d-44cb-b6b8-932918e97e49",
-   "metadata": {},
-   "source": [
-    "Once again we can examine the output of `ref_files`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9ffe7a81-c9cf-4750-a962-41a52dff27fc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "ref_files = crds.getreferences(meta, reftypes=['mask'], observatory='roman')\n",
     "ref_files"
    ]
   },

--- a/notebooks/crds_reference_files/bad_pixels_mask_reffile.ipynb
+++ b/notebooks/crds_reference_files/bad_pixels_mask_reffile.ipynb
@@ -1,0 +1,446 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
+   "metadata": {},
+   "source": [
+    "# Understanding the Roman WFI Bad Pixels Mask Reference File "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "620243a9-7836-4594-9c0e-c952166fe365",
+   "metadata": {},
+   "source": [
+    "## Kernel Information and Read-Only Status\n",
+    "\n",
+    "To run this notebook, please select \"Roman Research Nexus {VERSION}\" kernel at the top right of your window. For example \"Roman Research Nexus 2026.1\".\n",
+    "\n",
+    "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it.\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e739398-0b70-40fa-8a46-5319d7066c73",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "The purpose of this notebook is to understand the the content and purpose of the **Bad Pixels Mask** (`MASK`) reference file.\n",
+    "\n",
+    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1beac9c",
+   "metadata": {},
+   "source": [
+    "### Local Run Settings\n",
+    "\n",
+    "If you want to run the notebook in your local machine, refer to the information in [local installation](../../markdown/local-run.md) instructions before proceeding with the notebook. The instructions provide inportant information about setting up your environment and installing dependnecies."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd1a0491-6dcc-475e-9118-e22a9e2a31c2",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "Libraries used:\n",
+    "- *copy* for making copies of Python objects\n",
+    "- *crds* for access to calibration reference files\n",
+    "- *matplotlib* and *mpl_toolkits* for plotting images\n",
+    "- *numpy* for array manipulation\n",
+    "- *roman_datamodels* for opening Roman WFI ASDF files\n",
+    "- *asdf* for opening Roman WFI ASDF files\n",
+    "- *os* for operating system functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53a4bf0b-4a5d-4aa1-974f-fbc5ca87c9c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import copy\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import colors, colormaps as cm\n",
+    "from mpl_toolkits.axes_grid1 import make_axes_locatable\n",
+    "import numpy as np\n",
+    "import roman_datamodels as rdm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bb19274-2253-455f-b116-f49509ab7c3c",
+   "metadata": {},
+   "source": [
+    "### The Calibration Reference Data System (CRDS)\n",
+    "\n",
+    " The reference files, developed and validated by STScI’s Science Operations Center, are continually updated as new WFI data become available. For more information about how CRDS works and how it assigns the most appropriate reference file for each calibration step, refer to the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb). \n",
+    "\n",
+    "**IMPORTANT NOTE:** Reference files are a work in progress and will be updated several times before Roman launch. If you notice irregularities or missing information, please understand that they may be a known issue. If you have questions, please contact the [Roman Help Desk](https://romanhelp.stsci.edu)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8fcb955",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import crds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaf56d81",
+   "metadata": {},
+   "source": [
+    "Now let's dive into this reference file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e0c2b6f-a9b5-493b-aa8f-051c27c1ccc7",
+   "metadata": {},
+   "source": [
+    "### Bad Pixel Masks\n",
+    "\n",
+    "Bad pixels are masked during the Data Quality (DQ) initialization step.  The MASK reference file, which contains static bad pixel flags (i.e., locations of dead pixels, telegraph pixels, etc.) for each detector, populates the data quality (DQ) `dq` array of the L2 calibrated rate image files after processing by RomanCal. During RomanCal processing, the MASK file is used in the `romancal.dq_init.DQInitStep()` step (the first step in the Exposure Pipeline) to populate an array called `pixeldq` in the *RampModel* datamodel, which is used within the pipeline. DQ flags are combined with additional DQ flags from reference file DQ arrays during subsequent processing steps using `bitwise_or`.\n",
+    "\n",
+    "These mask reference files are created from dark or flat calibration datasets. Different types of pixels are flagged based on their pixel values (i.e., dead pixels with significantly reduced detector response) or behavior up-the-ramp (i.e., telegraph pixels jump between two electronic states).\n",
+    "\n",
+    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/dq_init/index.html) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook-home/roman-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-dq_init) for DQ initialization."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5d16bd8",
+   "metadata": {},
+   "source": [
+    "Let's check the environmental variables set for CRDS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e352faad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"CRDS server location: {os.environ.get('CRDS_SERVER_URL')}\")\n",
+    "print(f\"CRDS context file: {os.environ.get('CRDS_CONTEXT')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a72c7ea",
+   "metadata": {},
+   "source": [
+    "If we want to change the context, we can do it in the next cell. In this case, we choose context `roman_0055.pmap`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a3076f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['CRDS_CONTEXT']='roman_0055.pmap'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80b3db81-1b7a-448f-a462-16eff6ed8f9a",
+   "metadata": {},
+   "source": [
+    "### Retrieving Reference Files\n",
+    "\n",
+    "As you run the `RomanCal` pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, these can be retrieved through the `crds` Python API and the ELP run with those files (more on that later). Let's begin with how to access reference files from CRDS.\n",
+    "\n",
+    "First, let's start by looking at the `crds.getrecommendations()` function. This function returns a dictionary of file names that match the criteria that you supply. Selection criteria are specified in a dictionary of key-value pairs. Each Roman WFI metadata keyword in the dictionary is all-caps and always begins with \"ROMAN.META.\". The remaining parts of the string correspond to the metadata keyword locations in the science data file schema. Different reference file types require different combinations of science metadata to match to the reference files. In general, all reference file types will require the instrument name (\"INSTRUMENT.NAME\") and start time (\"EXPOSURE.START_TIME\"). Most file types require the detector name (\"INSTRUMENT.DETECTOR\"), and some file types require the exposure type (\"EXPOSURE.TYPE\") or optical element (\"INSTRUMENT.OPTICAL_ELEMENT\").\n",
+    "\n",
+    "For the mask files in particular, the required keywords are:\n",
+    "- mask\n",
+    "    - ROMAN.META.INSTRUMENT.NAME\n",
+    "    - ROMAN.META.INSTRUMENT.DETECTOR\n",
+    "    - ROMAN.META.EXPOSURE.START_TIME\n",
+    "\n",
+    "These keywords may be combined into a single dictionary to find multiple reference file types using `crds.getreferences()`. For example, if you would like to find the name of the dark and flat reference files used by the pipeline, you could run the following example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8f3dc8a-bcb3-4948-8d6d-0ccf99c2ac6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "       }\n",
+    "\n",
+    "ref_files = crds.getrecommendations(meta, reftypes=['mask'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99ec8fd5-c73a-488a-86ad-52d032dd543c",
+   "metadata": {},
+   "source": [
+    "The `ref_files` variable now contains a dictionary for the MASK reference file. This is the reference file that correspond to a science observation taken at midnight UTC on January 1, 2026 in the WFI imaging mode with optical element F158 and detector WFI01. Let's take a look at the names of the files CRDS returned:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db5933f4-2af7-4106-b2ab-a89b7a8fd7f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2916910d-6152-4db7-abfd-e69a3d3e8eac",
+   "metadata": {},
+   "source": [
+    "We can also use `crds.getreferences()` to accomplish the same thing; however, `getreferences()` goes one step further beyond `getrecommendations()` and will download the reference files if they are not already in your local cache. Using the same example as above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b09c9bd3-57a5-4fbf-87ce-ebcf22ac999a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "       }\n",
+    "\n",
+    "ref_files = crds.getreferences(meta, reftypes=['mask'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a60dab9f-c70d-44cb-b6b8-932918e97e49",
+   "metadata": {},
+   "source": [
+    "Once again we can examine the output of `ref_files`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ffe7a81-c9cf-4750-a962-41a52dff27fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44b65450-a2e1-40c6-ab75-144c28480778",
+   "metadata": {},
+   "source": [
+    "### Examining Reference Files\n",
+    "\n",
+    "Reference files use `roman_datamodels` just like WFI science data products and can be accessed in the same way (see the tutorial [Working with ASDF](../working_with_asdf/working_with_asdf.ipynb) for more information). Let's take a closer look at the files we retrieved from our `crds.getreferences()` example starting with the mask file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80ad3211-188d-45ef-b5f1-2ef6bf466450",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask = rdm.open(ref_files['mask'])\n",
+    "mask.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63708d3e",
+   "metadata": {},
+   "source": [
+    "We see that the mask file contains metadata and a single array called `dq`. If we display the `dq` array, then we can see all of the features that have been flagged. The [Working with ASDF](../working_with_asdf/working_with_asdf.ipynb) tutorial gives more information about how to parse the meanings of the DQ flags. Let's get basic statistics for this MASK file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "152bd29b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dq = mask.dq\n",
+    "print(f\"DQ array shape: {dq.shape}\")\n",
+    "print(f\"Data type: {dq.dtype}\")\n",
+    "\n",
+    "# Unique DQ values\n",
+    "unique_dq = np.unique(dq)\n",
+    "print(\"\\nUnique DQ values:\", sorted(unique_dq))\n",
+    "\n",
+    "# Overall statistics\n",
+    "total_pixels = dq.size\n",
+    "flagged_pixels = np.sum(dq > 0)\n",
+    "good_pixels = np.sum(dq == 0)\n",
+    "\n",
+    "print(f\"\\nTotal pixels: {total_pixels:,}\")\n",
+    "print(f\"Good pixels (DQ=0): {good_pixels:,} ({good_pixels/total_pixels*100:.2f}%)\")\n",
+    "print(f\"Flagged pixels (DQ>0): {flagged_pixels:,} ({flagged_pixels/total_pixels*100:.2f}%)\")\n",
+    "\n",
+    "# 3. Breakdown by DQ value (only non-zero)\n",
+    "print(\"\\nPixel count by DQ flag:\")\n",
+    "for val in sorted(unique_dq):\n",
+    "    if val > 0:\n",
+    "        count = np.sum(dq == val)\n",
+    "        fraction = count / total_pixels * 100\n",
+    "        print(f\"  DQ = {val:3d}: {count:10,} pixels ({fraction:6.3f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "457798c0",
+   "metadata": {},
+   "source": [
+    "Putting this information in a different way"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3a092d52",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.hist(dq.flatten(), bins=len(unique_dq), edgecolor='black', log=True)\n",
+    "plt.xlabel('DQ Flag Value')\n",
+    "plt.ylabel('Number of Pixels (log scale)')\n",
+    "plt.title('Distribution of DQ Flags in Bad Pixel Mask')\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "\n",
+    "# Optional: annotate the most common flags\n",
+    "for val in unique_dq:\n",
+    "    if val > 0 and np.sum(dq == val) > total_pixels * 0.001:  # only label significant ones\n",
+    "        plt.text(val, np.sum(dq == val)*1.1, str(val), ha='center', fontsize=9)\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf654d4c-522d-473e-b016-6b9a19be539d",
+   "metadata": {},
+   "source": [
+    "Now, let's plot two versions of the file, one with each bitwise sum of DQ flags on a color map and another flattened version with \"good\" (DQ = 0; black pixels in the right-hand panel of the plot below) and \"bad\" (DQ >= 1; white pixels in the right-hand panel of the plot below) flags:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ba0f4ca3-a00b-4c32-90a6-40c406f2b849",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(1, 2, figsize=(14, 14))\n",
+    "\n",
+    "# Make a copy of the colormap so we can reset non-finite numbers to black\n",
+    "my_cmap = copy.copy(cm.get_cmap('nipy_spectral'))\n",
+    "my_cmap.set_bad((0, 0, 0))\n",
+    "\n",
+    "# Display the mask file with a log normalization using the updated color map\n",
+    "im = axs[0].imshow(mask.dq, origin='lower', norm=colors.LogNorm(vmin=1, vmax=5e5), cmap=my_cmap)\n",
+    "divider = make_axes_locatable(axs[0])\n",
+    "cax = divider.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
+    "axs[0].set_xlabel('Science X (pixels)')\n",
+    "axs[0].set_ylabel('Science Y (pixels)')\n",
+    "axs[0].set_title('Color-Coded DQ Flags')\n",
+    "fig.colorbar(im, cax=cax)\n",
+    "\n",
+    "# Display the mask file with boolean good and bad values on a grayscale map\n",
+    "axs[1].imshow(np.bool(mask.dq), origin='lower', cmap='binary_r')\n",
+    "axs[1].set_xlabel('Science X (pixels)')\n",
+    "axs[1].set_ylabel('Science Y (pixels)')\n",
+    "axs[1].set_title('Good vs Bad Flags')\n",
+    "\n",
+    "plt.tight_layout();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d85a644e-96f8-4ba9-8e19-0b4247e04086",
+   "metadata": {},
+   "source": [
+    "Note that not all DQ flags > 0 are necessarily bad. Many DQ flags are informational about detector effects or note something about the data processing. It is important for you to decide what effects are important for your science case."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c9a36d6",
+   "metadata": {},
+   "source": [
+    "## About this Notebook\n",
+    "**Author:** T. Desjardins. & R. Diaz\n",
+    "\n",
+    "**Updated On:** 2026-07-06"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45fb919f",
+   "metadata": {},
+   "source": [
+    "<table width=\"100%\" style=\"border:none; border-collapse:collapse;\">\n",
+    "\n",
+    "  <tr style=\"border:none;\">\n",
+    "    <td style=\"border:none; width:180px; white-space:nowrap;\">\n",
+    "       <a href=\"#top\" style=\"text-decoration:none; color:#0066cc;\"> Top of page</a>\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:center;\">\n",
+    "        <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/roman_logo.png\" alt=\"roman_logo\" width=\"50px\">\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:right;\">\n",
+    "       <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/stsci_logo2.png\" width=\"90\">\n",
+    "    </td>\n",
+    "  </tr>\n",
+    "</table>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "roman_cal",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/crds_reference_files/crds_reference_files.ipynb
+++ b/notebooks/crds_reference_files/crds_reference_files.ipynb
@@ -462,9 +462,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "roman_cal",
+   "display_name": "Roman Research Nexus 2026.2",
    "language": "python",
-   "name": "python3"
+   "name": "roman_cal"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/crds_reference_files/crds_reference_files.ipynb
+++ b/notebooks/crds_reference_files/crds_reference_files.ipynb
@@ -1,0 +1,484 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
+   "metadata": {},
+   "source": [
+    "# Understanding CRDS and How to Select Calibration Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "620243a9-7836-4594-9c0e-c952166fe365",
+   "metadata": {},
+   "source": [
+    "## Kernel Information and Read-Only Status\n",
+    "\n",
+    "To run this notebook, please select \"Roman Research Nexus {VERSION}\" kernel at the top right of your window. For example \"Roman Research Nexus 2026.1\".\n",
+    "\n",
+    "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it.\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e739398-0b70-40fa-8a46-5319d7066c73",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "This notebook will help you understand how the Calibration Reference Data System ([CRDS](https://roman-crds.stsci.edu/static/users_guide/overview.html)) works, how the Roman Calibration Pipeline interacts with this subsystem to get the best reference files for your data, and how to retrieve these files directly from `CRDS` \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1beac9c",
+   "metadata": {},
+   "source": [
+    "### Local Run Settings\n",
+    "\n",
+    "If you want to run the notebook in your local machine, refer to the information in [local installation](../../markdown/local-run.md) instructions before proceeding with the notebook. The instructions provide important information about setting up your environment and installing dependencies."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd1a0491-6dcc-475e-9118-e22a9e2a31c2",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "Libraries used:\n",
+    "- *copy* for making copies of Python objects\n",
+    "- *crds* for access to calibration reference files\n",
+    "- *numpy* for array manipulation\n",
+    "- *roman_datamodels* for opening Roman WFI ASDF files\n",
+    "- *asdf* for opening Roman WFI ASDF files\n",
+    "- *os* for operating system functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53a4bf0b-4a5d-4aa1-974f-fbc5ca87c9c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import copy\n",
+    "\n",
+    "import numpy as np\n",
+    "import roman_datamodels as rdm\n",
+    "#import s3fs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bb19274-2253-455f-b116-f49509ab7c3c",
+   "metadata": {},
+   "source": [
+    "### The Calibration Reference Data System (CRDS)\n",
+    "\n",
+    "The Roman Calibration Pipeline (`RomanCal`), uses calibration reference and parameter files from the [CRDS](https://roman-crds.stsci.edu/static/users_guide/overview.html). These reference files, developed and validated by STScI’s Science Operations Center, are continually updated as new WFI data become available. CRDS assigns the most appropriate reference file for each calibration step using metadata keywords and file-specific matching criteria. To use the best-available reference files for an observation, no action is needed as `RomanCal` will query for the best reference files for each calibration step in the pipeline.\n",
+    "\n",
+    "To do this independently we will use the **[`crds`](https://roman-crds.stsci.edu/static/users_guide/index.html)** Python application programming interface (API); however, the [**CRDS** webserver](https://roman-crds.stsci.edu) can also be accessed to browse calibration reference files in a tabular interface. Note that there are multiple CRDS servers, though most users will interact with the Operations (OPS) instance. Please be sure to navigate to the correct webserver for the instance in which you are interested.\n",
+    "\n",
+    "For more details, see the [RDox page on CRDS for Roman WFI](https://roman-docs.stsci.edu/data-handbook-home/accessing-wfi-data/crds-for-reference-files) and the [CRDS documentation](https://jwst-crds.stsci.edu/static/users_guide/web_site_use.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8fcb955",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import crds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "106dcea6",
+   "metadata": {},
+   "source": [
+    "Check your environment. If running the notebook in Nexus, these CRDS environment variables would be already configured. If running locally and not currently set up, don't worry, we will select the CRDS context later in the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b6d10ccd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"CRDS_SERVER_URL:\", os.environ.get('CRDS_SERVER_URL'))\n",
+    "print(\"CRDS_CONTEXT:\", os.environ.get('CRDS_CONTEXT'))\n",
+    "print(\"CRDS_PATH:\", os.environ.get('CRDS_PATH'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80b3db81-1b7a-448f-a462-16eff6ed8f9a",
+   "metadata": {},
+   "source": [
+    "### Retrieving Reference Files\n",
+    "\n",
+    "As you run the exposure or mosaic pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, these can be retrieved through the `crds` Python API and stored localy to be used later in a particular calibraton step  (more on that later). Let's begin with how to access reference files from CRDS.\n",
+    "\n",
+    "First, let's begin with how to access reference files from CRDS. For that we will use the `crds.getrecommendations()` function. This function returns a dictionary with the basenames of the reference files that match the criteria that you supply. In this case, the files are not downloaded.\n",
+    "\n",
+    "In this function, the selection criteria are specified in a dictionary of key-value pairs, where eacb Roman WFI metadata keyword in the dictionary is all-caps and always begins with \"ROMAN.META.\". The remaining parts of the string correspond to the metadata keyword locations in the science data file schema. To lear more about Science Products Schemas refer to the [Roman Atribute Dictionary](https://rad.readthedocs.io/en/latest/schemas.html).\n",
+    "\n",
+    "Different reference file types require different combinations of science metadata to match to the reference files. In general, all reference file types will require the instrument name (\"INSTRUMENT.NAME\") and start time (\"EXPOSURE.START_TIME\"). Most file types require the detector name (\"INSTRUMENT.DETECTOR\"), and some file types require the exposure type (\"EXPOSURE.TYPE\") or optical element (\"INSTRUMENT.OPTICAL_ELEMENT\").\n",
+    "\n",
+    "For example, for the mask and flat files, the required keywords are:\n",
+    "- mask\n",
+    "    - ROMAN.META.INSTRUMENT.NAME\n",
+    "    - ROMAN.META.INSTRUMENT.DETECTOR\n",
+    "    - ROMAN.META.EXPOSURE.START_TIME\n",
+    "- flat\n",
+    "    - ROMAN.META.INSTRUMENT.NAME\n",
+    "    - ROMAN.META.INSTRUMENT.DETECTOR\n",
+    "    - ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT\n",
+    "    - ROMAN.META.EXPOSURE.START_TIME\n",
+    "\n",
+    "These keywords may be combined into a single dictionary to find multiple reference file types using `crds.getreferences()`. This function returns full local paths and downloads or caches if missing. For example, if you would like to find the name of the dark and flat reference files used by the pipeline, and download them, you could run the following example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8f3dc8a-bcb3-4948-8d6d-0ccf99c2ac6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "        'ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT': 'F158',\n",
+    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "       }\n",
+    "\n",
+    "ref_files = crds.getrecommendations(meta, reftypes=['mask', 'flat'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99ec8fd5-c73a-488a-86ad-52d032dd543c",
+   "metadata": {},
+   "source": [
+    "The `ref_files` variable now contains a dictionary for each of the reference file types you requested (MASK and FLAT). These are the reference files that correspond to a science observation taken at midnight UTC on January 1, 2026 in the WFI imaging mode with optical element F158 and detector WFI01. Let's take a look at the names of the files CRDS returned:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db5933f4-2af7-4106-b2ab-a89b7a8fd7f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2916910d-6152-4db7-abfd-e69a3d3e8eac",
+   "metadata": {},
+   "source": [
+    "We can also use `crds.getreferences()` to accomplish the same thing; however, `getreferences()` goes one step further beyond `getrecommendations()` and will download the reference files if they are not already in your local cache. Using the same example as above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b09c9bd3-57a5-4fbf-87ce-ebcf22ac999a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "        'ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT': 'F158',\n",
+    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "       }\n",
+    "\n",
+    "ref_files = crds.getreferences(meta, reftypes=['mask', 'flat'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a60dab9f-c70d-44cb-b6b8-932918e97e49",
+   "metadata": {},
+   "source": [
+    "And once again we can examine the output of `ref_files`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ffe7a81-c9cf-4750-a962-41a52dff27fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9d7dd229-a1a7-4455-b020-b224a9c8af7d",
+   "metadata": {},
+   "source": [
+    "This time, `ref_files` contains the path to the file in the local cache (controlled by the `CRDS_PATH` environment variable) since we did not simply ask for the file name but also checked if the file was in our cache, and if it was not then we downloaded it.\n",
+    "\n",
+    "### CRDS Mapping Files\n",
+    "\n",
+    "CRDS organizes the reference files using mapping files: the PMAP file, the IMAP files, and tje RMAP files. The first and most important mapping file is the PMAP file (commonly referred to as the CRDS context). This file is set by the the `CRDS_CONTEXT` environment variable. It provides a way to identify to the full set of reference files that each step of the `RomanCal` pipeline will use at a given time. By using the reference files tied to the same PMAP, you ensure compatibility between reference files.\n",
+    "\n",
+    "If not already set, we can select a particular context with the following command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c490cdb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['CRDS_CONTEXT']='roman_0055.pmap'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3e6d3b0",
+   "metadata": {},
+   "source": [
+    "Let's check again our environment variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b2ea7787-8c96-4f33-97b3-bd50609c9ef9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"CRDS server location: {os.environ.get('CRDS_SERVER_URL')}\")\n",
+    "print(f\"CRDS context file: {os.environ.get('CRDS_CONTEXT')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1a8f79fb",
+   "metadata": {},
+   "source": [
+    "We can see that the PMAP was correctly set.\n",
+    "\n",
+    "The IMAP is the second tier of mapping files. It contains the full set of reference types applicable to a giver instrument and available for use by `RomanCal`. For WFI, a particular version of the IMAP provides a list of all the reference file types used by `RomanCal` to calibrate that instrument, along with the RMAP versions part of the selected context. \n",
+    "\n",
+    "The RMAP is the third tier of mapping files. It provides the full list of reference files active with a given context, along with the selection parameters for that particular reference file type, which matches them to science observations. An RMAP includes the versions of the reference file that is part of that context.\n",
+    "\n",
+    "From the user point of view, only the PMAP or context file needs to be set. Note, however, that the context is also CRDS server-dependent and is set by the environment variable `CRDS_SERVER_URL`. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d4bfb5ba",
+   "metadata": {},
+   "source": [
+    "Let's explore the set of maping associated with our selected context."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0595a02a-2b18-48ed-ab94-0324a58023f6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "maps = pmap.mapping_names()\n",
+    "print(maps)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d9f0791-745a-4510-929b-103dbd9db28f",
+   "metadata": {},
+   "source": [
+    "For more information on the mapping rules, see the [readthedocs documentation](https://roman-crds.stsci.edu/static/users_guide/rmap_syntax.html). "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d28c1634-b530-48d4-83a5-baaad241c73a",
+   "metadata": {},
+   "source": [
+    "Now let's isolate the names of the MASK files in the associated RMAP."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aaa9b0d9-f49e-4bc6-b2fd-1bd76ec8fc7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for m in maps:\n",
+    "    if 'mask' in m:\n",
+    "        mask_rmap = m \n",
+    "        break\n",
+    "    else:\n",
+    "        pass\n",
+    "\n",
+    "masks = crds.rmap.load_mapping(mask_rmap)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ac06519-5fb8-47c4-a952-ffc5c15e9877",
+   "metadata": {},
+   "source": [
+    "Now that we have loaded up the list of MASK files in the applicable RMAP, let's take a look at it using the `todict()` method to turn it into a dictionary we can more easily visualize:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e0628107-18a9-47c7-a0c9-58f4aa01aa34",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "masks.todict()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1beb51f1-3e83-4f00-b95d-375fd6fa4226",
+   "metadata": {},
+   "source": [
+    "As we can see, the `parkey` key in the RMAP tells us the matching criteria unique to this reference file type from the dictionary we created when we used `crds.getrecommendations()` and `crds.getreferences()`. Also notice that the `parameters` field tells us the column names for the `selections` part of the dictionary. In this case, we see they include:\n",
+    "\n",
+    "    \"ROMAN.META.INSTRUMENT.DETECTOR\"\n",
+    "    \"USEAFTER\"\n",
+    "    \"REFERENCE\".     \n",
+    "\n",
+    "The REFERENCE column is simply the name of the reference file that matches those critiera. The USEAFTER date is the date after which a file should be used for a science observation. \n",
+    "CRDS will match the file with the closest **preceding** USEAFTER date to the science observation date (given by \"ROMAN.META.EXPOSURE.START_TIME\")."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "07b7a3f5-57df-47bc-af5c-fc64812ffa06",
+   "metadata": {},
+   "source": [
+    "### Download a File by Name\n",
+    "\n",
+    "If you know the specific reference file name and would like to download it directly from the CRDS on-premise server, you can call it via a command line option:\n",
+    "\n",
+    "```\n",
+    "crds sync --files <filename> --output-dir=<pathname>\n",
+    "```\n",
+    "\n",
+    "where `<filename>` is the name of the reference file (e.g. \"roman_wfi_mask_0022.asdf\") and `<pathname>` is the location where the file will be saved. **Note:** in the future, Roman reference files will also be available via an AWS S3 bucket, and these instructions will be updated to describe how to access them there. \n",
+    "\n",
+    "To run this in a Jupyter notebook, we write out the command as a string and pass it to the command line script code:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fd7b8142-d912-419a-ba43-635beb87995a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cmd = f\"crds.sync --files {ref_files['mask']}\"\n",
+    "_ = crds.sync.SyncScript(cmd)()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44b65450-a2e1-40c6-ab75-144c28480778",
+   "metadata": {},
+   "source": [
+    "In this case, nothing happened since we had already previously downloaded this file into our cache using `crds.getreferences()`. But if you know the file name of a reference file that you want to retrieve from CRDS without using the matching criteria, the cell above would download the file to your cache. Simply replace `{ref_files['mask']}` in the `cmd` string with the name of the ASDF file.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80ad3211-188d-45ef-b5f1-2ef6bf466450",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mask = rdm.open(ref_files['mask'])\n",
+    "mask.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "24865974",
+   "metadata": {},
+   "source": [
+    "## What is Next \n",
+    "* Understand and Explore the [Bad Pixels Mask](bad_pixels_mask_reffile.ipynb) reference file.\n",
+    "* Understand and Explore the [Dark](dark_reffile.ipynb) reference file.\n",
+    "* Understand and Explore the [Flat Field](flat_reffile.ipynb) reference file.\n",
+    "\n",
+    "----\n",
+    "\n",
+    "## Additional Resources\n",
+    "Additional information can be found at the following links:\n",
+    "\n",
+    "??????"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c9a36d6",
+   "metadata": {},
+   "source": [
+    "## About this Notebook\n",
+    "**Author:** R. Diaz, T. Desjardins.\n",
+    "\n",
+    "**Updated On:** 2026-07-02"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45fb919f",
+   "metadata": {},
+   "source": [
+    "<table width=\"100%\" style=\"border:none; border-collapse:collapse;\">\n",
+    "\n",
+    "  <tr style=\"border:none;\">\n",
+    "    <td style=\"border:none; width:180px; white-space:nowrap;\">\n",
+    "       <a href=\"#top\" style=\"text-decoration:none; color:#0066cc;\"> Top of page</a>\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:center;\">\n",
+    "        <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/roman_logo.png\" alt=\"roman_logo\" width=\"50px\">\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:right;\">\n",
+    "       <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/stsci_logo2.png\" width=\"90\">\n",
+    "    </td>\n",
+    "  </tr>\n",
+    "</table>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "roman_cal",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/crds_reference_files/dark_reffile.ipynb
+++ b/notebooks/crds_reference_files/dark_reffile.ipynb
@@ -1,0 +1,487 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
+   "metadata": {},
+   "source": [
+    "# Understanding the Roman WFI Dark Current Reference File "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "620243a9-7836-4594-9c0e-c952166fe365",
+   "metadata": {},
+   "source": [
+    "## Kernel Information and Read-Only Status\n",
+    "\n",
+    "To run this notebook, please select \"Roman Research Nexus {VERSION}\" kernel at the top right of your window. For example \"Roman Research Nexus 2026.1\".\n",
+    "\n",
+    "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it.\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e739398-0b70-40fa-8a46-5319d7066c73",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "The purpose of this notebook is to understand the content and purpose of the **Dark Current** (`DARK`) reference file.\n",
+    "\n",
+    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1beac9c",
+   "metadata": {},
+   "source": [
+    "### Local Run Settings\n",
+    "\n",
+    "If you want to run the notebook in your local machine, refer to the information in [local installation](../../markdown/local-run.md) instructions before proceeding with the notebook. The instructions provide important information about setting up your environment and installing dependencies."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd1a0491-6dcc-475e-9118-e22a9e2a31c2",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "Libraries used:\n",
+    "- *astropy* for image normalization\n",
+    "- *copy* for making copies of Python objects\n",
+    "- *crds* for access to calibration reference files\n",
+    "- *matplotlib* and *mpl_toolkits* for plotting images\n",
+    "- *numpy* for array manipulation\n",
+    "- *roman_datamodels* for opening Roman WFI ASDF files\n",
+    "- *asdf* for opening Roman WFI ASDF files\n",
+    "- *os* for operating system functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "53a4bf0b-4a5d-4aa1-974f-fbc5ca87c9c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from astropy.visualization import simple_norm\n",
+    "import copy\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import colors, colormaps as cm\n",
+    "from mpl_toolkits.axes_grid1 import make_axes_locatable\n",
+    "import numpy as np\n",
+    "import roman_datamodels as rdm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bb19274-2253-455f-b116-f49509ab7c3c",
+   "metadata": {},
+   "source": [
+    "### The Calibration Reference Data System (CRDS)\n",
+    "\n",
+    "The reference files, developed and validated by STScI’s Science Operations Center, are continually updated as new WFI data become available. For more information about how CRDS works and how it assigns the most appropriate reference file for each calibration step, refer to the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb). \n",
+    "\n",
+    "**IMPORTANT NOTE:** Reference files are a work in progress and will be updated several times before Roman launch. If you notice irregularities or missing information, please understand that they may be a known issue. If you have questions, please contact the [Roman Help Desk](https://romanhelp.stsci.edu)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "b8fcb955",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import crds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fce2f6d",
+   "metadata": {},
+   "source": [
+    "Now let's dive into this reference file type."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11b5ca61-dfe0-4031-8f4d-172f4a135b52",
+   "metadata": {},
+   "source": [
+    "### Darks \n",
+    "\n",
+    "The DARK reference file is selected based on the WFI mode (imaging or spectroscopy) used to obtain the science data. During the `romancal.dark_current.DarkCurrentStep()` step, the dark current is subtracted on a pixel-by-pixel and resultant-by-resultant basis. Pixels that are undefined in the dark reference file will not be subtracted from the science data.\n",
+    "\n",
+    "The dark reference files are created from dark calibration datasets.  A set of dark files are sigma clipped, and stacked resultant-by-resultant to create a super dark.\n",
+    "\n",
+    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/dark_current/index.html) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook-home/roman-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-dark_current) for dark current subtraction.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eec6339e",
+   "metadata": {},
+   "source": [
+    "Before proceeding, let's check the environmental variables set for CRDS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "89da1bcd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"CRDS server location: {os.environ.get('CRDS_SERVER_URL')}\")\n",
+    "print(f\"CRDS context file: {os.environ.get('CRDS_CONTEXT')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e2646d0",
+   "metadata": {},
+   "source": [
+    "If we want to change the context, we can do it in the next cell. In this case, we choose context `roman_0055.pmap`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "eb9d4df5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['CRDS_CONTEXT']='roman_0055.pmap'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b9d0830",
+   "metadata": {},
+   "source": [
+    "### Retrieving Reference Files\n",
+    "\n",
+    "As you run the exposure pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, these can be retrieved through the `crds` Python API and the ELP run with those files (more on that later). Let's begin with how to access reference files from CRDS.\n",
+    "\n",
+    "First, let's start by looking at the `crds.getrecommendations()` function. This function returns a dictionary of file names that match the criteria that you supply. Selection criteria are specified in a dictionary of key-value pairs. Each Roman WFI metadata keyword in the dictionary is all-caps and always begins with \"ROMAN.META.\". The remaining parts of the string correspond to the metadata keyword locations in the science data file schema. Different reference file types require different combinations of science metadata to match to the reference files. In general, all reference file types will require the instrument name (\"INSTRUMENT.NAME\") and start time (\"EXPOSURE.START_TIME\"). Most file types require the detector name (\"INSTRUMENT.DETECTOR\"), and some file types require the exposure type (\"EXPOSURE.TYPE\") or optical element (\"INSTRUMENT.OPTICAL_ELEMENT\").\n",
+    "\n",
+    "For the dark files in particular, the required keywords are:\n",
+    "- dark\n",
+    "    - ROMAN.META.INSTRUMENT.NAME\n",
+    "    - ROMAN.META.INSTRUMENT.DETECTOR\n",
+    "    - ROMAN.META.EXPOSURE.TYPE\n",
+    "    - ROMAN.META.EXPOSURE.START_TIME\n",
+    "\n",
+    "These keywords may be combined into a single dictionary to find multiple reference file types using `crds.getreferences()`. For example, if you would like to find the names of the dark reference files used by the pipeline, you could run the following example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b8f3dc8a-bcb3-4948-8d6d-0ccf99c2ac6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "        'ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT': 'F158',\n",
+    "        'ROMAN.META.EXPOSURE.TYPE': 'WFI_IMAGE',\n",
+    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "       }\n",
+    "\n",
+    "ref_files = crds.getrecommendations(meta, reftypes=['dark'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99ec8fd5-c73a-488a-86ad-52d032dd543c",
+   "metadata": {},
+   "source": [
+    "The `ref_files` variable now contains a dictionary for each of the `DARK` reference file you requested. These are the reference files that correspond to a science observation taken at midnight UTC on January 1, 2026 in the WFI imaging mode with optical element F158 and detector WFI01. Let's take a look at the names of the files CRDS returned:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "db5933f4-2af7-4106-b2ab-a89b7a8fd7f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2916910d-6152-4db7-abfd-e69a3d3e8eac",
+   "metadata": {},
+   "source": [
+    "We can also use `crds.getreferences()` to accomplish the same thing; however, `getreferences()` goes one step further beyond `getrecommendations()` and will download the reference files if they are not already in your local cache. Using the same example as above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "b09c9bd3-57a5-4fbf-87ce-ebcf22ac999a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "        'ROMAN.META.EXPOSURE.TYPE': 'WFI_IMAGE',\n",
+    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "       }\n",
+    "\n",
+    "ref_files = crds.getreferences(meta, reftypes=['dark'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a60dab9f-c70d-44cb-b6b8-932918e97e49",
+   "metadata": {},
+   "source": [
+    "And once again we can examine the output of `ref_files`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "9ffe7a81-c9cf-4750-a962-41a52dff27fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44b65450-a2e1-40c6-ab75-144c28480778",
+   "metadata": {},
+   "source": [
+    "### Examining Reference Files\n",
+    "\n",
+    "Reference files use `roman_datamodels` just like WFI science data products and can be accessed in the same way (see the tutorial [Working with ASDF](../working_with_asdf/working_with_asdf.ipynb) for more information). Let's take a closer look at the files we retrieved from our `crds.getreferences()` example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "80ad3211-188d-45ef-b5f1-2ef6bf466450",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dark = rdm.open(ref_files['dark'])\n",
+    "dark.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "021a3635-5642-48b8-9c96-f4a6f9d758ee",
+   "metadata": {},
+   "source": [
+    "We see that the dark reference file contains metadata plus several arrays:\n",
+    "- The `data` array contains a cube of dark values up-the-ramp. This is used in the current version of the Exposure Pipeline, however changes are being made towards a dark rate subtraction post-ramp-fitting. \n",
+    "- The `dark_slope` array contains the dark rate per pixel\n",
+    "- The `dark_slope_error` contains the uncertainty in the dark rate. \n",
+    "- The `dq` array is present to flag effects in the dark current (such as hot pixels)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "868eed54-c552-4324-bae3-4622ef81c4a9",
+   "metadata": {},
+   "source": [
+    "Let's take a look at the dark for this detector. First, lets check the shape of the data array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "30f444a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"dark.data shape:\", dark.data.shape)\n",
+    "print(\"dark.dq shape:\", dark.dq.shape)\n",
+    "print(\"dark.dark_slope shape:\", getattr(dark, 'dark_slope', None).shape if hasattr(dark, 'dark_slope') else \"No dark_slope\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4f0262f",
+   "metadata": {},
+   "source": [
+    "Now lets get some basic statistics on the cube (or a representative slice)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "86caf99b",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'refpix' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
+      "\u001b[31mNameError\u001b[39m                                 Traceback (most recent call last)",
+      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[1]\u001b[39m\u001b[32m, line 2\u001b[39m\n\u001b[32m      1\u001b[39m \u001b[38;5;66;03m# Example: inspect one of the coefficient arrays (adjust name after checking .info())\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m2\u001b[39m \u001b[38;5;28;01mif\u001b[39;00m hasattr(refpix, \u001b[33m'alpha'\u001b[39m) \u001b[38;5;28;01mand\u001b[39;00m refpix.alpha \u001b[38;5;28;01mis\u001b[39;00m \u001b[38;5;28;01mnot\u001b[39;00m \u001b[38;5;28;01mNone\u001b[39;00m:\n\u001b[32m      3\u001b[39m     coeff = refpix.alpha\n\u001b[32m      4\u001b[39m     print(\u001b[33m\"\\nStatistics for alpha coefficients:\"\u001b[39m)\n\u001b[32m      5\u001b[39m     print(\"  Min:\", coeff.min(), \"Max:\", coeff.max(),\n",
+      "\u001b[31mNameError\u001b[39m: name 'refpix' is not defined"
+     ]
+    }
+   ],
+   "source": [
+    "# Example: inspect one of the coefficient arrays (adjust name after checking .info())\n",
+    "if hasattr(refpix, 'alpha') and refpix.alpha is not None:\n",
+    "    coeff = refpix.alpha\n",
+    "    print(\"\\nStatistics for alpha coefficients:\")\n",
+    "    print(\"  Min:\", coeff.min(), \"Max:\", coeff.max(),\n",
+    "          \"Mean:\", coeff.mean(), \"Std:\", coeff.std())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44fec9cb",
+   "metadata": {},
+   "source": [
+    "Note that in this case the pre-launch darks are all zero, so the plot will be rather flat."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "437d9346",
+   "metadata": {},
+   "source": [
+    "Let's get a quick histogram of a slice:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "2c76715a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(8,5))\n",
+    "plt.hist(data_slice.flatten(), bins=100, range=(data_slice.min(), np.percentile(data_slice, 99.5)), log=True)\n",
+    "plt.xlabel('Dark Current Value')\n",
+    "plt.ylabel('Pixel Count (log)')\n",
+    "plt.title('Pixel Value Distribution (slice)')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b893996",
+   "metadata": {},
+   "source": [
+    "Note: In flight data the dark current will be non-zero and these visualizations\n",
+    "will show clear structure (hot pixels, gradients, etc.).\n",
+    "\n",
+    "Now let's check the dark image"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "f732d453-7394-4fec-b0e9-e9111a243e63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(1, 3, figsize=(18, 6))  # Add a third panel for dark_slope if available\n",
+    "\n",
+    "slice_idx = 10  # You can change this index to visualize a different slice of the dark current data\n",
+    "data_slice = dark.data[slice_idx]\n",
+    "\n",
+    "my_cmap = copy.copy(cm.get_cmap('nipy_spectral'))\n",
+    "my_cmap.set_bad('black')\n",
+    "\n",
+    "norm = simple_norm(data_slice, stretch='sqrt', percent=99.5, min_percent=0.5)\n",
+    "\n",
+    "im0 = axs[0].imshow(data_slice, cmap=my_cmap, norm=norm, origin='lower')\n",
+    "divider = make_axes_locatable(axs[0])\n",
+    "cax = divider.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
+    "fig.colorbar(im0, cax=cax, label='DN/s or electrons')\n",
+    "axs[0].set_title(f'Dark Current (slice {slice_idx})')\n",
+    "\n",
+    "# DQ panel\n",
+    "axs[1].imshow(np.bool_(dark.dq), cmap='binary_r', origin='lower')\n",
+    "axs[1].set_title('Dark Current DQ Flags')\n",
+    "\n",
+    "# dark_slope (rate image) \n",
+    "if hasattr(dark, 'dark_slope') and dark.dark_slope is not None:\n",
+    "    slope_norm = simple_norm(dark.dark_slope, stretch='sqrt', percent=99)\n",
+    "    im2 = axs[2].imshow(dark.dark_slope, cmap=my_cmap, norm=slope_norm, origin='lower')\n",
+    "    divider2 = make_axes_locatable(axs[2])\n",
+    "    cax2 = divider2.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
+    "    fig.colorbar(im2, cax=cax2, label='DN/s or electrons')\n",
+    "    axs[2].set_title('Dark Slope (Rate)')\n",
+    "\n",
+    "for ax in axs:\n",
+    "    ax.set_xlabel('Science X (pixels)')\n",
+    "    ax.set_ylabel('Science Y (pixels)')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c9a36d6",
+   "metadata": {},
+   "source": [
+    "## About this Notebook\n",
+    "**Author:** T. Desjardins & R. Diaz\n",
+    "\n",
+    "**Updated On:** 2026-07-06"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45fb919f",
+   "metadata": {},
+   "source": [
+    "<table width=\"100%\" style=\"border:none; border-collapse:collapse;\">\n",
+    "\n",
+    "  <tr style=\"border:none;\">\n",
+    "    <td style=\"border:none; width:180px; white-space:nowrap;\">\n",
+    "       <a href=\"#top\" style=\"text-decoration:none; color:#0066cc;\"> Top of page</a>\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:center;\">\n",
+    "        <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/roman_logo.png\" alt=\"roman_logo\" width=\"50px\">\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:right;\">\n",
+    "       <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/stsci_logo2.png\" width=\"90\">\n",
+    "    </td>\n",
+    "  </tr>\n",
+    "</table>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "roman_cal",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/crds_reference_files/distortion_reffile.ipynb
+++ b/notebooks/crds_reference_files/distortion_reffile.ipynb
@@ -1,0 +1,460 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
+   "metadata": {},
+   "source": [
+    "# Understanding the Roman WFI Distortion Reference File"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "620243a9-7836-4594-9c0e-c952166fe365",
+   "metadata": {},
+   "source": [
+    "## Kernel Information and Read-Only Status\n",
+    "\n",
+    "To run this notebook, please select \"Roman Research Nexus {VERSION}\" kernel at the top right of your window. For example \"Roman Research Nexus 2026.1\".\n",
+    "\n",
+    "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it.\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e739398-0b70-40fa-8a46-5319d7066c73",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "The purpose of this notebook is to understand the content and purpose of the **Distortion** (`DISTORTION`) reference file.\n",
+    "\n",
+    "This file contains the astrometric distortion model used by the `romancal.assign_wcs` step to convert between detector coordinates and world (sky) coordinates. It is critical for accurate astrometry and mosaicking.\n",
+    "\n",
+    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1beac9c",
+   "metadata": {},
+   "source": [
+    "### Local Run Settings\n",
+    "\n",
+    "If you want to run the notebook in your local machine, refer to the information in [local installation](../../markdown/local-run.md) instructions before proceeding with the notebook. The instructions provide important information about setting up your environment and installing dependencies."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd1a0491-6dcc-475e-9118-e22a9e2a31c2",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "Libraries used:\n",
+    "- *astropy* for image normalization\n",
+    "- *copy* for making copies of Python objects\n",
+    "- *crds* for access to calibration reference files\n",
+    "- *matplotlib* and *mpl_toolkits* for plotting images\n",
+    "- *numpy* for array manipulation\n",
+    "- *roman_datamodels* for opening Roman WFI ASDF files\n",
+    "- *asdf* for opening Roman WFI ASDF files\n",
+    "- *os* for operating system functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53a4bf0b-4a5d-4aa1-974f-fbc5ca87c9c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from astropy.visualization import simple_norm\n",
+    "import copy\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import colors, colormaps as cm\n",
+    "from mpl_toolkits.axes_grid1 import make_axes_locatable\n",
+    "import numpy as np\n",
+    "import roman_datamodels as rdm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bb19274-2253-455f-b116-f49509ab7c3c",
+   "metadata": {},
+   "source": [
+    "### The Calibration Reference Data System (CRDS)\n",
+    "\n",
+    "The reference files, developed and validated by STScI’s Science Operations Center, are continually updated as new WFI data become available. For more information about how CRDS works and how it assigns the most appropriate reference file for each calibration step, refer to the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb). \n",
+    "\n",
+    "**IMPORTANT NOTE:** Reference files are a work in progress and will be updated several times before Roman launch. If you notice irregularities or missing information, please understand that they may be a known issue. If you have questions, please contact the [Roman Help Desk](https://romanhelp.stsci.edu).\n",
+    "\n",
+    "To make use of `CRDS` functionality, we need to import the whole package. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8fcb955",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import crds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fce2f6d",
+   "metadata": {},
+   "source": [
+    "Now let's dive into this reference file type."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11b5ca61-dfe0-4031-8f4d-172f4a135b52",
+   "metadata": {},
+   "source": [
+    "### Distortion Reference File\n",
+    "\n",
+    "The DISTORTION reference file is used in the `assign_wcs` step to model geometric distortions of the WFI optics. It is typically an Astropy `CompoundModel` containing polynomial or SIP (Simple Imaging Polynomial) transformations.\n",
+    "\n",
+    "For more details, see the [romancal assign_wcs documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/assign_wcs/index.html) and\n",
+    "[Rdox documentation](https://roman-docs.stsci.edu/data-handbook/roman-wfi-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-assign_wcs) for the WCS assignment.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eec6339e",
+   "metadata": {},
+   "source": [
+    "Before proceeding, let's check the environmental variables set for CRDS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89da1bcd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"CRDS server location: {os.environ.get('CRDS_SERVER_URL')}\")\n",
+    "print(f\"CRDS context file: {os.environ.get('CRDS_CONTEXT')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e2646d0",
+   "metadata": {},
+   "source": [
+    "If we want to change the context, we can do it in the next cell. In this case, we choose context `roman_0055.pmap`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb9d4df5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['CRDS_CONTEXT']='roman_0055.pmap'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b9d0830",
+   "metadata": {},
+   "source": [
+    "### Retrieving Reference Files\n",
+    "\n",
+    "As you run the exposure pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, these can be retrieved through the `crds` Python API.\n",
+    "\n",
+    "For the REFPIX files, the required keywords are typically:\n",
+    "- `ROMAN.META.INSTRUMENT.NAME`\n",
+    "- `ROMAN.META.INSTRUMENT.DETECTOR`\n",
+    "- `ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT`\n",
+    "- `ROMAN.META.EXPOSURE.TYPE`\n",
+    "- `ROMAN.META.EXPOSURE.START_TIME`\n",
+    "\n",
+    "These keywords may be combined into a single dictionary that is later fed to the  `crds.getrecommendations` function. This function returns a dictionary of file names that match the criteria that you supply. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8f3dc8a-bcb3-4948-8d6d-0ccf99c2ac6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {\n",
+    "    'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "    'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "    'ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT': 'F158',\n",
+    "    'ROMAN.META.EXPOSURE.TYPE': 'WFI_IMAGE',\n",
+    "    'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "}\n",
+    "\n",
+    "ref_files = crds.getreferences(meta, reftypes=['distortion'], observatory='roman')\n",
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2916910d-6152-4db7-abfd-e69a3d3e8eac",
+   "metadata": {},
+   "source": [
+    "We can also use `crds.getreferences()` to accomplish the same thing; however, `getreferences()` goes one step further beyond `getrecommendations()` and will download the reference files if they are not already in your local cache. Using the same example as above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b09c9bd3-57a5-4fbf-87ce-ebcf22ac999a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files = crds.getreferences(meta, reftypes=['distortion'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a60dab9f-c70d-44cb-b6b8-932918e97e49",
+   "metadata": {},
+   "source": [
+    "And once again we can examine the output of `ref_files`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ffe7a81-c9cf-4750-a962-41a52dff27fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44b65450-a2e1-40c6-ab75-144c28480778",
+   "metadata": {},
+   "source": [
+    "### Examining Reference Files\n",
+    "\n",
+    "Reference files use `roman_datamodels` just like WFI science data products. Let's take a closer look at the DISTORTION reference file:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80ad3211-188d-45ef-b5f1-2ef6bf466450",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dist = rdm.open(ref_files['distortion'])\n",
+    "dist.info(max_rows=200)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "021a3635-5642-48b8-9c96-f4a6f9d758ee",
+   "metadata": {},
+   "source": [
+    "The Distortion reference file contains metadata and an Astropy model - the Distortion Transform Model representing the transform from detector to the telescope V2, V3 system. Let's inspect the model:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82916180",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = dist.coordinate_distortion_transform\n",
+    "print(\"=== Full Model Representation ===\")\n",
+    "print(model)\n",
+    "\n",
+    "print(\"\\n=== Model Parameters ===\")\n",
+    "print(model.parameters)\n",
+    "\n",
+    "print(\"\\n=== Model Components ===\")\n",
+    "for i, submodel in enumerate(model):\n",
+    "    print(f\"Component {i}: {submodel}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3f746526",
+   "metadata": {},
+   "source": [
+    "### Basic Statistics\n",
+    "We can also get some basic statistics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60a89d4e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Distortion statistics:\")\n",
+    "print(f\"  Mean offset X: {dx.mean():.4f} pixels\")\n",
+    "print(f\"  Mean offset Y: {dy.mean():.4f} pixels\")\n",
+    "print(f\"  Max distortion: {dist_mag.max():.4f} pixels\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4f0262f",
+   "metadata": {},
+   "source": [
+    "### Visualizing the Distortion\n",
+    "\n",
+    "We can evaluate the model on a representative grid."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1c99c40a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Evaluate the model on a grid to create distortion maps\n",
+    "# (downsampled for speed)\n",
+    "ny, nx = 4088, 4088\n",
+    "step = 10  # adjust for resolution vs speed\n",
+    "y, x = np.mgrid[0:ny:step, 0:nx:step]\n",
+    "\n",
+    "# Apply the model \n",
+    "x_corr, y_corr = model(x, y)\n",
+    "\n",
+    "dx = x_corr - x\n",
+    "dy = y_corr - y\n",
+    "dist_mag = np.hypot(dx, dy)\n",
+    "\n",
+    "print(f\"Distortion magnitude range: {dist_mag.min():.4f} — {dist_mag.max():.4f} pixels\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a0bcd4d6",
+   "metadata": {},
+   "source": [
+    "Now, let's plot the distortion magnitude map (X and Y offsets) grid"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86caf99b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot distortion magnitude map\n",
+    "plt.figure(figsize=(10, 8))\n",
+    "plt.imshow(dist_mag, origin='lower', cmap='viridis', extent=[0, nx, 0, ny])\n",
+    "plt.colorbar(label='Distortion magnitude (pixels)')\n",
+    "plt.title('Distortion Map (evaluated from coordinate_distortion_transform)')\n",
+    "plt.xlabel('X (pixels)')\n",
+    "plt.ylabel('Y (pixels)')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "437d9346",
+   "metadata": {},
+   "source": [
+    "Finally, let's get a view as a vector field"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b66c34ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Vector field with strong scaling + normalization\n",
+    "plt.figure(figsize=(11, 9))\n",
+    "\n",
+    "step_vec = 2  # adjust density\n",
+    "\n",
+    "# Normalize vector length for visibility\n",
+    "scale_factor = 90000   # tune this number (higher = shorter arrows)\n",
+    "\n",
+    "plt.quiver(x[::step_vec, ::step_vec], \n",
+    "           y[::step_vec, ::step_vec],\n",
+    "           dx[::step_vec, ::step_vec], \n",
+    "           dy[::step_vec, ::step_vec],\n",
+    "           scale=scale_factor,  \n",
+    "           color='cyan', \n",
+    "           alpha=0.85, \n",
+    "           width=0.003,\n",
+    "           headwidth=3)\n",
+    "\n",
+    "plt.title('Distortion Vector Field\\n(arrows scaled for visibility)')\n",
+    "plt.xlabel('X (pixels)')\n",
+    "plt.ylabel('Y (pixels)')\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c9a36d6",
+   "metadata": {},
+   "source": [
+    "## About this Notebook\n",
+    "**Author:** T. Desjardins & R. Diaz\n",
+    "\n",
+    "**Updated On:** 2026-07-06"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45fb919f",
+   "metadata": {},
+   "source": [
+    "<table width=\"100%\" style=\"border:none; border-collapse:collapse;\">\n",
+    "\n",
+    "  <tr style=\"border:none;\">\n",
+    "    <td style=\"border:none; width:180px; white-space:nowrap;\">\n",
+    "       <a href=\"#top\" style=\"text-decoration:none; color:#0066cc;\"> Top of page</a>\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:center;\">\n",
+    "        <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/roman_logo.png\" alt=\"roman_logo\" width=\"50px\">\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:right;\">\n",
+    "       <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/stsci_logo2.png\" width=\"90\">\n",
+    "    </td>\n",
+    "  </tr>\n",
+    "</table>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "roman_cal",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/crds_reference_files/distortion_reffile.ipynb
+++ b/notebooks/crds_reference_files/distortion_reffile.ipynb
@@ -201,42 +201,6 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2916910d-6152-4db7-abfd-e69a3d3e8eac",
-   "metadata": {},
-   "source": [
-    "We can also use `crds.getreferences()` to accomplish the same thing; however, `getreferences()` goes one step further beyond `getrecommendations()` and will download the reference files if they are not already in your local cache. Using the same example as above:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b09c9bd3-57a5-4fbf-87ce-ebcf22ac999a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ref_files = crds.getreferences(meta, reftypes=['distortion'], observatory='roman')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a60dab9f-c70d-44cb-b6b8-932918e97e49",
-   "metadata": {},
-   "source": [
-    "And once again we can examine the output of `ref_files`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9ffe7a81-c9cf-4750-a962-41a52dff27fc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ref_files"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "44b65450-a2e1-40c6-ab75-144c28480778",
    "metadata": {},
    "source": [
@@ -285,34 +249,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f746526",
+   "id": "620b4448",
    "metadata": {},
    "source": [
     "### Basic Statistics\n",
-    "We can also get some basic statistics."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "60a89d4e",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"Distortion statistics:\")\n",
-    "print(f\"  Mean offset X: {dx.mean():.4f} pixels\")\n",
-    "print(f\"  Mean offset Y: {dy.mean():.4f} pixels\")\n",
-    "print(f\"  Max distortion: {dist_mag.max():.4f} pixels\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b4f0262f",
-   "metadata": {},
-   "source": [
-    "### Visualizing the Distortion\n",
-    "\n",
-    "We can evaluate the model on a representative grid."
+    "We can also get some basic statistics. First let's evealuate the model on a representative grid,"
    ]
   },
   {
@@ -340,9 +281,31 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0bcd4d6",
+   "id": "278b1a05",
    "metadata": {},
    "source": [
+    "Now get some statistics on the distortion magnitude"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a4d4c169",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Distortion statistics:\")\n",
+    "print(f\"  Mean offset X: {dx.mean():.4f} pixels\")\n",
+    "print(f\"  Mean offset Y: {dy.mean():.4f} pixels\")\n",
+    "print(f\"  Max distortion: {dist_mag.max():.4f} pixels\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "707ca17e",
+   "metadata": {},
+   "source": [
+    "### Visualizing the Distortion\n",
     "Now, let's plot the distortion magnitude map (X and Y offsets) grid"
    ]
   },
@@ -381,7 +344,7 @@
     "# Vector field with strong scaling + normalization\n",
     "plt.figure(figsize=(11, 9))\n",
     "\n",
-    "step_vec = 2  # adjust density\n",
+    "step_vec = 10  # adjust density\n",
     "\n",
     "# Normalize vector length for visibility\n",
     "scale_factor = 90000   # tune this number (higher = shorter arrows)\n",
@@ -409,7 +372,7 @@
    "metadata": {},
    "source": [
     "## About this Notebook\n",
-    "**Author:** T. Desjardins & R. Diaz\n",
+    "**Author:** R. Diaz\n",
     "\n",
     "**Updated On:** 2026-07-06"
    ]
@@ -438,9 +401,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "roman_cal",
+   "display_name": "Roman Research Nexus 2026.2",
    "language": "python",
-   "name": "python3"
+   "name": "roman_cal"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/crds_reference_files/flat_reffile.ipynb
+++ b/notebooks/crds_reference_files/flat_reffile.ipynb
@@ -164,61 +164,16 @@
    "source": [
     "### Retrieving Reference Files\n",
     "\n",
-    "As you run the `RomanCal` pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, these can be retrieved through the `crds` Python API and the ELP run with those files (more on that later). Let's begin with how to access reference files from CRDS.\n",
+    "As you run the exposure pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, retrieve those from `crds` Python API and feed these to the Exposure Level or Mosaic Pipeline, see the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb) for more details. \n",
     "\n",
-    "First, let's start by looking at the `crds.getrecommendations()` function. This function returns a dictionary of file names that match the criteria that you supply. Selection criteria are specified in a dictionary of key-value pairs. Each Roman WFI metadata keyword in the dictionary is all-caps and always begins with \"ROMAN.META.\". The remaining parts of the string correspond to the metadata keyword locations in the science data file schema. Different reference file types require different combinations of science metadata to match to the reference files. In general, all reference file types will require the instrument name (\"INSTRUMENT.NAME\") and start time (\"EXPOSURE.START_TIME\"). Most file types require the detector name (\"INSTRUMENT.DETECTOR\"), and some file types require the exposure type (\"EXPOSURE.TYPE\") or optical element (\"INSTRUMENT.OPTICAL_ELEMENT\").\n",
+    "For the flat files in particular, the keywords that will identify the best reference file to use are:\n",
     "\n",
-    "For the flat files in particular, the required keywords are:\n",
+    "- ROMAN.META.INSTRUMENT.NAME\n",
+    "- ROMAN.META.INSTRUMENT.DETECTOR\n",
+    "- ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT\n",
+    "- ROMAN.META.EXPOSURE.START_TIME\n",
     "\n",
-    "    - ROMAN.META.INSTRUMENT.NAME\n",
-    "    - ROMAN.META.INSTRUMENT.DETECTOR\n",
-    "    - ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT\n",
-    "    - ROMAN.META.EXPOSURE.START_TIME\n",
-    "\n",
-    "These keywords may be combined into a single dictionary to find multiple reference file types using `crds.getreferences()`. For example, if you would like to find the name of the dark and flat reference files used by the pipeline, you could run the following example:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b8f3dc8a-bcb3-4948-8d6d-0ccf99c2ac6a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
-    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
-    "        'ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT': 'F158',\n",
-    "        'ROMAN.META.EXPOSURE.TYPE': 'WFI_IMAGE',\n",
-    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
-    "       }\n",
-    "\n",
-    "ref_files = crds.getrecommendations(meta, reftypes=['flat'], observatory='roman')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "99ec8fd5-c73a-488a-86ad-52d032dd543c",
-   "metadata": {},
-   "source": [
-    "The `ref_files` variable now contains a dictionary for each of the reference file types you requested (FLAT). These are the reference files that correspond to a science observation taken at midnight UTC on January 1, 2026 in the WFI imaging mode with optical element F158 and detector WFI01. Let's take a look at the names of the files CRDS returned:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "db5933f4-2af7-4106-b2ab-a89b7a8fd7f3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ref_files"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2916910d-6152-4db7-abfd-e69a3d3e8eac",
-   "metadata": {},
-   "source": [
-    "We can also use `crds.getreferences()` to accomplish the same thing; however, `getreferences()` goes one step further beyond `getrecommendations()` and will download the reference files if they are not already in your local cache. Using the same example as above:"
+    "These keywords may be combined into a single dictionary to find and download the file using `crds.getreferences()`.  "
    ]
   },
   {
@@ -235,24 +190,7 @@
     "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
     "       }\n",
     "\n",
-    "ref_files = crds.getreferences(meta, reftypes=['flat'], observatory='roman')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a60dab9f-c70d-44cb-b6b8-932918e97e49",
-   "metadata": {},
-   "source": [
-    "And once again we can examine the output of `ref_files`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9ffe7a81-c9cf-4750-a962-41a52dff27fc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "ref_files = crds.getreferences(meta, reftypes=['flat'], observatory='roman')\n",
     "ref_files"
    ]
   },
@@ -326,7 +264,7 @@
    "metadata": {},
    "source": [
     "## About this Notebook\n",
-    "**Author:** T. Desjardin & R. Diaz\n",
+    "**Author:** R. Diaz & T. Desjardins\n",
     "\n",
     "**Updated On:** 2026-07-06"
    ]
@@ -355,9 +293,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "roman_cal",
+   "display_name": "Roman Research Nexus 2026.2",
    "language": "python",
-   "name": "python3"
+   "name": "roman_cal"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/crds_reference_files/flat_reffile.ipynb
+++ b/notebooks/crds_reference_files/flat_reffile.ipynb
@@ -1,0 +1,377 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
+   "metadata": {},
+   "source": [
+    "# Understanding the Roman WFI Flat Reference File "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "620243a9-7836-4594-9c0e-c952166fe365",
+   "metadata": {},
+   "source": [
+    "## Kernel Information and Read-Only Status\n",
+    "\n",
+    "To run this notebook, please select \"Roman Research Nexus {VERSION}\" kernel at the top right of your window. For example \"Roman Research Nexus 2026.1\".\n",
+    "\n",
+    "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it.\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e739398-0b70-40fa-8a46-5319d7066c73",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "The purpose of this notebook is to understand the the content and purpose of the **Flat** (`FLAT`) reference file.\n",
+    "\n",
+    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1beac9c",
+   "metadata": {},
+   "source": [
+    "### Local Run Settings\n",
+    "\n",
+    "If you want to run the notebook in your local machine, refer to the information in [local installation](../../markdown/local-run.md) instructions before proceeding with the notebook. The instructions provide inportant information about setting up your environment and installing dependnecies."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd1a0491-6dcc-475e-9118-e22a9e2a31c2",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "Libraries used:\n",
+    "- *astropy* for image normalization\n",
+    "- *copy* for making copies of Python objects\n",
+    "- *crds* for access to calibration reference files\n",
+    "- *matplotlib* and *mpl_toolkits* for plotting images\n",
+    "- *numpy* for array manipulation\n",
+    "- *asdf* for opening Roman WFI ASDF files\n",
+    "- *os* for operating system functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53a4bf0b-4a5d-4aa1-974f-fbc5ca87c9c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from astropy.visualization import simple_norm\n",
+    "import copy\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import colors, colormaps as cm\n",
+    "from mpl_toolkits.axes_grid1 import make_axes_locatable\n",
+    "import numpy as np\n",
+    "import roman_datamodels as rdm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bb19274-2253-455f-b116-f49509ab7c3c",
+   "metadata": {},
+   "source": [
+    "### The Calibration Reference Data System (CRDS)\n",
+    "\n",
+    "The reference files, developed and validated by STScI’s Science Operations Center, are continually updated as new WFI data become available. For more information about how CRDS works and how it assigns the most appropriate reference file for each calibration step, refer to the notebook [Inderstanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb). \n",
+    "\n",
+    "**IMPORTANT NOTE:** Reference files are a work in progress and will be updated several times before Roman launch. If you notice irregularities or missing information, please understand that they may be a known issue. If you have questions, please contact the [Roman Help Desk](https://romanhelp.stsci.edu)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8fcb955",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import crds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b18e287",
+   "metadata": {},
+   "source": [
+    "Now let's dive into this reference file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4daaf93f-123f-419b-9929-08d3fe6ce032",
+   "metadata": {},
+   "source": [
+    "### Flats\n",
+    "\n",
+    "The FLAT reference file is selected based on the optical element used to obtain the science data.  It contains the flatfield data which corrects for both large-scale and pixel-to-pixel sensitivity variations, ensuring uniform data for a specific imaging filter.  During the `romancal.flatfield.FlatFieldStep()` step, the science array is divided by the flatfield reference array for the matching filter, effectively \"flattening\" the variations in the data.  Pixels with negative values or that are flagged will be skipped and not updated.\n",
+    "\n",
+    "The flat reference file is created from flat calibration datasets.  A set of flat exposures with the same filter within some date range to the science data are used to compute flat rate images. These are averaged together and normalized, producing a filter-dependent flat rate image. Spectroscopic mode observations are not flatfielded by RomanCal, and there are no flat reference files available for the WFI grism or prism available from the Science Operations Center at STScI. For grism and prism observations, the flatfield step will be skipped.\n",
+    "\n",
+    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/flatfield/index.html) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook-home/roman-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-flatfield) for flat fielding.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3be0f41c",
+   "metadata": {},
+   "source": [
+    "Let's check the environmental variables set for CRDS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "373e04c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"CRDS server location: {os.environ.get('CRDS_SERVER_URL')}\")\n",
+    "print(f\"CRDS context file: {os.environ.get('CRDS_CONTEXT')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ae32ee4",
+   "metadata": {},
+   "source": [
+    "If we want to change the context, we can do it in the next cell. In this case, we choose context `roman_0055.pmap`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44ccdcba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['CRDS_CONTEXT']='roman_0055.pmap'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80b3db81-1b7a-448f-a462-16eff6ed8f9a",
+   "metadata": {},
+   "source": [
+    "### Retrieving Reference Files\n",
+    "\n",
+    "As you run the `RomanCal` pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, these can be retrieved through the `crds` Python API and the ELP run with those files (more on that later). Let's begin with how to access reference files from CRDS.\n",
+    "\n",
+    "First, let's start by looking at the `crds.getrecommendations()` function. This function returns a dictionary of file names that match the criteria that you supply. Selection criteria are specified in a dictionary of key-value pairs. Each Roman WFI metadata keyword in the dictionary is all-caps and always begins with \"ROMAN.META.\". The remaining parts of the string correspond to the metadata keyword locations in the science data file schema. Different reference file types require different combinations of science metadata to match to the reference files. In general, all reference file types will require the instrument name (\"INSTRUMENT.NAME\") and start time (\"EXPOSURE.START_TIME\"). Most file types require the detector name (\"INSTRUMENT.DETECTOR\"), and some file types require the exposure type (\"EXPOSURE.TYPE\") or optical element (\"INSTRUMENT.OPTICAL_ELEMENT\").\n",
+    "\n",
+    "For the flat files in particular, the required keywords are:\n",
+    "\n",
+    "    - ROMAN.META.INSTRUMENT.NAME\n",
+    "    - ROMAN.META.INSTRUMENT.DETECTOR\n",
+    "    - ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT\n",
+    "    - ROMAN.META.EXPOSURE.START_TIME\n",
+    "\n",
+    "These keywords may be combined into a single dictionary to find multiple reference file types using `crds.getreferences()`. For example, if you would like to find the name of the dark and flat reference files used by the pipeline, you could run the following example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8f3dc8a-bcb3-4948-8d6d-0ccf99c2ac6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "        'ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT': 'F158',\n",
+    "        'ROMAN.META.EXPOSURE.TYPE': 'WFI_IMAGE',\n",
+    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "       }\n",
+    "\n",
+    "ref_files = crds.getrecommendations(meta, reftypes=['flat'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99ec8fd5-c73a-488a-86ad-52d032dd543c",
+   "metadata": {},
+   "source": [
+    "The `ref_files` variable now contains a dictionary for each of the reference file types you requested (FLAT). These are the reference files that correspond to a science observation taken at midnight UTC on January 1, 2026 in the WFI imaging mode with optical element F158 and detector WFI01. Let's take a look at the names of the files CRDS returned:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db5933f4-2af7-4106-b2ab-a89b7a8fd7f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2916910d-6152-4db7-abfd-e69a3d3e8eac",
+   "metadata": {},
+   "source": [
+    "We can also use `crds.getreferences()` to accomplish the same thing; however, `getreferences()` goes one step further beyond `getrecommendations()` and will download the reference files if they are not already in your local cache. Using the same example as above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b09c9bd3-57a5-4fbf-87ce-ebcf22ac999a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "        'ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT': 'F158',\n",
+    "        'ROMAN.META.EXPOSURE.TYPE': 'WFI_IMAGE',\n",
+    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "       }\n",
+    "\n",
+    "ref_files = crds.getreferences(meta, reftypes=['flat'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a60dab9f-c70d-44cb-b6b8-932918e97e49",
+   "metadata": {},
+   "source": [
+    "And once again we can examine the output of `ref_files`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ffe7a81-c9cf-4750-a962-41a52dff27fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44b65450-a2e1-40c6-ab75-144c28480778",
+   "metadata": {},
+   "source": [
+    "### Examining Reference Files\n",
+    "\n",
+    "Reference files use `roman_datamodels` just like WFI science data products and can be accessed in the same way (see the tutorial [Working with ASDF](../working_with_asdf/working_with_asdf.ipynb) for more information). Let's take a closer look at the files we retrieved from our `crds.getreferences()` example starting with the flat file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80ad3211-188d-45ef-b5f1-2ef6bf466450",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flat = rdm.open(ref_files['flat'])\n",
+    "flat.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "868eed54-c552-4324-bae3-4622ef81c4a9",
+   "metadata": {},
+   "source": [
+    "Once again, we see a `data` array, which in this case is the flatfield values, a `dq` array for flagging effects in the flatfield, and an `error` array. Let's take a look at the flatfield for this detector:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f732d453-7394-4fec-b0e9-e9111a243e63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(1, 3, figsize=(14, 14))\n",
+    "\n",
+    "norm = simple_norm(flat.data, percent=99.5)\n",
+    "data = axs[0].imshow(flat.data, cmap='gray', norm=norm, origin='lower')\n",
+    "axs[0].set_xlabel('Science X (pixels)')\n",
+    "axs[0].set_ylabel('Science Y (pixels)')\n",
+    "axs[0].set_title('Flatfield')\n",
+    "divider = make_axes_locatable(axs[0])\n",
+    "cax = divider.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
+    "fig.colorbar(data, cax=cax)\n",
+    "\n",
+    "norm = simple_norm(flat.err, percent=99.5)\n",
+    "err = axs[1].imshow(flat.err, cmap='gray', norm=norm, origin='lower')\n",
+    "axs[1].set_xlabel('Science X (pixels)')\n",
+    "axs[1].set_ylabel('Science Y (pixels)')\n",
+    "axs[1].set_title('Flatfield Error')\n",
+    "divider = make_axes_locatable(axs[1])\n",
+    "cax = divider.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
+    "fig.colorbar(err, cax=cax)\n",
+    "\n",
+    "axs[2].imshow(np.bool(flat.dq), cmap='binary_r', origin='lower')\n",
+    "axs[2].set_xlabel('Science X (pixels)')\n",
+    "axs[2].set_ylabel('Science Y (pixels)')\n",
+    "axs[2].set_title('Flatfield DQ')\n",
+    "\n",
+    "plt.tight_layout();"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c9a36d6",
+   "metadata": {},
+   "source": [
+    "## About this Notebook\n",
+    "**Author:** T. Desjardin & R. Diaz\n",
+    "\n",
+    "**Updated On:** 2026-07-06"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45fb919f",
+   "metadata": {},
+   "source": [
+    "<table width=\"100%\" style=\"border:none; border-collapse:collapse;\">\n",
+    "\n",
+    "  <tr style=\"border:none;\">\n",
+    "    <td style=\"border:none; width:180px; white-space:nowrap;\">\n",
+    "       <a href=\"#top\" style=\"text-decoration:none; color:#0066cc;\"> Top of page</a>\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:center;\">\n",
+    "        <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/roman_logo.png\" alt=\"roman_logo\" width=\"50px\">\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:right;\">\n",
+    "       <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/stsci_logo2.png\" width=\"90\">\n",
+    "    </td>\n",
+    "  </tr>\n",
+    "</table>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "roman_cal",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/crds_reference_files/gain_reffile.ipynb
+++ b/notebooks/crds_reference_files/gain_reffile.ipynb
@@ -5,7 +5,7 @@
    "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
    "metadata": {},
    "source": [
-    "# Understanding the Roman WFI Dark Current Reference File "
+    "#  Understanding the Roman WFI Gain Reference File"
    ]
   },
   {
@@ -27,9 +27,11 @@
    "metadata": {},
    "source": [
     "## Introduction\n",
-    "The purpose of this notebook is to understand the content and purpose of the **Dark Current** (`DARK`) reference file.\n",
+    "The purpose of this notebook is to understand the content and purpose of the **Gain** (`GAIN`) reference file.\n",
     "\n",
-    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)"
+    "The GAIN reference file is used during the `ramp_fitting` step to convert from instrumental units (DN) to electrons. It is critical for proper noise propagation and variance estimation. The gain values are assumed to be in units of e/DN.\n",
+    "\n",
+    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/gain_reffile.html#gain-reffile)."
    ]
   },
   {
@@ -112,13 +114,11 @@
    "id": "11b5ca61-dfe0-4031-8f4d-172f4a135b52",
    "metadata": {},
    "source": [
-    "### Darks \n",
+    "### Gain Reference File\n",
     "\n",
-    "The DARK reference file is selected based on the WFI mode (imaging or spectroscopy) used to obtain the science data. During the `romancal.dark_current.DarkCurrentStep()` step, the dark current is subtracted on a pixel-by-pixel and resultant-by-resultant basis. Pixels that are undefined in the dark reference file will not be subtracted from the science data.\n",
+    "The GAIN reference file provides the conversion factor from Data Numbers (DN) to electrons for each pixel. It is used in the ramp fitting step for accurate variance calculation and noise modeling.\n",
     "\n",
-    "The dark reference files are created from dark calibration datasets.  A set of dark files are sigma clipped, and stacked resultant-by-resultant to create a super dark.\n",
-    "\n",
-    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/dark_current/index.html) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook-home/roman-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-dark_current) for dark current subtraction.\n"
+    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/readnoise_reffile.html#readnoise-reffile) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook/roman-wfi-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-ramp_fitting) for the Ramp Fitting and Jump Detection."
    ]
   },
   {
@@ -167,7 +167,7 @@
     "\n",
     "As you run the exposure pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, retrieve those from `crds` Python API and feed these to the Exposure Level or Mosaic Pipeline, see the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb) for more details. \n",
     "\n",
-    "For the dark files in particular, the keywords that will identify the best reference file to use are:\n",
+    "For the  gain files in particular, the keywords that will identify the best reference file to use are:\n",
     "\n",
     "- ROMAN.META.INSTRUMENT.NAME\n",
     "- ROMAN.META.INSTRUMENT.DETECTOR\n",
@@ -190,7 +190,7 @@
     "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
     "       }\n",
     "\n",
-    "ref_files = crds.getreferences(meta, reftypes=['dark'], observatory='roman')\n",
+    "ref_files = crds.getreferences(meta, reftypes=['gain'], observatory='roman')\n",
     "ref_files"
    ]
   },
@@ -211,8 +211,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dark = rdm.open(ref_files['dark'])\n",
-    "dark.info()"
+    "gain = rdm.open(ref_files['gain'])\n",
+    "gain.info()"
    ]
   },
   {
@@ -220,31 +220,7 @@
    "id": "021a3635-5642-48b8-9c96-f4a6f9d758ee",
    "metadata": {},
    "source": [
-    "We see that the dark reference file contains metadata plus several arrays:\n",
-    "- The `data` array contains a cube of dark values up-the-ramp. This is used in the current version of the Exposure Pipeline, however changes are being made towards a dark rate subtraction post-ramp-fitting. \n",
-    "- The `dark_slope` array contains the dark rate per pixel\n",
-    "- The `dark_slope_error` contains the uncertainty in the dark rate. \n",
-    "- The `dq` array is present to flag effects in the dark current (such as hot pixels)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "868eed54-c552-4324-bae3-4622ef81c4a9",
-   "metadata": {},
-   "source": [
-    "Let's take a look at the dark for this detector. First, lets check the shape of the data array:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "30f444a2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"dark.data shape:\", dark.data.shape)\n",
-    "print(\"dark.dq shape:\", dark.dq.shape)\n",
-    "print(\"dark.dark_slope shape:\", getattr(dark, 'dark_slope', None).shape if hasattr(dark, 'dark_slope') else \"No dark_slope\")"
+    "We see that the gain reference file contains metadata plus the `data`,  a 2D array with the gain value (electrons per DN) for each pixel."
    ]
   },
   {
@@ -252,7 +228,35 @@
    "id": "b4f0262f",
    "metadata": {},
    "source": [
+    "### Basic Statistics\n",
+    "\n",
     "Now lets get some basic statistics on the cube (or a representative slice)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73bd5d09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Gain array shape:\", gain.data.shape)\n",
+    "print(\"\\nGain statistics:\")\n",
+    "print(f\"  Min: {gain.data.min():.4f} e-/DN\")\n",
+    "print(f\"  Max: {gain.data.max():.4f} e-/DN\")\n",
+    "print(f\"  Mean: {gain.data.mean():.4f} e-/DN\")\n",
+    "print(f\"  Median: {np.median(gain.data):.4f} e-/DN\")\n",
+    "print(f\"  Std: {gain.data.std():.4f} e-/DN\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a805ab5e",
+   "metadata": {},
+   "source": [
+    "### Visualization\n",
+    "\n",
+    "Let's check this reference file"
    ]
   },
   {
@@ -262,104 +266,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Quick stats on saturation thresholds\n",
-    "data = dark.data\n",
-    "print(\"\\nDark threshold stats:\")\n",
-    "print(\"  Min:\", data.min(), \"Max:\", data.max())\n",
-    "print(\"  Mean:\", data.mean(), \"Median:\", np.median(data))\n",
-    "print(\"  Std:\", data.std())\n",
+    "fig, ax = plt.subplots(figsize=(10, 8))\n",
     "\n",
-    "# DQ stats (reuse/adapt from your MASK statistics code)\n",
-    "dq = dark.dq\n",
-    "total = dq.size\n",
-    "flagged = np.sum(dq > 0)\n",
-    "print(f\"\\nDQ: {flagged:,} / {total:,} pixels flagged ({flagged/total*100:.3f}%)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "44fec9cb",
-   "metadata": {},
-   "source": [
-    "Note that in this case the pre-launch darks are all zero, so the plot will be rather flat."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "437d9346",
-   "metadata": {},
-   "source": [
-    "Let's get a quick histogram of a slice:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2c76715a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Select a slice of the data for histogram plotting\n",
-    "data_slice = dark.data[3:10]\n",
-    "\n",
-    "plt.figure(figsize=(8,5))\n",
-    "plt.hist(data_slice.flatten(), bins=100, range=(data_slice.min(), np.percentile(data_slice, 99.5)), log=True)\n",
-    "plt.xlabel('Dark Current Value')\n",
-    "plt.ylabel('Pixel Count (log)')\n",
-    "plt.title('Pixel Value Distribution (slice)')\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9b893996",
-   "metadata": {},
-   "source": [
-    "Note: In flight data the dark current will be non-zero and these visualizations\n",
-    "will show clear structure (hot pixels, gradients, etc.).\n",
-    "\n",
-    "Now let's check the dark image"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f732d453-7394-4fec-b0e9-e9111a243e63",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, axs = plt.subplots(1, 3, figsize=(18, 6))  # Add a third panel for dark_slope if available\n",
-    "\n",
-    "slice_idx = 10  # You can change this index to visualize a different slice of the dark current data\n",
-    "data_slice = dark.data[slice_idx]\n",
-    "\n",
-    "my_cmap = copy.copy(cm.get_cmap('nipy_spectral'))\n",
+    "my_cmap = copy.copy(cm.get_cmap('viridis'))\n",
     "my_cmap.set_bad('black')\n",
     "\n",
-    "norm = simple_norm(data_slice, stretch='sqrt', percent=99.5, min_percent=0.5)\n",
+    "# Gain map\n",
+    "norm = simple_norm(gain.data, stretch='linear', percent=99.5)\n",
+    "im = ax.imshow(gain.data, cmap=my_cmap, norm=norm, origin='lower')\n",
+    "ax.set_title('Gain Map (electrons per DN)')\n",
+    "ax.set_xlabel('Science X (pixels)')\n",
+    "ax.set_ylabel('Science Y (pixels)')\n",
     "\n",
-    "im0 = axs[0].imshow(data_slice, cmap=my_cmap, norm=norm, origin='lower')\n",
-    "divider = make_axes_locatable(axs[0])\n",
+    "# Colorbar\n",
+    "divider = make_axes_locatable(ax)\n",
     "cax = divider.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
-    "fig.colorbar(im0, cax=cax, label='DN/s or electrons')\n",
-    "axs[0].set_title(f'Dark Current (slice {slice_idx})')\n",
-    "\n",
-    "# DQ panel\n",
-    "axs[1].imshow(np.bool_(dark.dq), cmap='binary_r', origin='lower')\n",
-    "axs[1].set_title('Dark Current DQ Flags')\n",
-    "\n",
-    "# dark_slope (rate image) \n",
-    "if hasattr(dark, 'dark_slope') and dark.dark_slope is not None:\n",
-    "    slope_norm = simple_norm(dark.dark_slope, stretch='sqrt', percent=99)\n",
-    "    im2 = axs[2].imshow(dark.dark_slope, cmap=my_cmap, norm=slope_norm, origin='lower')\n",
-    "    divider2 = make_axes_locatable(axs[2])\n",
-    "    cax2 = divider2.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
-    "    fig.colorbar(im2, cax=cax2, label='DN/s or electrons')\n",
-    "    axs[2].set_title('Dark Slope (Rate)')\n",
-    "\n",
-    "for ax in axs:\n",
-    "    ax.set_xlabel('Science X (pixels)')\n",
-    "    ax.set_ylabel('Science Y (pixels)')\n",
+    "fig.colorbar(im, cax=cax, label='e-/DN')\n",
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
@@ -371,7 +293,7 @@
    "metadata": {},
    "source": [
     "## About this Notebook\n",
-    "**Author:** T. Desjardins & R. Diaz\n",
+    "**Author:** R. Diaz\n",
     "\n",
     "**Updated On:** 2026-07-06"
    ]

--- a/notebooks/crds_reference_files/linearity_reffile.ipynb
+++ b/notebooks/crds_reference_files/linearity_reffile.ipynb
@@ -5,7 +5,7 @@
    "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
    "metadata": {},
    "source": [
-    "# Understanding the Roman WFI Dark Current Reference File "
+    "# Understanding the Roman WFI Linearity Reference Files"
    ]
   },
   {
@@ -27,9 +27,15 @@
    "metadata": {},
    "source": [
     "## Introduction\n",
-    "The purpose of this notebook is to understand the content and purpose of the **Dark Current** (`DARK`) reference file.\n",
+    "This notebook covers the three related linearity reference files used by the Roman WFI pipeline:\n",
     "\n",
-    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)"
+    "- **LINEARITY** —The LINEARITY reference file contains pixel-by-pixel polynomial coefficients that map observed DN to linearized DN.\n",
+    "- **INVERSELINEARITY** —  has the same format but contains coefficients for the inverse transformation (linearized DN to observed DN), used internally to simulate individual reads from observed resultants.\n",
+    "- **INTEGRALNONLINEARITY** — contains per-channel lookup tables for correcting integral nonlinearity in the analog-to-digital converter.\n",
+    "\n",
+    "These files are critical for accurate flux measurement, especially at high signal levels.\n",
+    "\n",
+    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/gain_reffile.html#gain-reffile)."
    ]
   },
   {
@@ -112,13 +118,11 @@
    "id": "11b5ca61-dfe0-4031-8f4d-172f4a135b52",
    "metadata": {},
    "source": [
-    "### Darks \n",
+    "### Linearity Reference Files\n",
     "\n",
-    "The DARK reference file is selected based on the WFI mode (imaging or spectroscopy) used to obtain the science data. During the `romancal.dark_current.DarkCurrentStep()` step, the dark current is subtracted on a pixel-by-pixel and resultant-by-resultant basis. Pixels that are undefined in the dark reference file will not be subtracted from the science data.\n",
+    "The Roman WFI detectors exhibit classical non-linearity. The pipeline corrects this using polynomial coefficients stored in the `LINEARITY` reference file. The detector is read out through **32 amplifiers**, each covering **128 columns**.\n",
     "\n",
-    "The dark reference files are created from dark calibration datasets.  A set of dark files are sigma clipped, and stacked resultant-by-resultant to create a super dark.\n",
-    "\n",
-    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/dark_current/index.html) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook-home/roman-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-dark_current) for dark current subtraction.\n"
+    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/linearity_reffile.html) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook/roman-wfi-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-linearity) for the Linearity Correction."
    ]
   },
   {
@@ -167,11 +171,10 @@
     "\n",
     "As you run the exposure pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, retrieve those from `crds` Python API and feed these to the Exposure Level or Mosaic Pipeline, see the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb) for more details. \n",
     "\n",
-    "For the dark files in particular, the keywords that will identify the best reference file to use are:\n",
+    "For the linearity files in particular, the keywords that will identify the best reference file to use are:\n",
     "\n",
     "- ROMAN.META.INSTRUMENT.NAME\n",
     "- ROMAN.META.INSTRUMENT.DETECTOR\n",
-    "- ROMAN.META.EXPOSURE.TYPE\n",
     "- ROMAN.META.EXPOSURE.START_TIME\n",
     "\n",
     "These keywords may be combined into a single dictionary to find and download the file using `crds.getreferences()`.  "
@@ -186,11 +189,10 @@
    "source": [
     "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
     "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
-    "        'ROMAN.META.EXPOSURE.TYPE': 'WFI_IMAGE',\n",
     "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
     "       }\n",
     "\n",
-    "ref_files = crds.getreferences(meta, reftypes=['dark'], observatory='roman')\n",
+    "ref_files = crds.getreferences(meta, reftypes=['linearity', 'inverselinearity', 'integralnonlinearity'], observatory='roman')\n",
     "ref_files"
    ]
   },
@@ -211,8 +213,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dark = rdm.open(ref_files['dark'])\n",
-    "dark.info()"
+    "lin     = rdm.open(ref_files['linearity'])\n",
+    "inv_lin = rdm.open(ref_files.get('inverselinearity'))\n",
+    "int_lin = rdm.open(ref_files.get('integralnonlinearity'))\n",
+    "\n",
+    "print(\"=== LINEARITY ===\")\n",
+    "lin.info()\n",
+    "print(\"\\n=== INVERSE LINEARITY ===\")\n",
+    "if inv_lin: inv_lin.info()\n",
+    "print(\"\\n=== INTEGRAL NONLINEARITY ===\")\n",
+    "if int_lin: int_lin.info()"
    ]
   },
   {
@@ -220,148 +230,99 @@
    "id": "021a3635-5642-48b8-9c96-f4a6f9d758ee",
    "metadata": {},
    "source": [
-    "We see that the dark reference file contains metadata plus several arrays:\n",
-    "- The `data` array contains a cube of dark values up-the-ramp. This is used in the current version of the Exposure Pipeline, however changes are being made towards a dark rate subtraction post-ramp-fitting. \n",
-    "- The `dark_slope` array contains the dark rate per pixel\n",
-    "- The `dark_slope_error` contains the uncertainty in the dark rate. \n",
-    "- The `dq` array is present to flag effects in the dark current (such as hot pixels)."
+    "We see that the LINEARITY and INVERSELINEARITY reference files contain metadata plus a Linearity Coefficients `coeffs` array and a 2D `dq` array."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "868eed54-c552-4324-bae3-4622ef81c4a9",
+   "id": "461c15a9",
    "metadata": {},
    "source": [
-    "Let's take a look at the dark for this detector. First, lets check the shape of the data array:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "30f444a2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"dark.data shape:\", dark.data.shape)\n",
-    "print(\"dark.dq shape:\", dark.dq.shape)\n",
-    "print(\"dark.dark_slope shape:\", getattr(dark, 'dark_slope', None).shape if hasattr(dark, 'dark_slope') else \"No dark_slope\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "b4f0262f",
-   "metadata": {},
-   "source": [
-    "Now lets get some basic statistics on the cube (or a representative slice)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "86caf99b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Quick stats on saturation thresholds\n",
-    "data = dark.data\n",
-    "print(\"\\nDark threshold stats:\")\n",
-    "print(\"  Min:\", data.min(), \"Max:\", data.max())\n",
-    "print(\"  Mean:\", data.mean(), \"Median:\", np.median(data))\n",
-    "print(\"  Std:\", data.std())\n",
+    "### Understanding the Amplifier Structure\n",
     "\n",
-    "# DQ stats (reuse/adapt from your MASK statistics code)\n",
-    "dq = dark.dq\n",
-    "total = dq.size\n",
-    "flagged = np.sum(dq > 0)\n",
-    "print(f\"\\nDQ: {flagged:,} / {total:,} pixels flagged ({flagged/total*100:.3f}%)\")"
+    "The WFI detector is divided into **32 amplifiers**, each 128 columns wide. Linearity coefficients are stored or applied per amplifier."
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "44fec9cb",
+   "id": "666d3986",
    "metadata": {},
    "source": [
-    "Note that in this case the pre-launch darks are all zero, so the plot will be rather flat."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "437d9346",
-   "metadata": {},
-   "source": [
-    "Let's get a quick histogram of a slice:"
+    "### Visualizing Linearity Coefficients\n",
+    "\n",
+    "The linearity is a 5th order polinomial correction."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c76715a",
+   "id": "04934cb4",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Select a slice of the data for histogram plotting\n",
-    "data_slice = dark.data[3:10]\n",
+    "fig, axs = plt.subplots(2, 3, figsize=(15, 9))\n",
     "\n",
-    "plt.figure(figsize=(8,5))\n",
-    "plt.hist(data_slice.flatten(), bins=100, range=(data_slice.min(), np.percentile(data_slice, 99.5)), log=True)\n",
-    "plt.xlabel('Dark Current Value')\n",
-    "plt.ylabel('Pixel Count (log)')\n",
-    "plt.title('Pixel Value Distribution (slice)')\n",
+    "for i in range(6):\n",
+    "    ax = axs.flat[i]\n",
+    "    data = lin.coeffs[i]\n",
+    "    norm = simple_norm(data, stretch='linear', percent=99)\n",
+    "    im = ax.imshow(data, cmap='RdBu_r', norm=norm, origin='lower')\n",
+    "    ax.set_title(f'Coefficient {i} (order {i})')\n",
+    "    plt.colorbar(im, ax=ax, fraction=0.046)\n",
+    "    \n",
+    "    # Amplifier boundaries\n",
+    "    for amp in range(1, 32):\n",
+    "        ax.axvline(amp * 128 - 0.5, color='white', ls='--', lw=0.8, alpha=0.6)\n",
+    "\n",
+    "plt.suptitle('Linearity Polynomial Coefficients', fontsize=14)\n",
+    "plt.tight_layout()\n",
     "plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9b893996",
+   "id": "1bb672ab",
    "metadata": {},
    "source": [
-    "Note: In flight data the dark current will be non-zero and these visualizations\n",
-    "will show clear structure (hot pixels, gradients, etc.).\n",
+    "### INTEGRALNONLINEARITY (Per-Channel Lookup Tables)\n",
     "\n",
-    "Now let's check the dark image"
+    "Now let's check the Integral Non-Linearity reference file for all channels. Roman WFI has 32 amplifiers (channels). Each channel has a lookup table of length 2048 mapping raw digital numbers to corrected values.\n",
+    "\n",
+    "In the plot below, labels are only for the first 10 channels"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f732d453-7394-4fec-b0e9-e9111a243e63",
+   "id": "61f864c6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "fig, axs = plt.subplots(1, 3, figsize=(18, 6))  # Add a third panel for dark_slope if available\n",
+    "val = int_lin.value.flatten()\n",
     "\n",
-    "slice_idx = 10  # You can change this index to visualize a different slice of the dark current data\n",
-    "data_slice = dark.data[slice_idx]\n",
+    "plt.figure(figsize=(12, 7))\n",
     "\n",
-    "my_cmap = copy.copy(cm.get_cmap('nipy_spectral'))\n",
-    "my_cmap.set_bad('black')\n",
+    "# Plot all channels\n",
+    "for ch in range(32):\n",
+    "    start = ch * 2048\n",
+    "    end = start + 2048\n",
+    "    plt.plot(val[start:end], label=f'Channel {ch}' if ch < 10 else \"\", alpha=0.7, lw=1)\n",
     "\n",
-    "norm = simple_norm(data_slice, stretch='sqrt', percent=99.5, min_percent=0.5)\n",
+    "plt.title('Integral Nonlinearity Lookup Tables (per channel)')\n",
+    "plt.xlabel('Lookup Table Index (0–2047)')\n",
+    "plt.ylabel('Correction Value')\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.legend(ncol=2, fontsize=8)\n",
+    "plt.show()\n",
     "\n",
-    "im0 = axs[0].imshow(data_slice, cmap=my_cmap, norm=norm, origin='lower')\n",
-    "divider = make_axes_locatable(axs[0])\n",
-    "cax = divider.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
-    "fig.colorbar(im0, cax=cax, label='DN/s or electrons')\n",
-    "axs[0].set_title(f'Dark Current (slice {slice_idx})')\n",
-    "\n",
-    "# DQ panel\n",
-    "axs[1].imshow(np.bool_(dark.dq), cmap='binary_r', origin='lower')\n",
-    "axs[1].set_title('Dark Current DQ Flags')\n",
-    "\n",
-    "# dark_slope (rate image) \n",
-    "if hasattr(dark, 'dark_slope') and dark.dark_slope is not None:\n",
-    "    slope_norm = simple_norm(dark.dark_slope, stretch='sqrt', percent=99)\n",
-    "    im2 = axs[2].imshow(dark.dark_slope, cmap=my_cmap, norm=slope_norm, origin='lower')\n",
-    "    divider2 = make_axes_locatable(axs[2])\n",
-    "    cax2 = divider2.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
-    "    fig.colorbar(im2, cax=cax2, label='DN/s or electrons')\n",
-    "    axs[2].set_title('Dark Slope (Rate)')\n",
-    "\n",
-    "for ax in axs:\n",
-    "    ax.set_xlabel('Science X (pixels)')\n",
-    "    ax.set_ylabel('Science Y (pixels)')\n",
-    "\n",
-    "plt.tight_layout()\n",
+    "# Per-channel mean or statistics\n",
+    "means = [val[ch*2048:(ch+1)*2048].mean() for ch in range(32)]\n",
+    "plt.figure(figsize=(10, 5))\n",
+    "plt.bar(range(32), means)\n",
+    "plt.title('Average INL Correction per Channel')\n",
+    "plt.xlabel('Channel / Amplifier')\n",
+    "plt.ylabel('Mean Correction')\n",
+    "plt.grid(True, alpha=0.3)\n",
     "plt.show()"
    ]
   },
@@ -371,7 +332,7 @@
    "metadata": {},
    "source": [
     "## About this Notebook\n",
-    "**Author:** T. Desjardins & R. Diaz\n",
+    "**Author:** R. Diaz\n",
     "\n",
     "**Updated On:** 2026-07-06"
    ]

--- a/notebooks/crds_reference_files/notebook_data_dependencies.py
+++ b/notebooks/crds_reference_files/notebook_data_dependencies.py
@@ -1,0 +1,1 @@
+../../shared/notebook_data_dependencies.py

--- a/notebooks/crds_reference_files/photom_reffile.ipynb
+++ b/notebooks/crds_reference_files/photom_reffile.ipynb
@@ -1,0 +1,696 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
+   "metadata": {},
+   "source": [
+    "# Understanding the Roman WFI Photometry Reference File"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "620243a9-7836-4594-9c0e-c952166fe365",
+   "metadata": {},
+   "source": [
+    "## Kernel Information and Read-Only Status\n",
+    "\n",
+    "To run this notebook, please select \"Roman Research Nexus {VERSION}\" kernel at the top right of your window. For example \"Roman Research Nexus 2026.1\".\n",
+    "\n",
+    "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it.\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e739398-0b70-40fa-8a46-5319d7066c73",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "The purpose of this notebook is to understand the content and purpose of the **Photometry** (`PHOTOM`) reference file.\n",
+    "\n",
+    "This file provides the photometric calibration information used by the `romancal.photom.PhotomStep` to convert instrumental units (DN/s) into physical flux units (MJy/sr) and to populate photometric metadata (zero points, etc.).\n",
+    "\n",
+    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d80341a4",
+   "metadata": {},
+   "source": [
+    "## Reference Data\n",
+    "\n",
+    "The cell below will check to ensure ancillary reference files for `synphot` and `stpsf` packages are installed. If not, it will download the ancillary reference files and install them under your home directory (i.e., `${HOME}/refdata/`).\n",
+    "\n",
+    "### Local Run Settings\n",
+    "\n",
+    "If you want to run the notebook in your local machine, refer to the information in the [local installation](../../markdown/local-run.md) instructions before proceeding with the notebook. The instructions provide important information about setting up your environment, installing dependnecies, and adding to your working directory scripts to help with the reference data installation.\n",
+    "\n",
+    "Depending on which (if any) reference data are missing, this cell may take several minutes to execute.\n",
+    "\n",
+    "### On the Roman Research Nexus\n",
+    "\n",
+    "If you are working on the Nexus, then the ancillary reference data are pre-installed and this cell will execute instantly."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "c13d7b2b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Did not find stpsf data in environment, setting it up...\n",
+      "\tDownloading and uncompressing file...\n",
+      "\tFound 1 data URL(s) to download and install...\n",
+      "\tWorking on file 1 out of 1\n",
+      "\tUpdate environment variable with the following:\n",
+      "\t\texport STPSF_PATH='/Users/rdiaz/refdata/stpsf-data'\n",
+      "Found synphot path /grp/hst/cdbs/\n",
+      "Reference data paths set to:\n",
+      "\tSTPSF_PATH = /Users/rdiaz/refdata/stpsf-data\n",
+      "\tPYSYN_CDBS = /grp/hst/cdbs/\n",
+      "\tCRDS_SERVER_URL = https://roman-crds.stsci.edu (pre-set, not overwritten)\n",
+      "\tCRDS_CONTEXT = roman_0048.pmap\n",
+      "\tCRDS_PATH = /Users/rdiaz/crds_cache (pre-set, not overwritten)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import importlib.util\n",
+    "\n",
+    "import notebook_data_dependencies as ndd\n",
+    "\n",
+    "# Download reference data (if necessary)\n",
+    "result = ndd.install_files(packages=['synphot', 'stpsf'])\n",
+    "ndd.setup_env(result)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd1a0491-6dcc-475e-9118-e22a9e2a31c2",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "Libraries used:\n",
+    "- *astropy* for image normalization and units\n",
+    "- *copy* for making copies of Python objects\n",
+    "- *crds* for access to calibration reference files\n",
+    "- *matplotlib* and *mpl_toolkits* for plotting images\n",
+    "- *numpy* for array manipulation\n",
+    "- *asdf* for opening Roman WFI ASDF files\n",
+    "- *os* for operating system functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "53a4bf0b-4a5d-4aa1-974f-fbc5ca87c9c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from astropy.visualization import simple_norm\n",
+    "from astropy import units as u\n",
+    "import copy\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import colors, colormaps as cm\n",
+    "from mpl_toolkits.axes_grid1 import make_axes_locatable\n",
+    "import numpy as np\n",
+    "import roman_datamodels as rdm\n",
+    "import synphot as syn\n",
+    "import stsynphot as stsyn\n",
+    "import stpsf\n",
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bb19274-2253-455f-b116-f49509ab7c3c",
+   "metadata": {},
+   "source": [
+    "### The Calibration Reference Data System (CRDS)\n",
+    "\n",
+    "The reference files, developed and validated by STScI’s Science Operations Center, are continually updated as new WFI data become available. For more information about how CRDS works and how it assigns the most appropriate reference file for each calibration step, refer to the notebook [Inderstanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb). \n",
+    "\n",
+    "**IMPORTANT NOTE:** Reference files are a work in progress and will be updated several times before Roman launch. If you notice irregularities or missing information, please understand that they may be a known issue. If you have questions, please contact the [Roman Help Desk](https://romanhelp.stsci.edu)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "b8fcb955",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import crds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b18e287",
+   "metadata": {},
+   "source": [
+    "Now let's dive into this reference file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4daaf93f-123f-419b-9929-08d3fe6ce032",
+   "metadata": {},
+   "source": [
+    "### Photometry Reference File (PHOTOM)\n",
+    "\n",
+    "The PHOTOM reference file contains photometric conversion factors for each optical element. It is used to convert pixel values into physical units and to populate header keywords with zero points.\n",
+    "\n",
+    "For more details, see the [romancal photom documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/photom/index.html) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook/roman-wfi-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-photom) for photometric calibration.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3be0f41c",
+   "metadata": {},
+   "source": [
+    "Let's check the environmental variables set for CRDS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "373e04c2",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CRDS server location: https://roman-crds.stsci.edu\n",
+      "CRDS context file: roman_0048.pmap\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"CRDS server location: {os.environ.get('CRDS_SERVER_URL')}\")\n",
+    "print(f\"CRDS context file: {os.environ.get('CRDS_CONTEXT')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1ae32ee4",
+   "metadata": {},
+   "source": [
+    "If we want to change the context, we can do it in the next cell. In this case, we choose context `roman_0055.pmap`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "44ccdcba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['CRDS_CONTEXT']='roman_0055.pmap'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80b3db81-1b7a-448f-a462-16eff6ed8f9a",
+   "metadata": {},
+   "source": [
+    "### Retrieving Reference Files\n",
+    "\n",
+    "As you run the exposure pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, these can be retrieved through the `crds` Python API.\n",
+    "\n",
+    "For the `PHOTOM` files in particular, the required keywords are:\n",
+    "\n",
+    "    - `ROMAN.META.INSTRUMENT.NAME`\n",
+    "    - `ROMAN.META.INSTRUMENT.DETECTOR`\n",
+    "    - `ROMAN.META.EXPOSURE.START_TIME`\n",
+    "\n",
+    "These keywords may be combined into a single dictionary that is later fed to the  `crds.getrecommendations` function. This function returns a dictionary of file names that match the criteria that you supply. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "b09c9bd3-57a5-4fbf-87ce-ebcf22ac999a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'photom': '/Users/rdiaz/crds_cache/references/roman/wfi/roman_wfi_photom_0040.asdf'}"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "       }\n",
+    "ref_files = crds.getreferences(meta, reftypes=['PHOTOM'], observatory='roman')\n",
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44b65450-a2e1-40c6-ab75-144c28480778",
+   "metadata": {},
+   "source": [
+    "### Examining Reference Files\n",
+    "\n",
+    "Reference files use `roman_datamodels` just like WFI science data products and can be accessed in the same way (see the tutorial [Working with ASDF](../working_with_asdf/working_with_asdf.ipynb) for more information). Let's take a closer look at the files we retrieved from our `crds.getreferences()` example starting with the flat file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "80ad3211-188d-45ef-b5f1-2ef6bf466450",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "root (AsdfObject)\n",
+      "├─asdf_library (Software)\n",
+      "│ ├─author (str): The ASDF Developers\n",
+      "│ ├─homepage (str): http://github.com/asdf-format/asdf\n",
+      "│ ├─name (str): asdf\n",
+      "│ └─version (str): 4.0.0\n",
+      "├─history (AsdfDictNode)\n",
+      "│ └─extensions (AsdfListNode)\n",
+      "│   ├─0 (ExtensionMetadata)\n",
+      "│   │ ├─extension_class (str): asdf.extension._manifest.ManifestExtension\n",
+      "│   │ ├─extension_uri (str): asdf://asdf-format.org/core/extensions/core-1.6.0\n",
+      "│   │ ├─manifest_software (Software) ...\n",
+      "│   │ └─software (Software) ...\n",
+      "│   ├─1 (ExtensionMetadata)\n",
+      "│   │ ├─extension_class (str): asdf.extension._manifest.ManifestExtension\n",
+      "│   │ ├─extension_uri (str): asdf://stsci.edu/datamodels/roman/extensions/datamodels-1.0\n",
+      "│   │ ├─manifest_software (Software) ...\n",
+      "│   │ └─software (Software) ...\n",
+      "│   └─2 (ExtensionMetadata)\n",
+      "│     ├─extension_class (str): asdf.extension._manifest.ManifestExtension\n",
+      "│     ├─extension_uri (str): asdf://asdf-format.org/astronomy/extensions/astronomy-1.0.0\n",
+      "│     ├─manifest_software (Software) ...\n",
+      "│     └─software (Software) ...\n",
+      "└─roman (WfiImgPhotomRef) # WFI Imaging Photometric Flux Conversion Data Model\n",
+      "  ├─meta (AsdfDictNode) # Common Reference File Metadata Properties\n",
+      "  │ ├─author (str): T. Desjardins # Author\n",
+      "  │ ├─description (str): Roman WFI absolute photometric calibration information. Throughput information come (truncated)\n",
+      "  │ ├─instrument (AsdfDictNode)\n",
+      "  │ │ ├─detector (str): WFI01\n",
+      "  │ │ ├─median_gain (float): 1.9266027212142944\n",
+      "  │ │ ├─name (str): WFI # Instrument\n",
+      "  │ │ └─sigma_gain (float): 0.07495339959859848\n",
+      "  │ ├─origin (Origin): STSCI/SOC # Institution / Organization Name\n",
+      "  │ ├─pedigree (str): GROUND # Pedigree\n",
+      "  │ ├─reftype (str): PHOTOM\n",
+      "  │ ├─telescope (Telescope): ROMAN # Telescope Name\n",
+      "  │ └─useafter (Time): 2020-01-01 00:00:00 # Use After Date\n",
+      "  └─phot_table (AsdfDictNode) # Photometric Flux Conversion Factors Table\n",
+      "    ├─DARK (AsdfDictNode) ...\n",
+      "    ├─F062 (AsdfDictNode) ...\n",
+      "    ├─F087 (AsdfDictNode) ...\n",
+      "    ├─F106 (AsdfDictNode) ...\n",
+      "    ├─F129 (AsdfDictNode) ...\n",
+      "    ├─F146 (AsdfDictNode) ...\n",
+      "    ├─F158 (AsdfDictNode) ...\n",
+      "    ├─F184 (AsdfDictNode) ...\n",
+      "    ├─F213 (AsdfDictNode) ...\n",
+      "    ├─GRISM (AsdfDictNode) ...\n",
+      "    └─PRISM (AsdfDictNode) ...\n",
+      "Some nodes not shown.\n"
+     ]
+    }
+   ],
+   "source": [
+    "photom = rdm.open(ref_files['photom'])\n",
+    "photom.info(max_rows=50)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "868eed54-c552-4324-bae3-4622ef81c4a9",
+   "metadata": {},
+   "source": [
+    "In this case, the data is in the `photom_table` which includes the Photometric Flux Conversion Factors. Let's take a look at the photometric conversion information."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "a2777e15",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Photometric conversion information:\n",
+      "\n",
+      "Full Photometric Table:\n",
+      "       photmjsr   pixelareasr  uncertainty\n",
+      "DARK        NaN           NaN          NaN\n",
+      "F062   0.583626  2.808339e-13     0.022706\n",
+      "F087   0.805092  2.808339e-13     0.031322\n",
+      "F106   0.741749  2.808339e-13     0.028857\n",
+      "F129   0.738893  2.808339e-13     0.028746\n",
+      "F146   0.240393  2.808339e-13     0.009352\n",
+      "F158   0.736781  2.808339e-13     0.028664\n",
+      "F184   1.133710  2.808339e-13     0.044106\n",
+      "F213   1.175891  2.808339e-13     0.045747\n",
+      "GRISM       NaN           NaN          NaN\n",
+      "PRISM       NaN           NaN          NaN\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"Photometric conversion information:\")\n",
+    "\n",
+    "# Common fields in Roman PHOTOM files\n",
+    "df = pd.DataFrame.from_dict(photom.phot_table, orient='index')\n",
+    "print(\"\\nFull Photometric Table:\")\n",
+    "print(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f72aa18c",
+   "metadata": {},
+   "source": [
+    "Get unit values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "f3151ce7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PHOTOM Units Summary:\n",
+      "\n",
+      "DARK  :\n",
+      "  photmjsr     : None   [unknown]\n",
+      "  uncertainty  : None   [unknown]\n",
+      "  pixelareasr  : None   [unknown]\n",
+      "F062  :\n",
+      "  photmjsr     : 0.5836263702584822   [dimensionless]\n",
+      "  uncertainty  : 0.022705656904495823   [dimensionless]\n",
+      "  pixelareasr  : 2.8083389953727505e-13   [dimensionless]\n",
+      "F087  :\n",
+      "  photmjsr     : 0.8050920510180883   [dimensionless]\n",
+      "  uncertainty  : 0.03132165511790955   [dimensionless]\n",
+      "  pixelareasr  : 2.8083389953727505e-13   [dimensionless]\n",
+      "F106  :\n",
+      "  photmjsr     : 0.7417487930165987   [dimensionless]\n",
+      "  uncertainty  : 0.028857321159254122   [dimensionless]\n",
+      "  pixelareasr  : 2.8083389953727505e-13   [dimensionless]\n",
+      "F129  :\n",
+      "  photmjsr     : 0.7388933595729765   [dimensionless]\n",
+      "  uncertainty  : 0.028746232121149497   [dimensionless]\n",
+      "  pixelareasr  : 2.8083389953727505e-13   [dimensionless]\n",
+      "F146  :\n",
+      "  photmjsr     : 0.24039322273833708   [dimensionless]\n",
+      "  uncertainty  : 0.009352363628198133   [dimensionless]\n",
+      "  pixelareasr  : 2.8083389953727505e-13   [dimensionless]\n",
+      "F158  :\n",
+      "  photmjsr     : 0.7367810113020512   [dimensionless]\n",
+      "  uncertainty  : 0.02866405239530676   [dimensionless]\n",
+      "  pixelareasr  : 2.8083389953727505e-13   [dimensionless]\n",
+      "F184  :\n",
+      "  photmjsr     : 1.1337095345751624   [dimensionless]\n",
+      "  uncertainty  : 0.04410633417749541   [dimensionless]\n",
+      "  pixelareasr  : 2.8083389953727505e-13   [dimensionless]\n",
+      "F213  :\n",
+      "  photmjsr     : 1.1758909217444202   [dimensionless]\n",
+      "  uncertainty  : 0.04574737740930944   [dimensionless]\n",
+      "  pixelareasr  : 2.8083389953727505e-13   [dimensionless]\n",
+      "GRISM :\n",
+      "  photmjsr     : None   [unknown]\n",
+      "  uncertainty  : None   [unknown]\n",
+      "  pixelareasr  : None   [unknown]\n",
+      "PRISM :\n",
+      "  photmjsr     : None   [unknown]\n",
+      "  uncertainty  : None   [unknown]\n",
+      "  pixelareasr  : None   [unknown]\n"
+     ]
+    }
+   ],
+   "source": [
+    "def get_unit(val):\n",
+    "    if hasattr(val, 'unit'):\n",
+    "        return str(val.unit)\n",
+    "    elif isinstance(val, (int, float)):\n",
+    "        return \"dimensionless\"\n",
+    "    else:\n",
+    "        return \"unknown\"\n",
+    "\n",
+    "print(\"PHOTOM Units Summary:\\n\")\n",
+    "for filt, info in photom.phot_table.items():\n",
+    "    print(f\"{filt:6s}:\")\n",
+    "    print(f\"  photmjsr     : {info.get('photmjsr')}   [{get_unit(info.get('photmjsr'))}]\")\n",
+    "    print(f\"  uncertainty  : {info.get('uncertainty')}   [{get_unit(info.get('uncertainty'))}]\")\n",
+    "    print(f\"  pixelareasr  : {info.get('pixelareasr')}   [{get_unit(info.get('pixelareasr'))}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "599cf801",
+   "metadata": {},
+   "source": [
+    "### Extracting Zero Points and Units\n",
+    "\n",
+    "We can use this information to calculate the AB magnitude zero points"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3841c750",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Full Photometric Table with Zero Points:\n",
+      "       photmjsr   zp_ab   pixelareasr  uncertainty\n",
+      "DARK        NaN     NaN           NaN          NaN\n",
+      "F062   0.583626   9.485  2.808339e-13     0.022706\n",
+      "F087   0.805092   9.135  2.808339e-13     0.031322\n",
+      "F106   0.741749   9.224  2.808339e-13     0.028857\n",
+      "F129   0.738893   9.229  2.808339e-13     0.028746\n",
+      "F146   0.240393  10.448  2.808339e-13     0.009352\n",
+      "F158   0.736781   9.232  2.808339e-13     0.028664\n",
+      "F184   1.133710   8.764  2.808339e-13     0.044106\n",
+      "F213   1.175891   8.724  2.808339e-13     0.045747\n",
+      "GRISM       NaN     NaN           NaN          NaN\n",
+      "PRISM       NaN     NaN           NaN          NaN\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Add Zero Point column (AB magnitude)\n",
+    "# Approximate conversion: zp_ab ≈ -2.5 * log10(photmjsr) + 8.90\n",
+    "# (check the constant for Roman)\n",
+    "if 'photmjsr' in df.columns:\n",
+    "    df['zp_ab'] = np.where(\n",
+    "        df['photmjsr'].notna() & (df['photmjsr'] > 0),\n",
+    "        -2.5 * np.log10(df['photmjsr']) + 8.90,\n",
+    "        np.nan\n",
+    "    )\n",
+    "    df['zp_ab'] = df['zp_ab'].round(3)\n",
+    "\n",
+    "# Reorder columns \n",
+    "cols = ['photmjsr', 'zp_ab', 'pixelareasr', 'uncertainty']\n",
+    "df = df[cols + [c for c in df.columns if c not in cols]]\n",
+    "\n",
+    "print(\"\\nFull Photometric Table with Zero Points:\")\n",
+    "print(df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc5e4ad3",
+   "metadata": {},
+   "source": [
+    "### REMOVE FROM HERE ON Loading Throughput Curves into STPSF\n",
+    "\n",
+    "The full wavelength-dependent throughput curves are loaded separately using **STPSF**|. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "d4216b4e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Bandpass loaded successfully!\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjcAAAHGCAYAAACIDqqPAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAWR9JREFUeJzt3QeYVNX5x/F362xhlyK9iQhRQYIdxF6xxt5L7CWxYoyCMZa/Bo0t9mhsMVhjxBa7YkeJgIINREVQel1Ytu/8n9/ZuePMMgu7y+zeO7Pfz/PMMzN37p1yp9x33vOeczLC4XDYAAAA0kSm308AAAAgmQhuAABAWiG4AQAAaYXgBgAApBWCGwAAkFYIbgAAQFohuAEAAGmF4AYAAKQVghugDbvjjjvs/ffft1Q2c+ZM+9vf/maLFy+2VFNWVma33367zZ07d63bZsyYYY8++qh7bZ9//rkvz6+teuqpp+y9997z+2lgA2RvyMbAhrr//vutuLjYjj322Ljlq1atsgcffNDat29vp556atxt1dXVdvfdd9uvfvUr23///d2yRx55xFasWJHwMY444gjr06dPdL2cnBw74YQT1vm8Gnt/nq+++somTJhgNTU1dsEFFyTc7oUXXrDvv/9+reVFRUV2+umnr7W8qqrK/cDOnj3bQqGQbbHFFrbtttuu83m/88479tlnn9n6FBYW2plnnmmjRo2yiy66yHbZZRdLVVOmTLGLL77Ydt99d+vSpYsvz+G7776zF1980X2Ou3fv3ujtbr75Znv44Yftd7/73Vqfv3POOccOP/xw69q1q/s+pIKpU6faN998Y2vWrLH+/fvbsGHDrKCgwN32ww8/2PPPP9+o+9H388svv4z7LOfm5lrPnj3d+9yhQ4cmPXZjvh/6bnnfg2XLlrnv8bfffut+n5B6CG7gq2eeecYmTpzoAgYFHR4FCjpgZWZm2mGHHRb3YzZp0iR3QP7LX/4SDW6uu+46W7lyZcKgRf+OPVqvXbt26w1uGnt/jz32mN1www1WW1trq1evtp9//rnB4EaB3EcffWQnn3xy3PJEP9QKak488UR3eZ999nE/2GeffbZtvfXWbp81dABdunSpC4Y8ymY8/vjj7od++PDh0eX8YCfX9OnT3edV+7ixwc2SJUvsxhtvtFtvvTXusy/XXHONHX300S5zkwoU3J100kkuw7TffvtZ586dXUZqzpw5dv7559v//d//ue9N7GdT/vGPf7jP4jHHHBO3vLKy0n3O9SdGQbiCFAV4N910k/tM33vvve7xGvvYnvr3GUsBkUd/NvQb8Ne//tWdIwVpbinAL2PHjtXcZuEPP/wwbvmFF14Y3mKLLcI5OTnh5557Lu626667zm3z8ccfR5dtuumm4aFDh6738ZK93osvvhieNm2au3zIIYeEs7KyGlz3wAMPDG+22Wbrvc/a2tpw7969w/379w+vXr06uvzzzz9393/yySeHG2vq1KluX1111VUJb9f9XXLJJeFU9sQTT7jXqNfql/Hjx7vnMHHixEZvc+ONN4bz8/PDK1eujFteWVkZzsjICF955ZXhVLHNNtuEu3btGp4zZ07c8gcffHCd36Nu3bqFhw0blvC23//+926fzp8/P7qsrKwsvO2227rfBe+xmvLYie6zIX/4wx/CXbp0CVdUVKx3XQQPNTfw1V577eXO33777bjlun7ggQfa9ttvn/A2/dvbbrvtzG8HHXSQDRkyJKn3WVJSYj/99JPtuuuurvnI8+tf/9p69+5tX3/9tbUEZZX+/ve/u+YVNYmtqz5H2TatqyYhj56zMln6V/3KK69YRUVF3PZaV/Uj5eXlccv1T1zLVTtT37Rp01zG68knn3T/3JWZ0rpqfkhE2QH9O7/vvvsSNj/E1uco06baCt2/Mi/1Nfb5qjlE+0x0f7pNJzVVrouankaOHBmXRfv444/ttttu059Ol6H07kvXY5+7Xuezzz7r3hNl9WK31+tRk26iOh01jY4bNy66Lx544AF77rnnXFOvR00x2l77vLS0dJ2vwdsf2lcHHHDAWs21p512msscJkteXp7LfOrzqSamlnzsI4880t3/Sy+9lIRnjtZGcANfbbPNNq6uRs1QHv2gfPHFF7bHHnu49vXY4EYHTB1Yd9ttN8vKyrJUo4OFmhruueceV3+gpq/6tD8GDx5skydPjjvoKM0+b94822mnnZL+vJSGv/76612AoxS/mlfqByeqzxk/frwdf/zxLtX/2muvRd83NaNssskmrpnhk08+sXPPPdcGDhzoXoNH76OabhRUxFJTnpbHBkpy4YUX2lZbbeUO4gqW9Hnwmis//fTTtV7Djz/+6IJl7Vdtoya8sWPHJqzP0f3oM/Tf//7XravH0euL1djnq2B00aJF7vL8+fNd04tO9beLtWDBAhek7rjjjnHLVeel1+Fd9u5LwY333N99910X+Op5K5DR46uJS8sULL311lvugKz3UE26scGP1lczqs5Vy/bhhx+690q1JgqY7rzzTvvtb3/rll9yySVuHyb6jMZScJadne2C20QGDRpkyeQ14em70ZKPrd8mBVPan0g91NzAVwpQdJB5/fXX3cFUhbM68KjWRj+4+iHTAUoHDxVWKrDRj/Cee+651n15/6hj9e3b1xVlNkey708yMjLs5Zdfdj/IyoKocFH1AfqXGUsHrrPOOst23nlnl8HSAUpZAdUAJbsGQP/QFWz95je/if7710FX/+p///vfr7WusgX6V+sdpP/973/b1Vdf7epH/vjHP7rlOuAq0Dj44INdJiA2A9UY+setx9Fz8IqtdQBf175XxkOBjVdUfN5559m1117rDuL162D0vup96Natm7uug71qmpQpPO6445r0XPX5Xb58uQsoVAsWW9vUEC8wqn/wVc2I3nO9H7qs/VqfanSUKdJrUjZL3xUFnMpUKduz+eabu/X0XVHAc+mll7o6E48CMNWpKIARvT/aRu+1itsV4HoFwApQ77rrLrviiisafC36zurzq32ogmplVnbYYQdX+9IS9N3Q90if0eY+toJwvdb6wbTu16PfHnVaSBRII/jI3MB3Oggq9a8fY+8fs5qc9OOjLIUCAS9D4J17zVn1ixC9f7reaeHChc1+Xsm+v8svv9wdMBQgqGlAXX11ADvjjDPiMlce/WtU8KADkXpZKeujH1z9i0+mfv36RQMb0cFZBzWl/evTAdULbLzraobq0aNHXOZD/6h1YNaBVNmeptLBZ9NNN40L+nTAWlfgoYNbbG8pHej0uVImqT4VsHqBjajAdMCAAa6prTV4n6ONNtqoydseddRR0WBN3xFleNTcpM+RF9iIDv56r9TEFNu0pkzMmDFjotf1XitL8c9//tOuuuqq6HJl4vQ9TPTZrE/Bk7I++qzqs6T3Qfer7I+aEjeEPgsKRhXUK/BTJkWZQu+1Nuex1fW+/nc70fdK74+XlUNqIXMD33lZGAU1aobSj6n3D109GvRvWst0QNI6+vHacsst17qfXr16rZVp2RDJvj/9MNcPXvQPXTUi+uepZhdRc4Yu6+Cr7rBe1mPWrFnuIKSMUnMChoYk2pfqcqvml/qGDh261jI9RzXrKAiNpSYNURNjU+k+R4wYEfdPuqHn2tBteg3SmNehx1FNU6KAriV4B9L6r68x9DxjebU93v6OpWUKpvXZ8faP6rbU9BlLnzUFqJ06dYpbriBKQfj66L1XpkwnZVb1/ukzqmza008/7ep/6t93YykQ0e+AAnv1qlSwo2ERNuSxldFrTK82ZcXUExKph+AGvtOPrpqcFMDoQKRCRwU5Hl1W04eaZpR2P/TQQ5t1UAgiBWrKSHh1FqIDrGpr/vznP8c15yizcMghh7iiXQVA6tKeDInuRweMRDUjiTINGtunfmDj3Yd3u3g1UvUPFrFd6z1aZ1332ZjX4a2rDFx9ieq1tH7sc2vK820qL8OkZsmmqv8eePu3Me/But7vhpYnKi5fl/z8fJfx0UnZH2XFVDxdv6apsRobiLTEYyvz49fYSdgwNEshMNkbNR+obkH/0GKzHApuVBegmhMdqBI1SaUqBRD6AY398fYOnvXHPvGW6V9//WJfP6kJIFEPLi+joNtjMyn10/yJej4pkEuUMUjUo6o5Ej2mXoP3XJv6fPUPvznZl2S8Hu85N/QeKEiLHcMl2dTk1VDzj5chSzQCc9AfWwGhMl6JspUIPoIbBCa40T9E9eRQM1RsxkJ1Nzqo6x+ct26qUVNSoh4dKtRUsKKC0NjXq9FYVVQbWwegH3H17lHX8+bUarQU9a5RLdETTzwRXaaeLCoEV02ImhJE/6YVBKg+xKNsnGo96lOPLTVnvfrqq3EHsmQNavevf/0rLgOj4mJ1B48dYLEpz1eZR2lsfcnGG2/sap0S1QM1lWqT9JlRc03sFBSqQdFnSPu/fvFssgN01Wkpq1qfmoWkMUXWQXtsff50/6n4ewOapRAQ3g+ICvvqjwrs1d2oF4fGstC/+qBQe75XcKmDiYIRr05HBy81oYl6tWg0ZTXBeT1kVBipg9uVV14ZV6SrjIGKJNXzRiMLe72l1BylOh0N1x8k6tXldSFXrze9bnXd1sFB9R5eIKaDsNZV0aoCPS1XE5yaDtS9OZamHtB9af+pt5OCB+0vBVKqu2pqpqQ+jf6sz5xGf1ZAoH2qJj91i/Y05fmq5kivW4W6CpL0Pu27777r7Iqs56BCWAVtWn9DKODS4ykgU9G1/igoEFTRrXo7tSQ1BalpVQXMeg4KtJRhVW9A7Sf1QtNoy6n22KrbUVCozwVSDzU3CAQdSEaPHu0O4ol+jNTzQQFO/WJKjw6AynasT7LXU9DiDSmv5jKdvOv64fWoWUBNBBobRl121WNFBzcFLKoNqE89X9TzQ11+dX/6kVUXYB3sG/O8PKoXUBfXhv696jZ1F65P//br15Y0tK4CDR1IFRgoAFE3cGVAdB+xPZJEBdQ6CCmoU48qNTUqINR9b7bZZtH11JSiweX0+tWLTvtSPcy82qTY+hBtp+3r10Yo+6fliQpt1V1YgY0eX9Nf6F++uq3Xr+Vq7PNVcKIAT/ejZhBlrtY1zo3owKvh/fU6Y+dW0/ub6D1r6HV63x+vkNYLrlSkrtcUW4ujA3WiOh+tp0A60SCVifZf/f2s90hNOAoolMXT61fArp50sT246lPw2FChsYrq9dzXNYxAUx+7Mffp1Vnp86ZgOlm1bWhdGRqmuJUfEwCaRV21FUSp7iU2uGgsZZKU2dCowsq2+E2Frm+++abLAKZLkXw6UBOrgk/V+tUP0JEaqLkBEEj6Nx5LGSENeKgCz+YENkGkHnHK9sX2loP/lN3S+EAENqmLZikAgaRBD9U0piYkBTYamVYDGaoWJ12oSUzjsSBY6o/MjdRDsxSAQFKL+RtvvOHmp1KNkrI1Gtyx/gB0TaHmKBXfakoCDdIIID0R3AAAgLRCzQ0AAEgrBDcAACCttMmCYo1hoLl7NHYI3S8BAEidWjyNL6bBTtc1mGebDG4U2GikWwAAkHo0WKZmuG9ImwxuvHlWtHM06igAAAg+DQuh5MT65ktrk8GN1xSlwIbgBgCA1LK+khIKigEAQFohuAEAAGmF4AYAAKQVghsAAJBWCG4AAEBaIbgBAABpheAGAACkFYIbAACQVghuAABAWvF9hOKKigp7/fXXbeHChTZkyBAbNmzYOte///77rbKycq3lgwcPtj322KMFnykAAEgFvgY3ixYtst13391dHjp0qP3xj3+0ww8/3B544IEGt5kxY4YLiDwrV660cePG2Q033EBwAwAA/A1uLr/8csvJybGPP/7Y8vPz7bPPPrNtt93WDjnkEDv44IMTbnPLLbfEXb/77rvtySeftN/+9ret9KwBAECQ+Rbc1NbW2jPPPGPXXHONC2xkq622shEjRthTTz3VYHBT34MPPujW7d69ews/YwAAWl9NbdjWVFbbmsoaK62otrKqGqusrrXyqlpbVV5lFdW1lpOVaaGcTAu58yzr3C7X+nQssMzMdU8wma58C27mzp1rq1atsi222CJuua5/+umnjbqPKVOm2NSpU+36669f53pqxoptytKU6QAAtKSqmlpbXlppqyuqrbSiJnJebaWV1dHLqytqXICyqKTC5q8ss4UlFVZeVeO2VVBTVRt2gUxzdCjIscO37m2/32NT26hdyNoS34IbBTbSoUOHuOUdO3ZsdPChrE2fPn1s5MiR61xv7NixLkMEAMCGUNCxYGW5zVtRZvN1vrLMVpVXW1lljcugVNfU2sJVFfbj0lL7aXmZC1CSRUmYwlC25eVkWW5WpuXlZFpRXo6FsjPd86rUqbrWZXYULK1YU2UPffiDvf3NQnv8zOHWs0NdK0lb4Ftw4zVFeUGOR4FNQUHBercvLy+3xx9/3C666CLLzFx3j/bRo0fbqFGj4h5DQREAALW1YVtZVmVLVlfYYp1W1Z2WrK50mZelpZXuNmVWFq2qsHC4iQFJbrYLSgpDWdbOnUdOuVnWLi/b2oVyrFtxyHq0z7OuxXlu/eysDMvOzLDsrEzLz8mygtwsF8RkZDSumamqptY+nLXErhj/hc1eusYueGKq/fucHRu9farzLbjp27ev5ebm2g8//BC3/Pvvv7eBAweud/v//Oc/Lkg57bTT1rtuKBRyJwBA220eUmAy/eeVNu2nlS7zooBFp6WrK626CRkWZU16dsizHu3zrUeHPGufn+OCj9ysLBeUbFSYa/06F9omnQuta1HIl4AiJyvTdt+sqz151nDb57Z37dMfl9ubXy+yfQZ1s7bAt+BGvaT2339/l30588wz3Zv/008/2TvvvOPGsvFMmDDBFixYYMcdd9xaTVL77bcfGRgAaGPU1KMsyrLSSquqCbvalQUl5bZwZbktXFXummSUbdHtS1dXWEl5daPuV0GKCnE7twu5DIqCFJ06tas7VzCjph1dTpVC3T6dCuy0nTaxe975zu59Z1abCW4ywuGmJNiSS2PWqHfU8OHD3eB9Gq+mV69e9sYbb1h2dl3cdcYZZ7iu4l988UVcdmfAgAH27LPP2qGHHtrkx1XGp3379m6MnOLi4qS+JgBA01RUq6i22krKqlwgogLb1eXVNnf5Gvtx6RqXecnMyHBZlh+WlNrcZWWuvqQpFIt0Ksy1gV2LbKu+HWyTjQqtc1FdINOlKGQbFYYsNzs9B+1fWFJuw/7ylimB9L8r9navOVU19vjt6zg3m222mQta/vWvf7kRiseMGWMnnHBCNLCRPffc0/r37x+33Zw5c+yCCy6wgw46yIdnDQBIVLOi04rIuTutqXTnXsBSUlZtJeXx172uzE2lpqGN2uW65hfVpHRrn2fdi0PWrbiubqWzMi7KvLTTecg65OekTLYl2boV59mWvYrti59L7J0Zi+3IbXtbuvM1c+MXMjcA2nqzzoo1lbZ8TaXrUVMSE3hkRG73imgXr6p0Y6woq5GVkeHGWllTVWNrKiLjrlTWZVyS0SmoKJRtxfk5VpSX7WpY1ATUb6NCy8/NcgFUh8Jcl3HZeKMCd1tWGw1WmuPWN2baHW99a/tv2d3uPXFbS1UpkbkBADSdmmlUT6LakkWryl12RAO6qQuwxkhRDUo0g7KmylZVVFtWhrnr2k63tcTfWvX+Ud1K+4Jca5+fXXc5cirOqwta6oIXXc+uO8+vO1cvIoKVlrPbrzq74OZ/s5dbW0BwAwA+UjCiDIqCjuWlVbZMGZVIMayWL40Uxapbss41+JuKaJNBQYcGeiv2goxQjluu0TVUl6E6FNWlKPDQ+CnK6CiLUphbl1kpCNWd6z465Oembc1KOti8e7GruanrHVaR9oP6EdwAQJJoADdlRbzgxJ2iwUrVL0FM5FwnNe00h1pk6nr1qJ4k1wUdqj3RwG4FuXVZExd0FOS4YKQ2HHZZEwUsqkXRctWroG0oDGXbxp0K3Jg3MxasshEDCG4AoM1RjYd68CyLZlViAhUt0wBv0WClrrlHzT7NoeaYjgUqfM1xgYdOddcVhKhHT12vHhXHKsuibImacmjGQVNs1r3IBTdfu+Cmc1rvPDI3AFKS+kKol01FVa2VV9fVmqjupO68rui1XMWvlTWuFqUsclnrKsOiph3VriggqQtSqlzhrHc/av5p7tD5yop0igQnHRWsFETOC3OiQUvsctWftJWRY+Fv09RrXy60b+an//yKBDcAGh1AxJ5rbJLymPPKmhrT0CNq/lDWQ3GBuxwOR2Y1ron0yqly29fdVldzoqYcPY4KUtVUUjehoLoJq0dO3QBsylJorBMFJApWtH5r9PVUvUnHwoaClV8yLF7gouYgDZkPBM0WPYrc+TcL4qc9SkcEN0AKBhwaKt5lJCJdcddUKCvxS9dc111XXXWratxgaAoSNJ5IaaUCkLpgwws6FCQowHBBjBewKHtRXTcJXypQ/YkmE3SnbE0omOVqUNR8o8uu+DW3bsJB1aXkZEfm7cnMdMGIF7QokNH8PVrPC2pC2Vl+vzwgKQZ0befOZy8tTfs9SnADtAAFDfUDBq+LrhuJNWYgM133ggitu7KsOm4QNHd7jWYbrmtGacocOC0VQHgBgM5D3rnGQYlkV7Ru3XmG63mjJhdlZep65eS4olfvdvWwUTOOgggFaNpnGu9EEwqqrkTbuX0aCcbqZkPOslBO3XletrI9GTTrAOvRo31kwurIb5C+j+mK4CaF6AD4v9nLbObCVe6fucaMUBrcnSIp8UL9O83VgYZ/m+ujA6VXi+FqNCK1GTrAevUZdefVVhYZQ0QZjeg21bXuvKxKTSh1gcvqmAxJa1D2wctKFIR+yVAUesvUbTekIKHupMvaRkGFJvjTuT4rCjbWOq8XxNCzBkhthaG6XnT64zR/RbkVdye4gc8mfLPIrhg/3eatLG/U+kqpd2+vWWvz3NDbOu/TscB+1b3IdQfUv+KmHKy8ieoUBOiA6PXSUBYhtplDNRDuZHX1FGpCqUs01J3XBQN1B37XLJCVGWkeyHC3K0NREc14KFtRl9Fwt1XXuNtVCKrbKiMnZTPc5UhWQ/Ue1bV129fVbtQFJV6Nh9ZtzQBEWQUvYIgGGqG6Ac2UmdC5shAZlmG5WRkus6EeMl5XXt2ubIXeLwUkOs/JzHTNLowrAqApenbId8HNvJVlrvdUuiJzkwI+n7vCzhk32R2s1SV0u407uQG3NFy6N3y6uqZqOHVvcC8VY85atNqdGqIDo3ppdC3Kc4FQl3Yhy9IwphE1NWGbX1Juc5aW2k/Ly3xrDmkNqsPwxgnxajV02cuExI4honNlNWK3UdBSGKqr0/BGYtVtCmrorgsgKHp1yLOv55fYvBVlls4IbgJOmY/L/jPNBTZ7bd7V7j5hG9dM0BBlMdScohEoF6wst/kry21BSbn7IKuIbMaC1W6ESlEGQ6Oe6vRVI7oGKnvgzfGi+ofY7ItXZ6HerLqsEEl1Fhn1lnmFnrqsYEl1JMqy6FzrKRhQFkPNILmqpcisuw+zjMiyzLosRrayHHWZC53cbVl1NR+u7iMzwxWWKthQ4BGtB8nMcFkPBYe6ra7INJN6DQBtqu5m/orGtQKkKoKbgPtyXonrtqcD+C1HD11nYCNqsmifX9cDpH+Xusr4RAGQ19VW6UnNT6MAaMmqirjJ7xRUdCsOWd9OdRPVqXmLLAQApHazlJC5ga+enfKzO99nUDdXh5EMCoB0Xzr17mg2uGdS7hYAEHA9O+S585/TvFmKkaYC7vWvFrjzw7bq5fdTAQCkSeZmfiM7p6QqgpsA0zgEKuSV7ft18vvpAABSXPfiuszNwpJyV9OZrghuAmxmZIhsdeNuX5C+4xEAAFpHp8K68gZ1UvGG5UhHBDcB5s3/kc5jEQAAWk9BzPhYmsk+XRHcBNg3C+q6ZxPcAACSISMjw038KgQ38MWMSOZmczI3AIAkN00tI3MDP3y3uG7m1l91o1kKAJAcnQhu4BfNDu1F1T0jI0oCALChOhHcwC+aEsGbdFGTJwIAkMzgZvkaCorRyhaV1A2wpMksVQAGAEAydKSgGH5ZtKpucssukQGXAABIhk7tKCiGz8FN16IQ7wEAIGk6RTI3y0ur0navMs5NQC2ONEsR3AAAkqljYV0d59LSuj/R6YjgJvCZG5qlAADJs1FhXYvA8jVkbuBXcFNMsxQAIHk6RnrgqrdUbW16Tp5J5iagFq2iWQoAkHzF+XXBjSYFL62sTstdTHATUItKaJYCACRfKDvTsjPrhhhZXUFwg1YSDoejoxN3LqqragcAIBkyMjKsKC/bXV5VTnCDVlJWVWPVkXbQ4jxGJwYAJFdR5Niyqjw9i4pplgogL5LOysywgtwsv58OACDNFEUyNyVkbtBaSsqqoh8+pl4AACRbEc1SaG1eJO19+AAAaIlmqdVpmrnx/ei5fPlye+aZZ2zhwoU2ZMgQ+81vftOobMXkyZNtwoQJVlBQYEcccYR169bN0kVJpA20KES9DQCgJTM3VWm5e32tufnxxx9dQPPoo4/a0qVL7fzzz7dDDjnEamtr19mT6Nxzz7W99trLfvjhB3faZ599bObMmZZuNTfF+b7HngCANFQUSu/eUr4ePf/4xz9anz59XAYmOzvbzjvvPNt8883t6aeftmOPPTbhNvfdd5898sgjLnMzaNAgt2zMmDFWXl436F068CJpL20IAEAyFdFbqmVUV1fbiy++aCeddJILbGTTTTe1XXfd1Z599tkGt7vjjjvs+OOPjwY20rFjR+vRo4eli5KySOaG4AYA0AKK0ryg2LfMzZw5c6ysrMwGDBgQt3zgwIE2ceLEhNusWrXKvv76a7vsssvs1Vdfddmbnj17ujqdjTbaqMHHqqiocCdPSUmJpUbmhmYpAEDLZW5K0jS48a3mprS01J0XFxfHLW/fvn30tvpWrlzpzu+8804bO3asW2/cuHEuIJoyZUqDj6V1db/eSU1hqVBQXExwAwBoAUWR48vqivQsKPYtNdCuXbu4gMWzYsWK6G0NbaMeUu+++250uQqKL7/8cnv99dcTbjd69GgbNWpUXOYmyAHOLwXF1NwAAJKvKM2bpXzL3PTt29cFKfV7Oem6iooT6dChg3Xv3t2GDx8et3zHHXe0b7/9tsHHCoVCLkMUewoy78NGsxQAoGULiqvTcgf7FtxkZWW5bt/qBl5VVZcWmzFjhr3//vt25JFHRtd77rnnXDOU55hjjrEPPvjAdQn3aJvBgwdbuo1QTEExAKAlFDHOTcu58cYbbfHixbbTTjvZ7373O9tjjz3s0EMPdYPyeV566SXX/dtz1VVXuVobZWvU1KRtFRTdcsstli5+ydzQLAUAaNlmqXBMsiBd+NodR3Uv06dPt/Hjx7sRih966CEbOXJk3AjFhx12mO2www5x3b4nTZpkL7zwghsE8MILL7QDDzzQCgsLLe1GKKagGADQAooif56ra8NWXlVr+Wk2SbPvfY2Liors5JNPbvB2BS6JamiOOuooS1cUFAMAWlJBzi/BzJrK6rQLbnydfgFrq60N2+oKCooBAC0nMzPD8iMBzprKmrTb1QQ3AbOm6pcPWWGu74k1AECaKohkawhu0OLKYiLovBxiTwBAyygI1QU3pZXp1x2co2dAgxulC2MLqwEASKaCnOy1/lSnC4KbgFlTVR2XLgQAoEUzNxVkbtBamRuCGwBACyqIHGfKYmo90wWZmwA3SwEA0FIKIp1WSisIbtDCvKp1mqUAAK3TW6o67XY0mZuA8dKDNEsBAFojc7OGgmK0NJqlAACtoTCSuaErOFqclx70ImoAAFq0oLiSmhu0sLKqWndOsxQAoCUVhCgoRispi2Ru6C0FAGidruDVabejKSgOGHpLAQBaQwFdwdFa6C0FAGgNBXQFR2uhtxQAoDUUMCs4WgvNUgCA1lDAODdo/WYpuoIDAFpOAc1SaC00SwEAWkNhpCv4GuaWQktbE+mSx9xSAIBWydxU1Vg4HE6rnU1X8KBmbiIfOgAAWjK4qakNW0V13QCy6YLgJmBolgIAtIaCmNrOdJs8k+AmYJQeFJqlAAAtKSszw3KzM+M6s6QLgpuAoVkKANBa8iLBTTnBDVpKbLsnc0sBAFpafprODE7mJkBi04KxbaEAALSEvJy64IbMDVpM7IcrL4e4EwDQsvKjwQ29pdBCvCYpFXhlZGSwnwEArZK5KaPmBi2lIvLhCkUKvAAAaEl5kVYCmqXQ4pmbUDYD+AEAWq9ZqozMDVo+uCFzAwBoeXkUFKPVmqUoJgYAtGpBcU1a7W9SBAFSHsnc5NEsBQBoBXnRcW7oLYUWQuYGANCa8iJ/psurydyghVBzAwBoTfm5kbmlGKEYLYXeUgAAXzI3VemVufF9jP+ff/7ZHn30UVu4cKENGTLETjrpJMvNzW1w/ccff9zee++9uGW9evWyK6+80lJdRSQtSG8pAEBrzi1VnmbBja8Fxd98840LaCZOnGhdunSxm266yfbee2+rrq5ucBsFNpMmTbKtttoqetpss80sHVREhr8ORarXAQBoSXlpOs6Nr5mbyy67zIYOHWrPP/+8m27g1FNPtU022cTGjRtnp5xySoPb9e/f38455xxLN15BlzcFPQAArTPOTW1a7WjfjqJVVVX26quv2nHHHRedR6lnz562xx572AsvvLDObWfOnGmjRo2ya665xt5++21LF79kbghuAAAtLz9NMze+HUV//PFHq6ysdJmaWLo+a9asBrdTINSnTx/r3r27LVu2zA4++GA788wz1/lYFRUVVlJSEncKIgqKAQCtKS9N55byrVmqrKzMnRcVFcUtLy4utjVr1jS43Z/+9CdXQOw56qijbJdddrEjjzzSRo4cmXCbsWPHuixP0FFQDABoTfmMUJxcCmJkxYoVccuXL18evS2R2MBGdt55Z+vbt6999NFHDW4zevRoW7lyZfQ0d+5cCyIyNwAAX0YorkqvzI1vzVJqWlLW5quvvopbruuDBw9u0n2Vl5dbTU3Db0woFHIBU+wpiLy0IDU3AIDWHeemNq12uG/BTWZmph199NH28MMPR5uhJk+e7DIwxx57bHQ99Zz6v//7P3dZXcRfe+21uPvR9osWLbL99tvPUh0jFAMAfBnnppLMTdKoFiYcDtvWW2/tAh2NcaPi4AMPPDC6zjvvvGNPPfVUtJj47rvvtm222cYN9rfbbrvZeeed58bHUfNUuvSW8rrmAQDQKgXF1ekV3Pg6zo0G7psyZYq9+eabboRijXuz7bbbxq2jIGbfffd1l7Oyslw3cTVdTZ061Tp27OjW79atm6UDCooBAH4UFFfVhK2qptZystJjKBLfp1/QVAsHHHBAg7crO1PfoEGD3CndUFAMAGhNeTEtBar7TJfgJj1eRZqg5gYA0JpC2ZkWGUc3rYqKCW4CpILeUgCAVpSRkZGWM4MT3AQIzVIAAL+KiivSqKiY4CaAmRvvgwYAQEsLpeFYNxxFA4TMDQCgtYXI3KAlUVAMAPCjqDh2rLV0QOYmQJh+AQDgV3fwcmpukGzVNbVWXRuOa/8EAKClhcjcoKVU1tSu9UEDAKClhSJ/qL3SiHTAUTQgYts6CW4AAK2euammKziSzIuYszIzLDtNhr8GAKRQzU0VmRskGZNmAgD8ECJzg5ZSGcncpMukZQCAFBvnporMDVqooDiXYmIAQCsKUVCMls7c5JK5AQD4kLkpZ+JMtFRwQ08pAEBrCpG5QUs3S1FzAwBoTSEKitFSqqi5AQD4GtzUps3+p2tO0GpuKCgGAPgyzk1N2ux3gpuA8CJmCooBAK0pROYGLT7ODZkbAEArCkUyN4xzg6SrqqmbEZzMDQCgNeVRUIyWUhmZsIyu4AAAPzI35YxQjGRjhGIAgB9CZG7Q8nNLZbCTAQCtJkRBMVpKpVdzQ0ExAMCHruAVjHODlptbqu5DBgBAa2ZuyhnnBsnGIH4AAF+7glczQjGSrLKmrrcUzVIAAD8yN5XVtRYO15VIpDpGKA6IqmpvnBsKigEArV9zk07ZG4KbgKArOADAD6GYjizpMkoxwU3gCop5SwAArSc7M8MyI40GFZEBZVMdR9KgTZyZTW8pAEDrycjIsFDk2EOzFJKqqoZB/AAA/sjLqct1kLlBUtEVHADgl1B2es0vRbNUwAqKmTgTANDaQmRukuvLL7+0Cy+80I499li7/vrrraSkpNHbvvzyy3booYfagw8+aKmOzA0AwPf5parI3EQpIHnyySdt0qRJTdqZn376qW2//fZWWlpq++yzj73wwgu28847W3l5+Xq3nTt3rp1zzjk2ceJEmz59uqVPzQ3JNACAP2PdlLfl3lLPPPOMy7RIbW2t7bHHHnbGGWfYiBEjbNy4cY2+n9GjR9tee+1lDzzwgJ1++un26quv2nfffWcPPfTQOrerqamxE044wf70pz9Zjx49LB3QFRwA4JcQmRuz6667zq688kq3Qz744ANbvHixLVy40MaPH29//etfG7UjlZ2ZMGGCHXHEEdFlHTt2dMHOK6+8ss5tr776arfuWWedZenXFZzMDQCgdYXSrCt4dnM2mjlzpm266abu8ttvv22HHXaYFRYWuqYlL6PTmGYlZWD69OkTt1zX33333Qa3e+edd+zhhx+2qVOnNvr5VlRUuJOnKXU9rd0sRXADAPAtc1PdhpulevbsaR9++KFVV1e7JiplW7yApVevXo26Dy/YKCgoiFverl27BmtulixZYieeeKJrxurSpUujn+/YsWOtffv20VP9gCpQ0y9QcwMA8KvmpqoNZ27Uu+nAAw+0Tp06WXFxsY0cOdItV1Hxcccd16j7UJAhy5cvj1u+dOlS1+SUyNNPP22rVq2yv//97+4kP/zwg1s2e/Zse/bZZy0zMzNhbc+oUaPiMjdBC3DoLQUA8EsozTI3zQpuzj//fNthhx3sxx9/tH333ddCoZBbrqzNUUcd1aj76N27twuOPv/8czvggAOiyz/77DMbOnRowm32339/lzWKpe0HDRpkp5xyihtCOhE9P+85BhXBDQDA93Fuqtpw5kaGDRvmTl4mRGPObLnlllZUVNSo7RWIqIlJY9SoS7eyNarfmTx5st18883R9e6++25X43P77bfbJpts4k71i4tV/6PxblJVbW3YqmvD7jLNUgCA1hZKs4JiX7uCq9eVsj2bbbaZ7brrrnbQQQfZn//8Z9t9992j66hw+K233rJ05tXbSA69pQAAPmVuyqvacLOUgpLHHntsra7gyrxcccUVLiPTGMryqPeTAhhtr8xP/VqY8847z44//vgG7+O2226zzp07W7oEN2RuAACtLZRmmRvfuoLHNk9ts802Dd6+1VZbrXN7ZY1SnVdvIwQ3AIDWFkqzgmLfuoIj0dQLGZaZmbgoGgCAlu4KXtGWMzfJ6AqOtTM3zCsFAPAzc1PelmtuktEVHL+gGzgAIBjNUrVp8UYkpSu457TTTkvGc2pzovNKMToxAMAHIa9ZKk3GuWn2LI1fffWVG/n3mGOOiRtBuKysLFnPrc1gXikAgJ/yKCg2N+7MdtttZ19++aULaDzTpk2zu+66y9c3KKWbpcjcAAB8zNyUt+XMzZgxY+z++++3F154IW75CSecYPfdd1+ynlubEZ00kwH8AAA+CJG5Mfviiy/s8MMPdzskdj6nvn372pw5c/hgNhEFxQAAP4XSrKC4WZkbjSw8f/78tYKbSZMmrTWxJZpQc0OzFADAB3lpNs5Ns4Kbo48+2i666CJbtmxZdH6pd999184888wmj1CMXz5MjHMDAPBDKM3GuWlWcDN27FgX0HTp0sWdK5OjyS4333xzN0s3moZmKQBAILqCV7fhcW40j9R///tfN+Hlp59+6gIczQ+1/fbbJ/8ZtgEUFAMAgpC5qayutXA4HFdy0qYG8ZOtt97anbBhqryu4PSWAgD4WHPjZW9ir6d1cPPII480+k5POeWU5j6ftp25oaAYAOBj5sYbpbjNBDd/+tOfGn2nBDdNwyB+AAA/ZWdmWGaGWW1YmRsVFee0jeDmp59+atln0oZRUAwA8FNGRoaFsrOsrKomLYqKm9Vbql27ds26DYlV1oTdOTU3AAC/5OV4A/nVtM3gprS0NOHyqqoqd0LzMjeMcwMA8EsoO33ml2pSb6lx48YlvCzqDv7JJ5/YwIEDk/fs2ojKmroomcwNAMAvoZz0GcivScHNH/7wh4SXJScnx/r162f33HNP8p5dG8vcxFarAwDg11g3bSq4WbBggTvfcsst3eSZSI4qr+aGruAAAJ/kRbp/l7fVmhsCm5aquUntESEBAGkwM3hVG8rceIP4aQyb9Q3oxzg3TeN1u8uNFHMBAOBXQXFFW2qW8gbxU+CyvgH9CG6ahrmlAABB6Qpe3pYKimMH8WNAv+RibikAgN9CaZS5oXtOoOaWouYGAOBzzU11G8rc1PfZZ5/ZRx99ZMuWLdugeajA9AsAAP+FvN5SbamgONYdd9xhF110kRuwr2PHjmvdTnDT3IkzKSgGAPgj1NYzNzfddJM9+eSTdvTRRyf/GbVBVV6zFIP4AQB8HuemoqqN1tysWrXKDjrooOQ/mzbKK95inBsAgN+Zm/I0yNw0K7jZYYcd7OOPP07+s2mj6AoOAAjK3FIVaZC5aVaz1C677GLHHnusXXzxxTZgwADLyIjv5XPkkUcm6/m1CcwtBQDwW14adQVvVnBzyy23uPMbb7wx4e0EN82suaGgGADgk1BbHMQv1ooVK5L/TNqwaG8pCooBAD4JpVHmhkH8fFZbG7bq2rpZwSkoBgD4Pf1CRXUby9xsueWWCZcXFxfbZptt5sa+GTp0aLKeW5sqJhYyNwAAvzM35W2toHjvvfdusGv4tGnTbLvttrMJEybYzjvv3Oj71CjHd999ty1cuNCGDBlil19+uXXr1q3B9aurq+3RRx+11157zVavXm2DBw+23//+97bxxhtbKiK4AQAEaxC/WmtTwc3f/va3dd5+3XXX2VVXXWVvvfVWo+7vvffecwHTqFGj3ICAd911l+20005uaod27dol3Oa3v/2tGxVZvbWys7PtH//4hwuqpk6dar1797ZUrbeR3CxaCQEAPg/iV93GmqXW58wzz3RTMzTWFVdcYYceeqjdcMMN7roCnR49etj999/vAp5EdFthYWH0+siRI931N99800455RRL1eBG9Tb1u9QDANDqmZuq1M/cJDVVkJuba5WVlY1ad82aNa5J6je/+U10mYIUBThvvPFGg9vFBjYyadIkq6mpabAeKHXmlSJrAwAIwCB+1WRu4jz//POusLgx5s6da7W1tdarV6+45br+9ttvr3PbTz75xC655BIrKSmxn3/+2caPH++aphpSUVHhTh5tFxTMKwUACNIgfuVpkLlpUrPU3//+93UWFD/11FP2+OOPN+q+qqqq3HleXl7c8vz8/PVmfxRAqSlryZIl9uCDD7peWttuu22DNTdjx461a665xoLIK9yipxQAwE+htpq5Oe+88xIuLyoqcgGHApvGjk7cqVMnd7506dK45bru3daQDh06RHtkHXzwwfarX/3KFTvffPPNCdcfPXp0XA2PMjd9+vSxIPWWyqFZCgAQgK7gVTVhq6kNW1ZmRtsIbtQNO1l69uzpunxPnjw5boZx1dCox1RjZWVlWffu3W3RokUNrhMKhdwpiBidGAAQpEH8vOxNQW5S+xy1Kl+rWE899VR74IEHbP78+e76c889Z1988YVb7tH8VSeffLK7XFZWZrfffntckPXyyy+7gGi//faz1J5XioJiAIB/cmOOQ6neY8rXsExj4syYMcPNLK5B+GbPnu2Cl2HDhkXX+fbbb23KlCnusrIvCoTUXVzNSprjauXKlXb99dfb8ccfb6mIGcEBAEGQnZVp2ZkZbkqgVB/Iz9fgRsXEzz77rM2ZM8eNUKzamfbt28etoxGLVbAsmZmZrpD46quvdkGRuoUrKMrJybFU9cs4N2RuAAD+D+S3uqI65WcGD0SDWt++fd0pEWV1EgVF6TKHlVdQTG8pAEAQBvJbXZH6UzCQLvAZBcUAgODNL1VjqYzgJiiZG5qlAAABmV+qPMULigluglJzE4mWAQDwSy6ZGyS1txSZGwCAz0LezOBkbrAhmFsKABAUeZHMTTk1N9gQFBQDAIIiROYGyVDB3FIAgMD1lqq1VEYVq8+qqsPunHFuAADB6S1VY6mM4MZnlTV1HyC6ggMA/BYic4NkoOYGABAUIbqCI6nBDV3BAQA+y2MQPyRDVQ01NwCAYAiRuUEyeBXpFBQDAPwWyo4M4kdvKWwI5pYCAARFXk5kED96S2FDVEZGgWRuKQCA30L0lkJSa24oKAYA+CzECMVI6sSZzAoOAAhIs1QFc0thQzDODQAgcAXFVUy/gCQUFOfQLAUA8FmIruBIBjI3AICgyGMQPyQDXcEBAEERInODZCBzAwAIWuamgkH8sCGYWwoAELTMTTmD+GFDVEUKipl+AQDgtxDTL2BD1daGrbqWiTMBAEEb56bWUlndq4CvxcRC5gYAEJTMTU1tONqykIoIbnwUGxnnZGX4+VQAALBQJHOT6tkbghsfxUbFzC0FAPBbKGYqoFQuKia4CUhPqYwMMjcAAH9lZGREyyTI3KBZGOMGABDYgfyqyNxgg+aVImsDAAiGvDSYgoFmKR+RuQEABE0oDaZgILgJwrxSMQVcAAAEI7ipTdk3gqOqj5h6AQAQ3GapGktVBDcBCG5ysngbAADBECJzg2QEN16UDABAUEYpLidz03zPP/+87bXXXrblllvacccdZ7NmzVrn+rNnz7aLL77Yhg0bZjvttJNddtlltmzZMktFXntm7KBJAAD4KT+3LripoLdU87z00kt25JFH2sEHH2wPPvighcNh22WXXRoMVmpqamzkyJHWr18/u/POO+3666+3d955xwVHFRUVlmq8SvQQmRsAQEDkR45JZSmcucn288GvvvpqO/HEE+2iiy5y1x999FHr0aOH3XvvvXbFFVestX5WVpZ9+eWXlp39y9PWNptvvrl98skntuuuu1oqZm6YegEAEBR5aRDc+NYesmrVKpsyZYrLxHhyc3Nt7733dtmYhsQGNqJsj6Ti9AXe6I+xE5UBAOCn/Ny6Y1JZZeoGN75lbn766ScXmHTv3j1uua5Pmzat0fdz5ZVXumaqHXbYocF11GQV22xVUlJiQUDNDQAgqM1S5Qzi13S1tZFu0Dk5ccuVvVFtTWObtV5++WV78sknLRQKNbje2LFjrX379tFTnz59LFjBDb2lAAABG+emMnUzN761h3Tu3NmdL126NG75kiVLoretyw033GA33XSTK0pWz6l1GT16tK1cuTJ6mjt3rgWqoJjeUgCAgMij5qb5unXr5jIoEydOjFv+4Ycf2nbbbbfObW+88Ua79tpr7cUXX7Q99thjvY+lrE5xcXHcKQi8bnbU3AAAgtdbqtZSla+VrOecc4498MAD9s0337jr999/v33//fd25plnRtcZM2aMHXDAAdHrN998swtslLHZc889LZXRLAUACOo4N2Up3Czla1dwDcCnwuKhQ4daYWGh6+o9btw4GzJkSHSdRYsW2Zw5c9zl5cuX26WXXmrt2rWzs846a626mqOOOspSCc1SAIDAFhRXEdw0i4KZe+65x9XOaOA+jXFTv6u3gpby8nJ3WcXA3377bcL76tq1q6UaeksBAIImLw1qbnzN3HiUtdEpkS5dukQvZ2Zm2oABAyzd5pZihGIAQFDkRcZeS+XMDaPH+YjMDQAgaPLTIHNDcOMjam4AAEEtKC5P4YJigpsgdAVnED8AQEDkk7lBUpqlmFsKABAQeQQ32BA0SwEAAtssVVUbnZw61dAs5SMG8QMABDVzE3ucSjUEN4GoueFtAAAEQ17MMSlVRynmqOojmqUAAEGTnZVpuVmZKd0dnODGRzRLAQCCPJBfGcENmoreUgCAIMpP8ckzydz4pLqm1mpq66rQqbkBAARJfopPnklw45PYCnQG8QMABLHHVHmk40uqIbgJQHCTS28pAECA5KX4QH4ENz73lMrJyrCszAy/ngYAAGk3BQPBjU+YVwoAEPyC4mpLRQQ3vncD5y0AAARLPr2l0BwM4AcACKrCSHBTSldwNEVldEbwX+bwAAAgCApys935Gpql0BQ0SwEAgqowFMncVFBQjCagWQoAEFQFZG7QHN7ASIxxAwAImkJqbtAc3nwd+ZHoGACAoCgIRWpuKugKjibwBkbKj8y8CgBAUBRG/njTWwpN4k1G5o0CCQBAUBRECorpLYUmWUOzFAAgoAoif7zX0FsKzWuWInMDAAiWwkjNTSnj3KB5BcXU3AAAgqUg0luKzA2ahJobAEAqZG7C4bClGtIGPqHmBgAQ9MxNbfiXEfVTCcGNT6i5AQAEfYTi2D/jqYTgxu9mKWpuAAABk5WZYXmRcdhKU3AgP4IbvwuK6S0FAAigwuj8UmRu0EjU3AAAUmEgv9IU7A5O5sYn9JYCAARZoZe5ScGB/AhufEJBMQAgFXpMlZK5QZODGwqKAQABHutmDcFN0z300EM2dOhQ6969u+2zzz42derUda5fVlZmjzzyiA0fPtw6dOhgH3zwgaVyzU0eBcUAgCBnbipolmqSJ554ws4991y79NJL7cMPP7RNN93U9txzT5s/f36D21x99dU2YcIEt83KlSutujr1Cp1qasNWGRkUKXYsAQAAgqIwcnyiK3gTjR071k499VQ78cQTXWBz9913WygUsnvvvbfBbW644Qb75z//acOGDbNULyYWuoIDAIKoKK8uuFlVnnpJBN8KilesWGHTp0+3vfbaK7osKyvLZW7W1dSUkZFh6VJvI6FsaroBAMFTnJ/jzkvKqyzV+NYmMm/ePHferVu3uOVdu3a1KVOmJPWxKioq3MlTUlJiQRjAT6M/ZmamfrAGAEg/RWRumi8zMz5zkZ2dnfQZSNX81b59++ipT58+FoTMDfU2AICgKsqLZG7KUi9z41ubiDI0smTJkrjlixYtit6WLKNHj3bFx95p7ty55iemXgAABF1xJLih5qYJOnfubP3797f3338/bvl7772X9GJhFSkXFxfHnYKQufEmJQMAIKjNUiUpWHPj69H1wgsvtAceeMB1A6+srHTNRwsWLLCzzz47us4FF1xgI0aMsHQSzdxExhAAACCoBcWrUrC3lK+DrJx//vmuWeqAAw6w0tJS69evnz333HM2cODA6Dpr1qyJKwB+/PHH7Xe/+120Lueggw5ydTqXX365O6WCaM1NDmPcAACCqSiFMze+Hl3Vrfvaa6+1a665xsrLyy0/P3+tde688864gfqOPPJIFwzVl5eXZ6k2OnGIZikAQMBrblZXVFttbTilevcGInWgICdRYCP1l+fm5rpTKlsdiYK9qBgAgKApihyj1FCyurI6GuykAipafaAoWIpCqfNBAQC0LXk5WZYbGWg21bqDE9z4wCvOInMDAAiy4hQdyI/gxgclkQ9JO5qlAAABVpyiA/kR3PjZLJVC7ZcAgLaniMwNGmsVBcUAgBRQ5I1SXEHmBo2tuQnRWwoAEFzF+ZGxbsqoucF6rI4WFNMsBQAIrqJIr15qbrBeNEsBAFJBh8K64Gb5GpqlsB50BQcApIKNCusGzV1WWmGphN5SrUxDWGukR6ErOAAgyDYqDLnzpaWVlkoIblpZaWW1G8paUmkoawBA29OpXV3mZulqghs0okkqJyvDQpFhrQEACHazVKWlEo6uPg3g1y6U7SYMBQAgqDrFBDdhr9khBRDc+NZTiiYpAEBq1NxU1tTaqsif81RAcOPTvFJMmgkACLr83CwryM1yl5elUN0NwY1PA/ipWQoAgFRpmlqaQnU3BDe+jXFDsxQAIPg2SsGiYoKbVrZ8Td2Ho0MBwQ0AIJWKilNnID+Cm1a2eFXdh6NLUV2RFgAAQdYpUlS8hJobNGTx6khw047gBgAQfJ2LcuP+nKcCMjetbEnkw9GZzA0AIAX0bJ/vzuetKLNUQXDTysjcAABSSa8OdcHNzwQ3WF/mpkskzQcAQJD16khwg3Uor6qJDuLXpV0e+woAkDLBzYo1VVaaIqMU0yzVirwBkHKzMq04n0H8AADBV5yXY8V52SnVNEVw04q8SvPO7XKZNBMAkDJ6dSxw5z8tX2OpgOCmFdFTCgCQ0kXFy8ncoB56SgEAUlHvSN3NTzRLob4FK8vdOaMTAwBSycYb1TVLfbdotaUCmqVa0azFdR+K/l0KW/NhAQDYIIN6FLvzr+aVWCoguGlFXsQ7sGtRaz4sAAAbZFDPuuBm3spyW54Cs4MT3LSS6ppa+35xqbs8oGu71npYAAA2WFFeTrRp6ssUyN4Q3LSSOcvWWGVNreXlZEarzgEASBWDI9mbr+avtKAjuGklsyJNUpt2aWeZmRmt9bAAACTF4J7t3fnUOSss6AhuWsnMhavcOU1SAIBUtNOAzu78vZmL3XRCQRaY4Ka2trZVtvHLuzMXu/Ot+3Tw+6kAANBkv+7V3roX51lpZY199N0SCzLfg5uxY8dat27dLCcnx4YMGWJvv/12i2zj97QLn/643F3ed3B3v58OAABNppKKfQd3c5df/Hy+BZmvwc3f//53+8tf/mKPPfaYrVy50g4//HA76KCD7IcffkjqNn579csFFg6bDe3d3npSTAwASFGHbd3LnT//2c/29fzg9pryNbi59dZb7fTTT7e9997b2rVrZ1dffbV17tzZBTDJ3MZPS1ZX2N/emOkuH/Trnn4/HQAAmm3rvh3twCE9rDZsdvFTn0UnhA6aujnMfbB06VL79ttvbbfddosuy8jIcNcnTpyYtG1a05tfLbRVFVVWXlXriq0U2Dw75WdbWlppm3cvspNHbOz3UwQAYIOMPmBzmzR7mX2zYJXtefM7rtxik84F1r4g1wpysiwrM8M1Ye29RVcryM1uW8HNwoUL3XmXLl3ilnft2tUmTZqUtG2koqLCnTwlJS2TSrviuem2sKQi4YRjdx63tYWys1rkcQEAaC29OxbY02fvaOeOm+wCnP9M+Snheh9dvmfbC24a6vGk68rGJHMbFSBfc8011tK279fJVpZVWSg700I5WVacl2Nb9Wlvh2zVy/JyCGwAAOlhk86F9vIFu9hH3y21ST8sdX/sl6+ptPLqWqutDVtNbdjX455vwU2PHj3c+aJFi+KW63r37t2Tto2MHj3aRo0aFZe56dOnjyXbXcdvk/T7BAAgiDIzM2zngZ3dKWh8Kyju2LGjDRo0yCZMmBCXgdH1nXbaKbqsurraKisrm7RNfaFQyIqLi+NOAAAgPfnaW+qyyy6zhx56yP7zn//YvHnzXHZl9erVdu6550bXOeecc2ybbbZp0jYAAKDt8rXm5uSTT3aBiZqNVCysAfneeOMN6927d3QdDdSnzEtTtgEAAG1XRjis4eXaFtXctG/f3g0CSBMVAADpdfz2ffoFAACAZCK4AQAAaYXgBgAApBWCGwAAkFYIbgAAQFohuAEAAGmF4AYAAKQVghsAAJBWCG4AAEBa8XX6Bb94gzJrpEMAAJAavOP2+iZXaJPBzapVq9x5nz59/H4qAACgGcdxTcPQkDY5t1Rtba2bUbyoqMgyMjIs1aNYBWlz585lnqyA4j0KPt6j4OM9Cr6SVjgeKWRRYNOzZ0/LzGy4sqZNZm60Q9JtFnF9kJgENNh4j4KP9yj4eI+Cr7iFj0fryth4KCgGAABpheAGAACkFYKbFBcKheyqq65y5wgm3qPg4z0KPt6j4AsF6HjUJguKAQBA+iJzAwAA0grBDQAASCsENwAAIK20yXFu/LZixQr74osvbODAgdatW7cG16uoqLD//e9/1qlTJxs0aNBaty9atMh+/PFH69evn3Xp0iXhfSRrnbamtLTUPvvsMzcgVd++feNuW7JkiX3zzTdrbTN8+HDLzo7/Si1fvtxmzZplvXr1coNOJZKsddqayspKmzx5svvMDhgwoMH1NKDY0qVLbfDgwZaTk7PW7RoQbMaMGda5c2f3HUgkWeu0NTU1Ne49KiwsdPu//vui351E6n+XysvL7auvvnIDr+p3M5FkrdMWTZ061Z1vvfXWCW9fvXq1ff/99+496d+/v+Xl5a21TnV1tTuu5ebm2hZbbJFwgNxkrdMoKihG6/j222/Dp512WrhHjx7hjIyM8D/+8Y91rn/++eeHMzMzwwceeGDc8traWndbKBQKDxo0yJ1fcsklLbJOWzNv3jy3T/QeaX9cddVVa63zxBNPhLOzs8M77bRT3GnFihVx611//fXRfZuXlxc+6aSTwlVVVS2yTlui/Tx69Ohwr169woWFheHTTz894Xpz5swJ77bbbuEOHTqEt9tuu3D//v3Db7zxRtw6+g4WFBSEN9tsM3df+++/f3j16tUtsk5bUl5eHr7uuuvC/fr1CxcXF4dHjhy51jr//Oc/1/oOdenSxe3HsrKy6HrPP/98uGPHjuEBAwa493L48OHhhQsXxt1XstZpa2677Tb3mdX+GDx4cMJ19D7qMz1kyBC37zp16hT+17/+FbfOBx984H4z+/bt695D/VbNmjWrRdZpLIKbVvTSSy+FH3jggXBpaak7WK0ruNEXccstt3SBTf3gRvfRrl278LRp09z1//3vf+7+HnvssaSv09Z8+OGH4dtvvz28fPny8KabbtpgcLPRRhut835effXVcFZWVnjChAnu+nfffed+FG688cakr9PWfP311y7gW7BggQteEgU3Ojhuvvnm4YMOOsh932TRokXhp556KrqOPvf68/D4449Hb9fBWMFtstdpaxYvXhweM2ZMePbs2eETTjghYXBTn/5sab+deuqpcX82FOz89a9/ddf1Xm6zzTbhww47LOnrtEUXXnhh+KuvvgpfdtllCYObKVOmqDd1ePz48XHBjv7clZSUuOsK4rt37x6+4IIL3PXq6mr3fm+//fbRbZK1TlMQ3PhkXcHN3Llzwz179gx//vnn4SOOOGKt4GbEiBHhE088MW7ZoYceGt5rr72Svk5btq7gRgHGl19+GZ4+fbr7l1rf0UcfHd59993jlp133nnuX1Ky12nLGgpuHnzwQfcDrINaQ0aNGuX+ica64YYbwu3bt3c/rMlcpy1rbHCjrJoOpB999FF02a233uoyPxUVFdFl48aNcwH/kiVLkrpOW3ZZA8HNa6+95t4T/ZHw6I+Wlv3444/u+tNPP+2C+9gs2DvvvOPW0e9jMtdpCgqKA9hGfcIJJ9gll1xiv/71rxtsH912223jlu2www7RdtNkroPEli1bZocccog7qSbqxhtvbNR7NHPmTFuzZk1S18Ha3nrrLbffunfvbtOnT3e1MGrLb8x7tHLlSldfkMx1sH4PPvigq8vZcccd496jIUOGuPqL2H2r38lp06YldR2sbc8997SRI0faaaedZq+88oqNHz/eHZvOP//8aC2i9q1qE7t27Rq3b73bkrlOU1BQHDDXXnut+wJefPHFDRbElZWV2UYbbRS3XNdVdKpsnAqRk7FOqs+Y3lI22WQTV2w8dOhQd/3555+3ww8/3H3ZjzvuuGjwk2jfar9q/xYUFCRtHaxt3rx5ruhRP476nKvYVweyhx9+2PbZZ5/oe6SCxfr71rstmetg3bSfdOCs/yehoc9//f2fjHWwNhUQn3feeXbuuefapZde6o4/+s05+eSTo+sk2rf5+fnutK7935x1moLMTYDoH6a+3GeeeaZ9+OGH9sEHH7heHjqI6bJ+pL3eHvqQxdJt+iAqIEnWOkhs2LBh0cBGlL3Zf//97cknn4wu0/5NtG/F+/eYrHWwNu23d99918aMGeN6XsyePduOPPJIO+aYY1zPD96jYHnsscfc+UknnRS3nO+Rvz744AP3+3bfffe575F6bJ566qm2++67208//dTge6Q/X+rNuK7fseas0xQENwGiZobtttvO7rjjDrv88svdSQHP119/7S4vXrzYsrKyXHfgn3/+OW5bXd94443d5WStg8ZTl/7Yfal9mGjf6l+P9+8kWetgbeqKrfT2YYcd5q4rWD/77LPdHwX9SK9r34qXck/WOlh/k9QRRxzhmnhj8R7567///a/7Lh1wwAHRZb/73e/csertt9+Ovkfz5893gYhH15Upjf2OJGOdpiC4CVhGQJFy7EkR8ogRI9xl7w1WWv3FF1+Mfghqa2vddS/dnsx1kHgMnFhq4nvvvfdsyy23jNu3r776qlVVVUWXqflqr732sszMzKSug7WpTqCkpCSapRHvn6Y3lpP2rd431cbE7luN9eEFjslaBw379NNP7fPPP3cZ6/q0b7/88kv77rvv4vataqlUQ5PMdbA2fVfUehCbUVHgrmNG7PdIfxref//9uH2rZuFddtklqes0SZNLkNFsK1euDL///vvulJub6yrUdXnGjBkNbpOot9TMmTNd5f8pp5wSfuGFF8LHH3+8G79B3S6TvU5bo55P3nukcVTULVWXve7yXo+yyy+/3O0zVfirx466hmt/xnaFVY+3Qw45xK2nHk4ao2by5MlJX6ct8t6jrbbaynX31uVPP/00entNTU145513Du+9997hF1980Q1voHFu9H2K7S6ucTR23XXX8HPPPRf+85//7HrPvPLKK0lfpy365JNP3Puy7777hocNG+Yua6iF+s4555zwwIEDXVfw+rRM36+hQ4eGn3nmmfAtt9wSzsnJcb3hkr1OW/TZZ5+590U92jbZZJPo98obR0u9DTt37hzeb7/93Pfo3//+d3jrrbd2PatixyI67rjjXDd+DYdw//33h4uKisLXXntt3GMla53GYlbwVqQmJhVmJfqXeeWVVybcRsvV5li/0E6jbN5yyy32ww8/2KabbuqKvX71q1+1yDptyYIFC1xtRn36F37nnXe6y/oXozbod955x11Xr7YLLrhgrX/pc+bMce+bRjNWE+CFF164Vq+aZK3TlihNvdtuu621vHfv3nF1T8qw6bOtrKdGpFW266yzzoob+VajTWvfqjeG3r9zzjnH9thjj7j7TdY6bY1qNfSvP1YoFHI92TzKABx88MGu+fD0009PeD96H2+66SZXh6j3UcWshx56aIus09acccYZCUdbV3NU+/btoxnP22+/3WW+VBej0gn1lurQoUN0fR2j9Pv4+uuvu/oYNTGecsopcfeZrHUai+AGAACkFRrtAQBAWiG4AQAAaYXgBgAApBWCGwAAkFYIbgAAQFohuAEAAGmF4AYAAKQVghsA6/Xjjz+6odCDQsPoa6Cx5pg2bZpNnjw56c8pXWiQvblz5/r9NIANQnADBMDChQvd6LqakC6WRtd95pln1lr/5ZdfdqPhthbN96KJJ/2g0bNfeOGFuGVvvPGGG6m5qTSj+m9+8xs3Emp9EyZMsH//+9/ml0Sv0w8asbah0YKBVEFwAwSAJi097rjjolM6eE499VQ76qij7Pvvv487QGu4+raSfXj33XfdTMTJcPfdd7tpRnbccce45ZpgU0HP0Ucf7YbnT/XXuSE0geWUKVNcsAekql8mWQHgmx49ethmm23mDigHHHBAdPZdNQdpRlwt79+/v1uug68yD3vuuafL+HgHofz8fDcv2BZbbBG93xUrVrhZxQ866CBr165ddLlm333ttdfilmsOK2WDOnXqZNtss40VFhau93mvaxs1HSkLsN9++7mmIL2erbbays0BFUvzC3300UduVm3N05WRkWGffPKJHX744TZv3jx3WQGdN2+U1omdZ2pd913/cRTcXHvttWvdpvvu3Lmze64PPPCA7bTTTnG3J+O1eJYtW+Zmws7KyrLtt9/eiouLG3ydmotJj6v55yZOnGjz58938yFp3h3NFK/H0v1pRvqBAweuFSxpfqBNNtnEvUeaE01zculzom20rR57xIgRcfNt6b6POeYYt6/a+vxYSGHNmm4TQNJpduTtttsuev1f//pXeMSIEeEbbrghfOKJJ0aXX3HFFeG+ffu6y9OnTw8fc8wx7qTZsTt16uQuezMsV1ZWumUPP/xw3GPdeuutbtZzzZ4tF198sZsR/oADDggPHz7c3fbxxx/HPZdu3brF3cf6trn33nvDXbp0Ce+4445uxuzdd9/dzWj+7LPPxs3Cvtdee7lZ1ffff/9w79693SzS7du3d7dPmTIlvMMOO4Tz8/Ojr1PbN+a+69O+0k/e3Llz17pNs1Zfd9114TfffDNcWFgYXrlyZdztyXgtopndi4uL3QzVI0eOdDOVv/baa+t9nbpNs5xreUlJSXjWrFnhAQMGhDfddFN3P3rO5557btxz1vJtt9023KdPn/CBBx4Y3njjjd3Mz5oJW5e1TM9Rr8f7HHg0c3a7du3c5wdIRQQ3QEA8/fTT4czMzPCKFSvc9dNOOy08ZsyY8MSJE13g4FHAc8oppyS8jyVLlrgD1pNPPhlddvbZZ4f33nvvuPV00Lv00kvd5Yceeijcr1+/8KJFi6K3K6DSwbOh4KYx2+jArGAi9rlcfvnl4UGDBkWv33HHHe7g/fPPP7vry5Ytc/cRGxAoMIt9/Y297/r++c9/usCivi+++CKcnZ3tnoOCQj3+fffd1+THa8xrURB47bXXRq8vX748/Pbbb6/3df7jH/+IW77ffvu5wMkLPqZOnRrOyckJP//883HBTefOncPz5s1z1/W50uvv0aNH9H3TuQKq//73v3H3P2PGDPe406ZNa3B/AkFGzQ0QELvvvrtr1njvvffcdTU3adl2223nmpe+/fZbKy0ttf/9739xzQXV1dX28ccf27PPPusKbfv06WOTJk2K3n7iiSfa22+/7Zo0ZMaMGa5eR8vl4Ycfdk0gasZQQe3TTz/tmpdmzZrVYK+Zxm7TsWNH18QR+xr1OvQ6RcXSJ5xwgvXs2TO6/hlnnNGo/bW++65vyZIlbpv61Ax14IEHuuegZiQ9vpY19fEa81rUJKRt1PwkHTp0WG/Tj/ZrbIFvSUmJa2r8wx/+YDk5OW6Zmsj0GrwmLY/qiNTkKWqiGjRokKvX6tKli1umc9UgzZw5c63X6u0zIBVRcwMEhA40gwcPdkGNAoeffvopWg+hcy3feOONXa2F6m3kyy+/tP3339/VZmy++ebuQKggZtGiRdH7Vf1I37593YHv4osvtscee8yGDBkSrV2ZPXu2K6it3ytLB3I9ViKN3Ua1OLH0PHW7amX0uhQIxdajSL9+/Rq1v9Z33/WptkjBYSzVLo0bN84VEnuBgQIQBZDTp093+ymZr+X22293Bbt6r/WeHnzwwXbWWWe5+2pIt27dXNAVu+/Fq8HyKEhRXU6s+sGcHifRMtXjxPL2U1FRUYPPCwgyghsgQPQv3gtuVGzqFeiqENQLblQ46hWyXnnllbbzzjvb448/Hr0PFQnHZi90YDz++ONdUKPgRuvqgOpRUamyELfeemujn2dztklEAYOyUrFU7NwSVGy9dOlSl/nQ85fnnnvO7Sst12WPirKVvVEwkszXomBJWbYFCxa48WRU3Kxu9sp8NSQ2sBEVPouKghXQeHTduy0Z3dIzMzNtwIABSbk/oLXRLAUELLj5/PPP7T//+Y8LHjwKbtRNXAFObDOGDpLK2HiUsdHBsj41Qakp6pFHHnEHLgU7HvUAeuKJJ1wPn1jqEdSQ5myTiLJKGtslNhirP9aLMi71MwvNMXz4cCsoKIjLbiiA0b5R1ib2dP3117uMTkVFRVJfi7d/unfv7pqwLrroIhfsNOV1qtlLWRs1Q3o0PpLGPlKgmwzqkafmUDWbAamIzA0QIApo9E/9pZdesgsuuCC6fIcddnCBhGppRo0aFV2ubsE33HCDO2ireeGuu+5y/7jrUyZi6623tvPPP98FSrFdmP/0pz+5Wh1lipTRUbZIj6PaHHUXTqQ52yTyxz/+0QURhxxyiGuiUfCmJqHYbIWetzIi11xzjesuH9sVvCny8vJcIKOgTF2r1c1e2ZMxY8asta5uV13M+PHj7dhjj03aa9GYRcogaZwdBTK33XabW9bU1/m3v/3NjjjiCPccFdwqaFVz03nnnWfJ8NRTT8V9/oBUQ3ADBIgOUBp5V3UzqsmIHXvkkksuccWoXr2NXHrppe6fvLI6WueWW25xtR8aFLC+0aNHu4zQySefHLdc/841xoqarZTVUJCkx7j//vvjakcUSDVlGzVpqIksVteuXV1djheA9erVywUA99xzjzvXmD677rqr/eUvf4luo6aXV155xTUbacwXPVZj7ruhAEQZCWW8vvrqK5fB0mPWp2BR+0vrJfO1qABbwZUCQBUD6/1SgW9TXqcoeNJ9ePtfgY6CTNULxQbKKi6PpfcoNtPnBXIqNPbos7Rq1So76aSTGtyPQNBlqMuU308CQNulWpHYYt0jjzzSFekqa9IS7rvvPlebooAg1V9LS1DApUEBFfQAqYrgBoCv1OTmdcVWU5eyF2ou0vJUk06vBUhlFBQD8JVmG1dXahXWqjfRF198kbLBQDq9FiCVkbkBAABphcwNAABIKwQ3AAAgrRDcAACAtEJwAwAA0grBDQAASCsENwAAIK0Q3AAAgLRCcAMAANIKwQ0AALB08v+j886hSshxzgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Method Using STPSF\n",
+    "try:\n",
+    "    wfi = stpsf.WFI()\n",
+    "    bp = wfi._get_synphot_bandpass('F158')   # Change filter as needed\n",
+    "\n",
+    "    print(\"Bandpass loaded successfully!\")\n",
+    "\n",
+    "    # Plot the throughput\n",
+    "    bp.plot()\n",
+    "    plt.title('WFI F158 Throughput (from STPSF)')\n",
+    "    plt.show()\n",
+    "\n",
+    "except Exception as e:\n",
+    "    print(\"Could not load via STPSF:\", e)\n",
+    "    print(\"Alternative: Use official synphot throughput files from MAST reference atlases.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6c75ff56",
+   "metadata": {},
+   "source": [
+    "### Using the PHOTOM file with Synphot \n",
+    "\n",
+    "You can combine the photometric conversion from the PHOTOM file with a Synphot bandpass:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "f20a3abd",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['f062', 'f087', 'f106', 'f129', 'f158', 'f184', 'f213']\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkwAAAG2CAYAAACNhdkhAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjExLjAsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvlcelbwAAAAlwSFlzAAAPYQAAD2EBqD+naQAAjN9JREFUeJztnQecXHXV/p+pW7ObtpuekNBCCYTepShNUJH+UlQUO0XhVeAF/ooNVFBREARRLCCCBQQERLrSO4HQkpCebJLtber9f87v3t/szO7sTtk7M/feeb58hrs7mZm9beY+c85zzvEZhmGAEEIIIYSMin/0fyKEEEIIIRRMhBBCCCF5wAgTIYQQQkgOKJgIIYQQQnJAwUQIIYQQkgMKJkIIIYSQHFAwEUIIIYTkgIKJEEIIISQHFEyEEEIIITkIosKsX78et9xyC95++21ceuml2GGHHUY8ZtmyZfjNb36DjRs3YtGiRfjCF76Aurq6gh9DCCGEEOK6CNPPfvYz7LPPPli7di1uu+02JXaG8/rrr2O33XbD8uXLlRASUXTwwQcjGo0W9BhCCCGEkGLxVXKW3Pvvv4958+YpoTRnzhw89thjOOSQQzIe89GPfhSJRAIPPfSQ+r2trU095+c//zk+//nP5/0YQgghhBBXRpi22WYbhEKhUf9dIkT//ve/cfLJJ6fua21txWGHHYb77rsv78cQQgghhLjawzQWq1atQiwWU9GidOT3p556Ku/HZCMSiaibJplMor29HVOmTIHP57N9WwghhBBiP5Io6+npwcyZM+H3+6tTMA0MDKhlY2Njxv0TJkxI/Vs+j8nGlVdeiSuuuKIEa00IIYSQcrN69WrMnj27OgVTc3OzWnZ0dGTcL5Eg/W/5PCYbl1xyCS644ILU711dXZg7dy5WrlyJpqYmW7dDolebN2/G1KlTS6p+nQC31ZvwuHqTajqu1ba91bStnZ2dmD9/vgqUlBJHCyYxgk+cOBFLlizB0Ucfnbr/jTfeUNVw+T4mGzU1Neo2HHmtUggm8VrJa3v9xOW2ehMeV29STce12ra3mrZVU2o7jd/pG3/qqaeqPk2SnxSefvppPP/88zjttNPyfgwhhBBCiGsFk5iyzzjjDJx33nnq9+9///vq97/97W+px/zgBz9QYbadd95ZtQ848sgj8fWvfx1HHHFEQY8hhBBCCHFlSm7WrFk46qij1M/HH398RrsBzaRJk/Dss8/iv//9r+rX9JOf/AQLFy7MeJ18HkMIIYQQ4krBtGDBAnXLRSAQwIc+9KFxP4YQQgghxHMeJkIIIYQQJ0DBRAghhBCSAwomQgghhJAcUDARQgghhOSAgokQQgghJAcUTIQQQgghOaBgIoQQQgjJAQUTIYQQQkgOKJgIIYQQQnJAwUQIIYQQkgMKJkIIIYSQHFAwEUIIIYTkgIKJEEIIISQHFEyEEEIIITmgYCKEEEIIyQEFEyGEEEJIDiiYCCGEEEJyQMFECCGEEJIDCiZCCCGEkBxQMBFCCCGE5ICCiRBCCCEkBxRMhBBCCCE5oGAihBBCCMkBBRMhhBBCSA4omAghhBBCckDBRAghhBCSAwomQgghhJAcUDARQgghhOSAgokQQgghJAcUTIQQQgghOaBgIoQQQgjJAQUTIYQQQkgOKJgIIYQQQnJAwUQIIYQQkgMKJkIIIYSQHFAwEUIIIYTkgIKJEEIIISQHFEyEEEIIITmgYCKEEEIIyQEFEyGEEEJIDiiYCCGEEEJyQMFECCGEEJIDCiZCCCGEkBxQMBFCCCGE5ICCiRBCCCEkBxRMhBBCCCE5oGAihBBCCMkBBRMhhBBCSA4omAghhBBCckDBRAghhBCSAwomQgghhJAcUDARQgghhOSAgokQQgghJAcUTIQQQgghOaBgIoQQQgjJAQUTIYQQQkgOKJgIIYQQQnJAwUQIIYQQkgMKJkIIIYSQHFAwEUIIIYTkgIKJEEIIISQHFEyEEEIIITkIwuEkEgn84Q9/wD//+U90dHRg7ty5OPvss7HffvtlPO7pp5/G9ddfj40bN2LRokW4+OKLMW3atIqtNyGEEEK8g+MjTBdddBEuvPBCHH744fjmN7+JiRMn4qCDDsITTzyResyTTz6JQw45BHPmzMG5556LJUuW4IADDkBvb29F150QQggh3sDxgulvf/sbvvKVr+Dzn/+8Ek3XXHMNFi5ciH/84x+px1x66aU47rjjcNVVV+ETn/gE7r77brS1teGmm26q6LoTQgghxBs4XjDtvvvueOmllxCPx9Xva9asUbc99thD/d7f36/ScR//+MdTz2loaMBHPvIRPPzwwxVbb0IIIYR4B8d7mG699VblWZJ026xZs7Bs2TJceeWVOO2009S/r169GslkUv1bOvL7o48+OurrRiIRddN0d3erpbyW3OxEXs8wDNtf14lwW70Jj6s3qabjWm3bW23bWg4cL5gkrSbC54orrsDWW2+Nf/3rX7j88sux7777YrfddkMsFlOPq62tzXheXV0dotHoqK8rokteczibNm3C4OCg7Qezq6tLnbx+v+ODeuOC2+pNeFy9STUd12rb3mra1q6urrL8HUcLJjFtX3LJJbjuuuuUh0k44ogj8NZbb+Gyyy7D/fffj8mTJ6v7t2zZkvFc+V3/WzbkdS+44IKMCJNEsVpaWtDU1GT7ievz+dRre/3E5bZ6Ex5Xb1JNx7XatreatjUcDpfl7zhaMPX09Kgo0ezZszPul99ff/119fPMmTNV+wDxOR177LGpxzz//POqUm40ampq1G04cmKV4uSSE7dUr+00uK3ehMfVm1TTca227a2WbfWXafscvRdnzJiBBQsW4Oabb06l18SzdO+99+LAAw9MPe6ss87Cr3/9a6xfv179LlVy0lpA7ieEEEII8XSESfjzn/+MM888U0WV5Pb222/jyCOPxLe//e3UY771rW/hnXfewTbbbIN58+bhgw8+wLXXXot99tmnoutOCCGEEG/geMG055574s0338SqVauUL0kE0dSpUzMeI4Zv6dckj5FO39tttx2am5srts6EEEII8RaOF0w6P7nVVlup21jI2BS5EUIIIYRUjYeJEEIIIcQJUDARQgghhOSAgokQQgghJAcUTIQQQgghOaBgIoQQQgjJAQUTIYQQQkgOKJgIIYQQQnJAwUQIIYQQkgMKJkIIIYSQHFAwEUIIIYTkgIKJEEIIISQHFEyEEEIIITmgYCKEEEIIyQEFEyGEEEJIDiiYCCGEEEJyQMFECCGEEJIDCiZCCCGEkBxQMBFCCCGE5ICCiRBCCCEkBxRMhBBCCCE5oGAihBBCCMkBBRMhhBBCSA4omAghhBBCckDBRAghhBCSAwomQgghhJAcUDARQgghhOSAgokQQgghJAcUTIQQQgghOaBgIoQQQgjJAQUTIYQQQkgOKJgIIYQQQnJAwUQIIYQQkgMKJkIIIYSQHFAwEUIIIYTkgIKJEEIIISQHwVwPIIQQ4h6SRgKxWAfiiR71nTgcmohgoAk+n6/Sq0aIq6FgIoQQlwmiSHQTorEtiMW7EU90q6W+mULJyHhOODgZM1qOQWPdgoqtNyFuh4KJEEIcimEYiMU70DuwAgODazAY3YhItA0GEmM+z+8LIRhsAowkovFOROPtWLn+NsyZdiKaGnYo2/oT4iUomAghxEHEE33o7V+GvoEV6BtcgVi8a8Rj/P5a1IZaEAw2IxScgJBaNqnUm/wcDDSkUnCJ5CDWb7ofXX1LsG7Tvaivnav+nRBSGBRMhBBSYZLJGHr630Vn72vo7X9/WErNj/ra2aivnYe6mhmoDU9DKDgpb09SwF+LWa3HIbJ2k4pQbdzyb8xq/UTJtoUQr0LBRAghFUD8RiKSevrfQ9/AchhGPPVvteHpaKhbgIa6+SoiFPCHx/W3fL4AZkw9BivW/QZdvW9g+pQjEAjU2bAVhFQPFEyEEFIGEskIBgbXon9wpRJKg9ENGf8eCk5Ec+POmNi4K2rCU23/+3U1s1ETblUeqK6+NzG5aU/b/wYhXoaCiRBCbCCRjCq/kVSpxeO9iCd6rcq1TkRj7YjENmUVMRPqt8OEhu1QE2otaem/vLaIsY3tD6Oz5zUKJkIKhIKJEELyrFgTMSTiR93isuxQVWixWCcSyf6cryFRpPraOaq8v7F+27Kbr5sbFynBNBBZg3hiAH5fTVn/PiFuhoKJEFK1GEZSVZElkgNIJAbUMh7vx0BsEzZ1BpBMDloRIhFGHRk+o2xI9VooMAHBQCOCwUa1DIcmKZO2+JJCwUZUEqmoC4emIhrbjIHB1Wio26ai60OIm6BgIoS4AgMG+hFVtwD8mIBahBAY8TgRN1JpFoltUc/y+fxIGvGUIEotkwNIJiOj/r3+zmz3+hAOTjJFUGiSaggpP8t9oVCzqkhzOhLhEsHUP7iKgomQAqBgIoQ4kkHEsBadWIMOrLGWEQxFeEQs7YQZOAzboxG1iCf6sXbTPejtf7fgvyWpKakaC/jlVotYzIf6uokIButVfyNTGE1WPY5EgLkZqbrr7HlFCSZCSP5QMBFCKk4UcaxHN9ajE+vQhfXowhb0ZX2sxJUSSCKGBF7FGryDjfhMYjE61/1ZeYuE+tqtVM8iKadXUSYEhgRRShjpn2utx5kkk0m0tbWhdWor/H53i6PRBJMwEFmHZHLsFCMpIT09wLJlQEcHEAoBwaC51D83NACTJwONjeLY56FwABRMhJC8iSMBnxIg0k5R/svvgzwJA32IoBuD6LFu8nM3BrAB3diE3qzPm4R6zMZEzMIkzMUktGCCSsdJem4VOvAAlqANPViy5W9ojbWrCNDc6f+jmjuS7Ej6MOCvVyZ1s3JvZFqT2CyMXnwRePpp4K23TJEkt82b83u+iCcRTnKbMQOYMwfYay/gmGOA+fN5qMoIBRMhJIUIkS5LxEiUpxMDpsDxDaK7dQAxf3LYB4gfYQQRRgA1CCKEoFrK79KrWoujHkTUa4+FeJJmohkz0IyZmKh+rkf2ho0++DAPk3E69sZdA/ejtXejevXZrSdRLOXRXiAcmoKBSD9icYnItfAdYBcigt5+G1iyBHj+eeC554ClS6W6IPvjp04FWluBeByIxTJvvb1ANGr+W1ubeZPXFn7/e+Dcc4F99gHOPBM4+2yghhWPpYaCiVQVW3oN3Pd6Am+tS2J1u4G+KNAywYcjdvTj44sDqA35qi5iJCmwlWjHKrQrkSSm6hHIbsmya+JIIq6M2LmRpzeiRgkjuTVZy1ZMUCJJfi4Uec6ePQPq5/UTpmOn2pkFv0Y1UhOchOT6pfCvexSNmxLAxCnAxGlAc6u5bGoFgiH7/3AiDnRvBga6rVsP0N8NRPqARALwB4BA0PzbgRDQNBWYOgeYON38t0ohgmfLFmDduqHb+vWZv0vUSB6TDYkK7b8/sPvuwNZbm7cFC4CmprH/5sAA0N5u3kSMyd9cvhx49FHgySdNQSa3n/4U+OUvgSOOKNkuIBRMpEqIJwzc9lwC1z8Wx8AwPbB8k4Hnlifx2/8mcNOnQpg+yYd7enrQlkigye/H1EAAu9TWYqaExl2KRHfa0WdFjrqxAV3YjF6VFhuOpNlExExHE6agERNQg4ZkDWJb+jB3ygwE/RI9MpCAobxHUSSUGdv82fxdlvKdWosiuTUirJJ4diLVb6G+NZC417sTmjEfm7ANWm39G57jvecw7Z93INgu6biXsj9GvFuTZwEtWwGt1m3qXFNQ1Y7hqYlFgO5NQFfb0LJrE9C5AehYZy6TmVHKvBDxNHkmsNWuwKLDgLmL7PP1dHUBq1ZlF0L6Z1lK1Ccf5s0DFi4E9tjDjADtvTcwfXrh6yXbV19v3mbPzvy3yy8HNmwA7rgD+NGPTLF29NHAz35mRp5ISXDvFYCQPOnqN/C1P0fx4gdmWHzHmT4cvkMA81t8aKwB3lpn4I/PxbGmw8Al9w9i8NB2LJVQ+DCmBwLYrbY2dZsfcLb3Q0TNMmxSxuj30aaETDYk7SXpLbmJV2gaJiA4zNeSRFIJSDFcp4ue0VJm5aKvfzmSRgTxQC221DTiTaynYBqLF+8D7vspgoaBRNCPaMtUJKcsRn0oAF+3iBvrJsJn82rztvSpzNcI1QATpprRnwlTgOggoJ67Cejvyn3QJHpU3wzUNQF1E8xlTb0ZWRIxlYiZkah4BOjcCGxZA8SjwKaV5u2FfwDzdwOOOR9oMQ3sBfP668B11wEPPGAKonxpaQFmzjS9RLJM/1mE0nbbmWbtciAi7GtfM9NxsrzlFuC880zT+Je+VJ51qDIomIinWd2exFdui+GDzQYaaoBvHBnEJ3cLwO8f+na6zwLg8J38OP76KF5p7lG+gWa/Hx9paEB/MonV8TjejkSwIZHAA3196ibIK7T4fJi3YQPmhkKYEwxidiiEyYEAJsnN78fEQAChHN+EE4aBrmQSHYkEOpNJdCYS6ufNiQT6kknU+f1KvvQkk+hOJtGbTKr1kmWfYWAwmUSt348Gnw9719XhjOZmNAQM3I83sATrMvxG09CkIkfT0ayiSJNRr0SPeILcSHe/6ekIN2yjvpFLWpGMwuq3lFiSVE988SF4b4cYfLVNmFh7JupaW+HTFYGSCurZDLR9YN5EpMhyy2ozhSZiqn2tectGuNZM6TW3DC2bp5kRIrmJ2CokOiQiSkRc23LgraeAJY8CK14BbvwCcMq3ge32zf+1EglM+Pa34bv55sxI15QpwKxZmUJouDCaNg0IV/YLQlakik62R9b1e98zI0yLF5uRLWIrFEzEs7yxJomv3hZFRz8wvRn45elhbDste0po9iQ/Tj/Ij5ummW6c77e04NC0b4oiUN6IRPDK4KC6vR6JKPHSZhhoGxzEC4MjU1saSetNFEHj9yMuFytJERoGYoaBfsNQQmhsO3T+vBKJ4O6eHnx6zkas9G9SQmgvzMMumKWEkt0psUozGFmvli112wNYiQ70K5N5MX4oTyMRm39cY4qhXT4C38cvQHLlD4Fkv4rQZSBipknETguwzV6Z/yZiScSU+JB6tpi3YNhM1enbWCm7YhAhN2m6edt+f+DgM4F7fwosfwm4+0fAV38DNEzM/TqGAd/Xv46GX/3K/P2EE4Avf9msOBvLS+QGZH9/5zvAO+8Ad90FnHMO8OyzlV4rz0HBRDzJix+YYqk/aqbgrjstrMzdY+Fb0A/EDPi6A9h/Tl3Gv9X7/dinrk7d9FyxLfE4XmtrQ++ECVibSGBVLIZ18biKDulokQghEVZyy4UWVhKdksjUlEAAjX6/iiBJMm2C368eI/fVW8tGqXjy+xER8ZZI4MaODvQHekyxZPjwad++mIvJ8CKGkUAkag60bQqLIOxQHi2JMu0Emr8zkLRa2wozFXbUVxEI1Ko5dvFEH5LJ7vx3uqTjxNskt0ohUarTvw/86svmNv3zF8BJl+d+3t13w3f99erH5O9+B/+nPgVPIaJJ0owPPgi89BLwpz8Bhx9e6bXyFBRMxHO8s2FILO0z34+f/08I9TW5v/GuD0cB8XUuq8ebk4Dd541dmi2pt50CAbQ2NmZtcCipNhFKSkBZaTRJz0ntUdDnU7dan08JJBFC8vt4WVxTgx/HV6ifpyemYW7Qm2JJiMQ2K+u5dOmWobYiDCmYRuHlB8zlXh8HGprVj9JaQARTwsjDd+Q0JKr1yYuAm74CLHkMOOg0YPrWoz9eKvAuvVT92HvOOag/4wx4EmlRcPHFalt9V18NfOQjlV4jT+Gt+Dypejb3Gjj3dlMs7T3fj+tOz08sCcviVhVMZ1BVzY2XgCWGFoTD2KO2FgfV12PfujrsUVeHXWtrsVNNDbYOh5XwskMsCTPCfrTWmU0gV3d7u7/OYGSDWtbWTFMCdg4mqd+lTQJJQ4zTkr4SFh+ZulvGvQiuFEzCzO2AnQ42f/7PHWM/VqrJli6FMXky+rxeRSZpxtpa+F5/HaFXXqn02ngKCibiqdYBF/45ivVdwNzJPvzk5FDefZWShoHlujKuM4SXV41fMFWC1ehQkfneWAgPdycRHa1hngcYjFqCKWyWbEsLBEHaJ5Bh6Tg5D+btYqazLGRosJBM9rh3dx1wirl860kgavbjysqtt6qFcd55MNzuV8rFpEnAySerH+v+8IdKr42noGAinuHGJ+J4eZVZDfeL00Jors8/arMhHseAYZjF9D0BrO10p9DQVWLdkQaVDnxBGt95lMHoRrXUY1Ck4k8YQEzdiMXKN8zltvtk7JJgcIJaJg0XC8wZ25qNNqUVwQevZX+M9FCSRo+CV1Nxw5FWA/LeuP/+/PtHkZxQMBFP8MKKBG560uwz9K2PhbCgpbBT+33rQ2VOIKTM0hu6DCSThmsF0+Sk6VPJ1k/KK+hBuzVhM/UoI1qkk7jQwSiTiUSWVi0xf563KGP/hQJaMOXTp92hSDh1a6uSb9mL2R9z551mC4H99que2Wv77w+jpQV+mWP3n/9Uem08AwUTcT0dfQYu/mtMXRukx9LRiwpvKLnMEhbb1YQR8AOxBLClz31jTtaiU/08y5icsV1ewzCSiMXN6i4ZuJs+rFdoz2tYSxUgvZL6OsxmkeL5SSMYbHJ/hEnYZk9z+f4ogunee83lKVb6rhqQprrS+Vs0pUSZSOUE05577lnUvxXLpk2bcMEFF2Dx4sXYf//9cauVj07nr3/9Kw4++GAsXLgQJ510Et6RfhTE80h5//+7J4a2HmD+VB8u/mhxhZ9aWGxbE0ar+cUb61yWlhORkEBSDb/dzroYelUwxRNibJfj40MwYHqXhMkwe2fRx2SxykrHzVxoVpalEbQiTAYiSCalO5hLmb874PMDm1eZBvd0JHL8zDPmz4cdhmrCOOYY84f77qv0qlS3YHpJejxkIZFI4NVXX4XdYmmfffbB0qVLccMNN6jbf//7X/wnLcx4zz334NRTT1VC6bbbbkM4HMaHPvQhbJZhhcTT3PF8Ao+/k0QoAPz4pBDqw8VVm0n/JEG6dc9oNl9jfZe7BFMXTL/SRNRj25B5cVweiylDu9dIRZcCE+CTi6WF9jFJA0siVQBLzd0wd6cRuyPgr4XPZ37BiCdcbPyuawRmLzR//mDY9UeqxPr7TSP0TiP3gac54ggYfj98771X2PgXMioFfR1/8cUXs/4sJJNJPPPMM5g7t8jZPqNwuQwZVD3H7kZNjelPuPnmm9Xf03znO9/BmWeeiXOku6kqiLgVM2bMwI033ojLLrvM1vUhzuH9tiSu+ZcpdC44PIjtpxefYZYmk4K0AZgx0QesMrC+052CqRl1akSL9HsSI7uIQfndS8TiZil8MC0dJzDCNAwZayJk6VEkrRgkyhSLd1iCaQpcy6yF5uiX9e9ltE7Ak0+ay4MOMjuGFzP41600NSG+cCFCb70FPPcc8MlPVnqNqksw7SUt5LP8rJk6dSp+8Ytf2Jpuueuuu/DVr341JZY0ulFgT08PXn75ZXzzm99M/VsoFMKHP/xhPP744xRMHiUaN3DRX2KIxIEDtvHjtH3GNwi3SxrbSXRGBJMVYVrnsghTpxVVmYg61ddpfjiMd6NRvB+NelAwaf9SZon4pFRKjhEmxWZLME3N/kU2UzC5mBmWP0sEUzpPPTUkmKqQ2OLFpmB6/nkKpnILpo6OjpQwGp7uEpHSYPOUZvkb7e3tmDVrFs444wyVCpw5cyY+/elP41NWW/s1a9ao5XSZ3JyG/P66TKQehUgkom6a7m7zA1giV+nRKzuQ1xPxZ/frOpFybeuPH4zj3Y0GJtUD3/mEiKXxVbVJJ25BLr/TrWvw+s6xzwWnHddO34CaCNyUrEUSSWwdCqUE04eskS7F4rRtTUWYAk0Z69SIsDIa9BkRxI0E/EUMFXbathZNfxf8/dbnmowyybI92v8VjXW7e3unLVD+EmP9MhgyN89K0/peeEGdAcl991Xb75ljmweyjdHddkP97bfDeO45GB7e5mSZtq0gwTRxojngMG75PUpN1DKsSvToxz/+Mf7v//4Pzz33HL74xS8qgSMpOL2jgsHgCAEnnqrRuPLKK3HFFVdk9UwNjjFItRhkHbu6utQbNdsIDS9Rjm3997sh3PGCKc4vPKQXyf442sYRUBg0DEQsn0+8vR31KpnViNVb4mhrM78kuOG4bp7cLbX1QFcUbZE2TLbeP8t7etCW9uWgGJy2rb0Rc4bc4IAPbW1tqfvV9D5pyyRZ1U3rUJ8MuX5biyW07m2VZEtMmIpNHSKcRs6Mi0bMyGx3z0Yko0P70XUkazFNWoJE+7H5/SVINE+Hr7MT06QHk3yuT5sGo63NM8c2H2RbB7fdFnLVNl54AW2yL6R6zoN0dZWnW31RJUWS6hqLQw45BHYwZcoUdVIff/zx+MIXvqDu23HHHfH888/jlltuUYJJol3Cli1bRkSnWlpGHw1xySWXqMo7jQiwOXPmqOc02dwJVk5c8QvIa1fDm7SU2/ruxiSufcIU7F/4kB8f22v8s9KkaSXWrFFvhnmtrYj7RDzFsaU/gFaZzeSS49rvM/vtzG2ejlY0Y65ETdvb0R8Oj7kd+eC0be1bF4FMJJ40cRaaGjK3TQRvP2Kon9qEVlgljy7e1qJZ/YJa+Fu3GvX4+zunYVPnGwjXJMZ9jlScaQuAde9gSrQdaN0FePdddbchn+tbb+2tY5sHsq2b9tgDRkMD/L29aJUM0Y47wouEw5kVoI4STIceeuiY/y7q3Q5qa2ux6667ork509gpvw9YHYynTZumjOZPP/00Pv7xj6ceI5V0x+iyyiyIJ2q4L0qQN1Ep3kjyJi3VazuNUm3rB5uTOP+OOAYt39JXDg3B7x//DLYu63wV/1IgEMCkBlMw9Qya2yI3px9X6cHUCzOKNMlfDz/8aLWirpsTCVvWzynbKsQTZrSkJtQ8Yn0aUKMEU78/pvaD27e1aLasVgtfyzz4RtmOkNXtO5Hodfe26q7f696Bf+MKYNFhgHh3ZPt33jlj+z1xbPPEJ58Bu+yiWiv433wT2HlneBF/mY5lUX8lFotl3MQLtGTJEhx00EH44x//aOsKnnvuufjTn/6U6qu0bNky/OEPf8DHPvax1GO+8pWv4Ne//rVaBxFrv/zlL/HBBx/g85//vK3rQipn8L7x8ThOuCGKdZ3AvCk+XHVCCAEbxJLQaaVuJ1lvugm15v1iiZIhvm6gH+aKimenXuXlgKlpgslrTSvNPkxDzReHCyahzxKQVYv0JRrD8C0EA2ZqO5H0wAidqXMyhCJEIAjV1k5gODvsYC4tAUnKHGEa7hcSdtppJ5UmO+GEE3D66afDLs466yxl7JaqPIk49fb24jOf+Qy+973vpR7zjW98A2vXrlVNMyVqJI+7/fbb1ToRd/P8igS+e18cH2w2o0D7be3H944LYWIBc+LybSkgESahJij9fcxu3xJlktl0bhFMIpZ8ltF5qrU9XhNM5sXdyLjgZxdMLlG7paLDHE6MKbNGfUjAbxYDxBMeqCqcMnuou7lAwaQwdtrJ/ETQ+4MUTXFtkUdB0mPLly+H3Ugvposvvlj5lCTPPjz8Jr///Oc/xw9/+EN0itFv2rSqCLd6mfY+A9c8FMM/XjPFzJRG4KKjQjhqZ/+YKbJi6EhrKSDI60uUqb0P6BowMN1qM+BkJAUl6OiSMMXaHunF1JdMosEj74lEwoyG+FXjxZHb1GDtg6qOMEmaudsycTeP7k0KBOpTIlSi83a/t8qKFoYimGT7KZhMtG+JgqkygmnDBuuby7CWAz/60Y/UaJJSIFVvw1sHDKeurk7diLsRr9IXfh/F+i5ztubJewZw3oeDaKorzYd5KsKUJijkb4lokwiTG9ARpjpV4WciAqne50O/Yagok2cEU9KMhgSt6MhwKJikfLAXiFon7wSzMGasCJPUFyaNCAI+Kx/tRibOMNsJyHavWQHo6kmdkqp2wSQdv6VytkwGaS9SlGCSLtrZWLBgAe64447xrhOpYt7ZYIolie6IV+kHx4ewy+zSXujTm1ZqmqzrRs+gO5pXpqfk0pG03Kp4XAmmeR5pXqnTRzo6Mhym5KTs12y7gPomIDy6CPL7Q9ZlIK4idzIuxbXIgOGJ04CO9cAbZoUgpFK6cWjWYFUya5bq+g2pmpXKQY8avx0rmN54wxromMakSZNUU0lXh3RJRXl9TRJf+kNURXV2mOHDjWeGMbmh9OdTtgjThFr5u+6LMI0QTMGgKZjK1DutnCm5gD+XYKrilFyXFV1pGr21isbvq0XS6FVCNByaBFcjDTpFML1lXaO22qrSa1R55Josfl4ZQuzhSjnHCqaducOJzbzwQRLn3BZVVWmL5/jwyzPClmgpPb2WYEpPWU1wWYRpYBTB1OJB47dOyQUCuVJyVWz67t6ct2DyQU723tR+dTXiY1r2IvC+2YMJ8+dXeo2cwXbbmYJp2bJKr0l1mr5XrlypyveXLl2aaigp5f12D98l3ueeVxP49j9iiCeAfeb78fP/CaG+pnyRyv6sgsn8+91ujzB5UDDplFwwZ0ouAgNGqmqwqigowlSDhCGROw8IpslWpdwH1gw9CqbM/bBiRWWOi0coyhzyz3/+E9tttx0eeughVZEmtwcffFDdJ0tC8vEq3fZsHP97ZxSX/d0US4fv6Md1p5dXLAl9VuNKMUi7NcJUTYJJ9wwaMixnjzDFkURU2oFXs4dpjAo5jc8yenuiF9MkqzBo3UZzyZScCQVT5SJMX//611Wp/2WXXZZxv/RGkn876qij7Fk74jnWdiRx0V9jeG11phD54sEBfOWQoC2duwtlYIwIk3s8TGZbgbphgkm3FtjiJcGUw/QdRhAhBBBDQkWZauztnuIuwZRPSs4STJ7oxaS3d5M1A5IRpkzhyAhT+SNM0khS5rgNR+5btcrqLktIFq56IK7EUjAAHLStH186OIDffTaMcw6zZ8xJMUiPIqE+va2ARyJME6xt6vHQpPKhCFN2wSRUfWuBVIQpj5Sc8jB5JCUngkkixlJmKzDClCkc5frsoS9P5aaor1477LCDGkNy4IEHjqieEy8TIaOl4R5/R4ZfAnd9KYxtWp3RF0j6FAkNaSk53fOp2wVZCvHpDAmmUFbBpI3tXkBf2IOjmL61j6kTA9Vr/C4iwuSJlFx9MxCXXkyWKJhteZqqnZkzpZmhzDUD1q4F6DUun2D61Kc+hZNOOgmXXHKJGlkiHWJffPFFXHnllfi///s/JaY0rKgjmtufMz/EjtzJ7xixJOdutgiTmzxMknpKIJk1wtTgQcGUqw9T+n7Q1YNVRXRgqGll4+S82gp4JsIk57thCemmCUDDyNE5VYmk5ufNA95/30zLUTCVTzCdf/75Gct0zjvvvBEXJEKEpevNi/ZROw81iKw0EcOwpIZ7PUw6uhSEX/l3vBxhks+TfFJytdZ+GIR3+k/lTV+XuQyGgXDuyQc+n1lVGPdCWwEhbn1pmJpbLFZdWk4LpoMPrvTaVI9gWr9+vf1rQjyNXOhWbjHF8/ypzinz1hVyQl2WKrluF0SYRvMvCY1pgsn1s8JkgEdSFKwxZh8modZKTQ5aZviqos8yPDdMNJsW5h1h8kBKThi0vvhMmlDpNXEWrJSrjGDKNdONkOFs6oFqSim+7tmTnHPR1j2YRCz5MwST+XNvRC7SRsUM6fmgoyhaJGQTTEnLq5Xu03IjcSu65PeF4feN/vFVU9WCqXNIMOWB2bjSTMl5QVSj34qmNo8egaxKWCk3boqut92yZQtee+01tLe3j/i3E088cbzrRTzGyi3mh9isST6Eg875QM7mXxImmFkKVXDTFx2KODmRqCWYhqfjhFqfz5oUZkaZ3D6AN5kaizL2AdFDiKsyJddfmGDSESZDnHBGDAGfy4ezyrccYYI3ZifaBiNMlRFMd999N8444wwMDg6iMctgQwomMpwPrHScDNR1Etkq5ISakA+hABBLAL2DzhZMEUsUZOs3JNECiTLJvDxpLTAN7iZhmBdDfw7BNORhqsIIU68WTPnOhQvCh4ASTBJlCvhdLpg6rZYCde7+cmA72ui9enWl18S1FHVGffOb31TVcCKYOjs7R9wIGc4Hm01hspXDBNNoESahzrpuDMad7WPSgimM7Gb6dB+T20kmtWCyQoCjUN0epgJTcj5fquLQE60Ftlim9zD7DWUwa5a5XLfODJ2T8gimdevWqQq5YLAKO+iSotCGb6cJpmxz5DS1VkR/0OHXXJ2SG62jtZcEU8ISTIEcgkl7mLSYrFrTd55oAWqa6l1OmzV4OBynMEhnxgxzKb2YNlv7iJReMElvpXfftaZBE5IHq9qtlJyDKuTSU3Lpc+Q0tZbXyumCaSjClF0wTajiCNNANUaY+rsKFkzaE5Zwu2CS9/MGa45cQwAYtNJzBAiHgVZrtqA0ryQFk3eIKL0ZpTSuPP300/H9738f22yzzYiqCjardCaJGPD23cCyh4CBLUDDNGDrI4EFHwZqmkr7t7sGTGEyucGNESbD1RGmBg+NR0nmGWGqag9TUREmjwimLVvMCIrQGDb3Rd1In21Vp+Xa2kzBtHhxpdfGu4Jp0aJFI+47/vjjsz6WzSqdx4rHgHs/D3Qsy7z/pV8B/iCw4HBgp1OAYK0ppgbagX5ZbgGCdcA2RwLbfQwIFFF4IueDbgDZZJXru8HD5J6UXKJqIkyJPCNMukpOd0EPFBdMd7eHqb6QCJO5PxMJlwsm3SOwoUY2ytwXU+dUeq2cNSLllVcYYSq1YGKzSvdGqP/7Q+CRS8zfG1qBXT4FTN4a2Pw28N4/gfb3gPcfMG+j8fJNZkRq108Diz8NtBQwMjASN6vNhMaxr3OOSsnVheQ+w/GCKWJFUarBw5RvSi59X0jKMltTT88y0DM0V63ACJPrPUzam9NUnxltIyON36R0gonNKt2HaIF/Xww8/SPz992/ABzx48z021E/Aza/A7xxu5mqC9YAdVPMW70sJwO9G4E3bgP6NpqvJbcZuwNzDgCm7QrM2gtoXTR6U2EdXZLej/UOu27lF2Fydkoukooweb9KLl/Tt98aEyPpSknLVY1gikWBmNWHqIBUlGc8TJusocPN1rb3UjBlFUz0MBVFUWVujz/++Kj/VlNTg/nz51NgOYD/XDUklo64BtjvguyPm7o9cOgV5m00PnIV8O59wGu/A967H1j/snnTSOTpE7/N/lw9wFai5E7rmD1oRZjSx6IMF0wDHqmS85KHyW/NP8vlY9KCqWoYtKJLcsxrGooQTJbYcrtgmjQxMz1JTCiYyi+YDj300JyPOfroo3HHHXegqanEbmKSlddvAx79P/Pno64F9smciVww4l3a4ZPmrW8T8P6DwMbXgA2vACseNYXU3AOBxZ8d+Vyn+pf08F2hJotgqnGNhym/KjkdTXMzSSO/CJOulOvGYHV1+x7oNpe1E/KaI+e5lJwWTFOmmEsKpkwomMZFUU7IW2+9FYsXL8ajjz6Krq4udXvkkUewyy674IYbbsCzzz6LjRs34qKLLhrf2pGiEAFzz1nmz/tdOH6xNJyGFmDXM4EjrgY+9QjwESuK9fA3ZHTFyMf3RkxR4sRu2VFLMIVH9TC5ISVXPVVy+Zq+q7Z5pfYv1RU2eDZl+vaKYGqZai7pYcqEgqn8EaarrrpKjUfZfvvtU/cddthhKqIkY1HefPNN3HLLLfjEJz4xvrUjBdOxArjzBCAZA3Y6GTjcEjOlRFJ9T3wbGOwEtkh7LuvL3fAIU6ODBVO2CJNbquTYhyk7FEyo3gjTNBkQv4WCabTmldJ+IRo1ezOR0kaYVqxYgSk65JnG1KlTsXz5cvWz9GeSyBMpH/EI8JeTTeEya2/guN8BvjJUU/sDpglcWP/iyH/vtnowTXBwSi7s0rYCBowq8zANFpCSC1ZvhElScgXgOdP3DMvczJRcJpMnA4FA5r4ieVPU5VR6Ml1yySUYGBiaO9Tf34+LL7441a/pueeew3777VfMy5Mi+c+VwLoXzcq2k+4yeyqVixl7msv1L/lGHx7usJYCQsQSEdkjTM7v9B1HEjphOJqHqdHatj6Xz4+Sfl5MyZUmJadTnJ4RTDOt3ksUTJnIlyfd7Xuj1RGdlDYld+ONN+JjH/sY/vKXv2DHHXdUH2RLly5FXV0d7rvvPvUY8TFdffXVxbw8KYL2ZaZgEo65AWi2BlOXi5mWYFr3ErDbKFVyTowwjZWSq3NBW4H0WWmjtRWY4JEIk2HIthoZKaSx0AJSN/asCor2MOmUXER9ng+f3uA6wTR7HvCGtT/iMSBYRMddryKCSRp8SsdvUnrBtMcee2DZsmW48847lVCSN9cXv/hFnHzyyUo0CZdeemkxL02K5IkrgETU7Ni940nl341aMEnVXDKe3cPkNtO3G9oKpFfI+eAbMyUn2yq3bNvqBtJL3v2+3BdAnaKsqgG8xUaYfENvThFNgYAD36y5kC8E4s0RZm9lRlPkPpmt12SZwAkwbZq5FxhhKo9gEkQYffrTny726cRGpGO3NJYUPnxlQdXEtjFlWyBUD8T6feheGcD0mSMjTI1O9jBlbSvg/JTcUIVc9ujS8Dl50rxysvYwuLjLdz4REB1x06KyqtoKFJySC8LnC6oonqTlXCmYOjpktstQFKVhEtBjGb8pmEYKJkaYKt+4UjjkkEOKeVlSJE/9ADCSwPafAGbuUZndKObyxulAx3JgsN0/Sh8mOA6vpORG8y8JAZ9PNeYcMAyXCybL8J1H08qqTckN9hYlmHRaLp7oda+PKdXlu9ms/pLhwyKY2O07E3qYnNW4ksN3y0f/ZuDNP5s/H1ThLKiMU8kmmHQfJidHmNzaViBXhZxGRr8MJBKpzuZuJGHk34OpelNyxUWYUr6wRK97WwvoOXJTp2bO0tP7hJgwJVfeKrlYLJZxi0QiWLJkCQ466CD88Y9/LH5tSMG8eqvpXZqxhznTrZLUW59TwwVTn2U9aQi7zcNkpeTi7u3yram1tm/AxcbvoZRcbYERJgcfwJJ5mAqfsOD61gKpppUtmfugn4Ipa4SJKbnyCKZgMJhxC4fD2GmnnVSzyh/+8IfFvCQpktd+by73+ELld2FKMHVkig8doakLOzfCNJbp29kpuURegknPypO0nNsFUz49mKrXw2Sl5GrzH7yr0fs16RnBZEXZGGHKhBGmorG1reG0adNSjStJ6dm0FGh7A/AHgR1PrPwel5RctgiTFhxagDiFhGGkLqVje5jgWCJWU8ZcKbk6y/jt5ghTIT2YqtLDJMd2sPgI01Avpig8FWHSUTdiQtN3eT1MGzZsGHFfR0cHfvSjH2HhwoXFrw0piLfuMpdbH2E2q3RKhCnSkSmYdFm+0wSTTseNWiUXdL5g0mJgrCq5jJScByJMfn9+ud2q8zBF+sRAav5cV3iESe9XvZ/d72GiYMqZkhORnWXKAbFRMM3Q82iGsWDBAjVPjpSHd+81lzs4ILqUkZLbMjzClDnM1mnpuHw6fSeTBvx+Z61/vlVy2vTtlQhToSm5BJLqFrA3oO48dCQlVAsECzcM+q3qw6RlrncdnZ3mctKkzJQcPUyZ6AictGCQVgxZxpwRGwXTG29IC9VMJk2ahJkzZ7q3Q6zL6Gszx6AI2x4NR1CvU3JpEaZ4wkAs4cwIU8wSTHJZDY6RkhMicfFgwbWmb+1hcnOVXHofpnxI3ycSiaurFsFURIVcuhBNbxDqSsE0ceKwCBNN3xlIywURlSKWpHklBVNpBdPOO+9czNOIjbz/kLmcvpvZ/8gJZKuSE6GhcZpgGsvwLdSkra9EmZwpmAozffe7WTAZZqjS78vvQEhESW4SXRJhWQeHnYAOaimQLkSTbvUw6WHv0ocpw8NEwZTVxySCSdJyO+5YxoNUpZ2+hRdffFGNRpG+SzJTbs89rfkYpOS8/4C53MYh0aXRBFP6WBHtCXKLYAr4fQgHgWg8U/g5iZglmEK5PEweSMnpC7nfn7/wER9TP6LV4WMa7DOXtQ1FPd31HqbhESaavscWTG+/zfEoBVLUJWzTpk049dRT8eijj6Kx0TQX9vb24rDDDlMephadIyUlIZkAlj3krHRcepVcpNMHI2moGkxdISfpLaela8fq8p0eFRPBNKC2w1nrL8RTgsnv/ZRcgREm7WPqr5bWAmL6FmqKE0xDbQUi7o4wpQTThKHu5/Kh6Xdnh/uSwF5MRVFUUv/888/HwMCA8jL19PSom/zc39+v/o2UlnUvAAPtQO1EYPa+ztnb2sNkJH0Y7Mw0fDstHZery7em1uGVcjrCFMwRYfJCWwEjJZjyP5mqqrVARKShnND1RT1dm74TRtTdEaZUSs4STPI+1yNjSGYloR5WTEoXYbr//vvx8ssvY+utt87wNUmX7z32qNAwsyr0Ly043OzB5BQCYaCmyUCk24f+LUDDVGcLprG6fGdWyhmOFUxxmAIomGeEyd1tBcwLua+AlFxVdftOCaZiU3IujjDJeT08whQImvtCIm9SKadHpZAho7duxUBKOxpFp+LSaWhoQDTq0m8nLmLlE+Zy/ofhOHRabmDz8B5Mzktn5fIwpQs9MyUHB6fkvB9hKjYlVzWCKWoJpnBd9XmY+vrMMvl0wZTR7ZvNK7NGmCiYSi+YPvShD+GCCy5QqThNd3c3vva1r6l/I6VD5satecb8eZ4Dd7U2fstQYCd3+S7EwyS4PiXnoQhToaZvoSpM3+OMMLnaw6TTccEgUJcmGNlaIDtMyRVFUQmda6+9FkcffbTqu7TDDjuo+6RaTszeDzxglW+RkiC9l+KDpjCZ6sCm6mHrC120d3jTSrgywlTnkpRcqAoEEz1M+QqmYiNMunFlDIaRhM/nor5V6em49Pcz58llhym58gmm7bffXgmku+66C2+++aaqfjrvvPNw0kknoaYmv6ZypDhWPjkUXXJY0ZkiZH1Wx6zP7iEPk8+dpm8dYYoaDm8r4M8rJTfo5pRc0jyZfHmORqm6lJwWTOHxmb6FpBFFwFcL1xq+Nbq1QD9TchkwJVc+wfSxj30M9957L84444zi/ioZt2Ca68B0nBCyPqslCiYMRJ2bkosVIpjiTjd9ezvCJBEPwxKHxVXJOfQAlsLDVFucYPL5AvDBDwNJlZYL+F0omNL9SwKbV2aHKbmiKCrm+thjj6kWAqS8SCuRVf9xrn8pXTCNjDDBsRGm0BiCSXf7dmJKzpQQyaowfWvDd6Gm76r0MBUZYZJMgU7LJdzW7Xt4hZyGKbmxU3IDAwCv5aUVTIcffjj++te/FvNUMg42vgZEe6R0H5i2izN3ZTCVkhsaXOvEwbv5puT0eutImRMr5PJpK1Dr8ghT+rgOiYTkC/swVUlrgdFSctr0zQG8mUiVu8yUE1gpV9qUnJi9zzrrLNxzzz1qJEpY73iLyy67rJiXJfmm4w50btPakREmd1fJ6XEuThyNov1LBUWY3CqY0loKFNIxvio9TEU2rvSEYBo1JUcPUwbyHpK03Lp1pmCaO7dMB6oKBdNLL72k5satWbNG3YZDwVTa/kvzDoZjSXmYBob3YYIrq+S0YJLxKE71L8mAWV+OsS311jaKSEwYBgJOrBgYA8MyfBfSUqDqUnLR8QumgJXudJ1gGjUlZ/ULZKfv7Gk5EUzs9l1awfTss88W8zQyDowksPIpZ/uXhFC9OXPNDVVyqQiTFX3JRo213k6OMOVKx6WbvvU8uQaXCSap2hJ8BRi+qyolF4+Zt3F4mISUh8lwmWAaLSVXS8E0KqyUKxgXNdqobjYtBQa2mBGcGbvDsQx5mMxl+vBdx0aYxnjMUErOcG2Xbx1F0xKp34XGb91SoBDDd1Wl5HR0ybaUnEdM3xRMo0PBVJ4Ik2EYuPPOO/Hf//4X7e3tI/5dZsqR0viXZu9nzmxzKqP3YYLjiFrCITxGhCnsaA9TfnPkBPH9SJSp3zBc6WNKeZgKTMlVTVuBiJUDD4bNGWpF4trxKPlEmFx43pelUo4pudJGmP73f/8Xn/3sZ7Fy5UoEg8ERN2I/q9IaVjqZUT1MYXdWyTnbw5R/hMntrQUMKyVXSA+mqkrJyYDZcUaX0sejJNwqmEZEmKzRA4k4EHPZNpUaRpgKpih184c//AEPP/ww9t9//2KeTgpEruvpHb6dTKpKbiAzlaWFh9uq5MJB53uY8hZM1naKh6kaunynp+RkXxkwcprjXUt0wBbBpLt9uy7CNFpKLlwrYTPZIGCwB2i0oiqEgqlcESZJye26667FPJUUQcdyoGedmYqbtY+zd+FwD5OOzDhZMI1VJadTic70MOXX5dsL3b6TRUaY0sVkehsGz0aYxmH4zpwnF/VGSk7OefqYssN5cuURTIcddhjuv//+Yp5KikBHl2btPeQRcirD+zBpwaS9QE7C7W0FCqmSS0/Judv0TcE0podpvBEmt3qYRoswCSnBZIlKYsKUXMHkfRn73ve+l/q5paUFZ555phJN22yzzYhGcuzDVBr/klPnx40pmKwv9WEHNtrMx8OkhZ4TR6MU6mGqdXNKrkjTt6TgZP+IuBQfUwM8SjV7mCIRc8RHtghTuo+JvZgymTzZXHZ0lPgAVaFguu+++zJ+32233fDOO++o23AomOzlA92w0kWCSZu+dWQmZHmB3Nfp2+fgCFOBKTkXm751mXuhbQUELZi8nZIbf9NK17YV0NElocnq7J0twsRu39kFU5ZKdzJOwcRmlZWhazXQuULMrsCc/eB4RnqYDMdHmMZKyQ21FTAcHGHKLyVX72IPk2FFmHwFRpi08bvf660FtOnbLg+TmyJMWjCJWApk+aCpteKKjDBlF0y9vUA0OjRbjtjjYZJ2ApXkm9/8pkr/fe1rXxvxbz/96U8xb9481NbWYq+99sJ//vMfeIFVVndvaVYpQ3fdk5Lzqeq+VErOpaZvd3iYCowwuVAwDc2SK1ww6ZSltyNMNqXkdJWcmzp9j2b41tD0nR3ZX/qzj2k5+wXTNddcg0rx0EMP4d5778W222474t9uueUWXHrppbj++uuxdu1aZUo/6qijsGrVKnglHecG/1K6YBLig+6oknPr8N2hKjl/QR4md6bktIepmJRcFfRistn07SoP02g9mDQUTNmRaJzeZ0zLeWc0yoYNG3D22WerDuL19SM/EH784x+rfz/22GMxZcoUXHXVVZg4cSJuuOEGeMXwvZWDB+6mk17FJz4mHWEKBXwurZJzbh+mghtXujglN54IU3ovJu+3FaizJSVnGHEYMsDS7RVyQp1l+h7oLd86uQX6mLwlmKTnk1TkffWrX8Uee+wx4t9lNIsYzw855JDUfZK2k9+ffvppuJm+NmDz2+bPcw+EK/AHAX/IvCBH+gzEHZySK6TTdyIJxBOGq1NytVZKLuLCCJORMn0Xn5KrCg9TTYMtgslVPiam5IqHgqkgCr6MTdW9G8Zg8+bNsAuJFkWjUeVfGi36pFsdpNPa2ooXXnhh1NeNRCLqpunu7lbLZDKpbnYiryfCr9DXXfG4/N+P1kUGaibK8+F4ZBuDdX5EYz70dQ+tcNAv+9VZUaaYJZhCYxybYGBIJA3Gkinj9HiOq13EfAmpm0cw6UPSSs+NRa21lJRcoetc6W1NpBopBgteh5AvoPZTNClJzKTjt7UYfIN9qod5UjpbF7DeI7dVGjEEYCCBeGIQPsvT5Gg6O9U3f6O5GUa2ba+pN/99sNeVx7ZY8tlW36RJ5nkj12wX75Nkmda9YMFUTuP3iy++iJ/85Cd46aWX4B9jQGo25EQZ3h8qnSuvvBJXXHHFiPs3bdqEwcFB2H0wu7q61DoVsh3v/EtCyQ1o2asfbW09cAOyrf4aEa9+rFkt/T3Mkt7O9k3od1ClXMIwUvGGLhk+Ocq5IpElwAz1r12/Gc11xriPq130TRxQKmigpx9tA205Hx+NmWmtrsFBtLXlfnw6ld7WWMx8T3Z19aG/t7B1TzRFgXqgo68LbRK2dfi2FsOU/m5I7K1zIIZoAcc2+7bKKyWwafN6BP3OjzI1rl2rPmX6w2H0ZNn28GAcUg8W7+nAprY21x3bYsnnPG5uaIAkcXtXrUJ/gZ8JTkK205GC6eKLL0a5kFYGEq2S6rd0XnvtNVx77bWIxWKYPn16SuikI79PmzZt1Ne+5JJLcMEFF2REmObMmaMiVU3ZenmM88QV8SavXcibdNOL5kV84RF1aG11eIvvtG0NNwCDm2Tg7iSVOBJmTW8ZU8CWG9Xt2ioKmNXSgvoxjkvQH0U8CTRNmorWJt+4j6td+H0r1XLyhIlondCa8/EtPT1qMrkRDqsIbCFUelu7VieRTEgGoRV1NYWte5NPIt5bEG6sQ2tDq+O3tRh8CfN9NrF1hoTX835etm3tXlOLWHwQEyc2or62sH1dCXzWF4H6GTNQl23bI7PVIhgfVOe9245tseRzHvtmzFDLCbEYGgv8THAS4TK1RHCgs2SIc845R93SWbx4sfIn/exnP1O/T548Gdtvvz0ee+wxHH/88eo+UdSPP/648j6NRk1NjboNR06sUryR5MQt5LUHOoCNr5s/b3WwPA+uIVhremsGB/wp/1IgW3+UChJPMz7XBgLw55gn1xsBYgnzGI7nuJaiSi7slzq53H+/3joG0um7mPWt5LZq03cwUFPw3w9bH3NxXwJ+aWjm8G0tiqjZ+Mxf12gOmy2A4ds65GOKuWP7LTuFSi9lW9968wuwL9Kntsd1x3Yc5NxWa56cr6Mj+75zCf4yrbt799CwNOFvfvMbNapFTOASBevs7MSXvvQluLr/kgFM2R5oNINoriFopa0G+p3ftFIupcEcka/UeJS4M6vkCm0r4MbRKEaqrcB4TN9erpLrt6VxpRDwuay1QN6m7z45kcq3Xm6Apu/SRZjWr18PJyItBSSl9uUvfxkbN27EokWL8OCDD45I5bmJ5f82l1sNFf+5UDC5u2ml05tXFtu40m2CScrbxYQs+NhWYCSJOBCP2tKHKaPbt1uaV+ZqK6AFk4glXU1ITCiYCqKgS5n2C1WSV199Nev94kdK9yS5neUPm8utj4BrBZP2zoccHGHKTzDJYwzH9WLSKbl8R6Po9gmDLquGSaYq5IqdJefxxpU6umS3YHLLPLlcjSuDYSAQAsTnpXoxOcdLWXEomKovJefF+XHSf0nsFvMPg+sIWPXreoB42KWDd50+T67gPkwuTcnpLt+q5F1aBBTduNJhitduwaSEwfjDubrbt2f6MMl5L94ugfPkMqFgKggKJgdHl2btDdSO8qXJHREm53uY8okwienbiSm5Yjt9u04wpXX5LqbS0vMeJsvwbUd0SQhYESbXeJhypeQEjkfJDgVTQVAwOZBl/zKXCw6HK0kJpoi7u3yPMH3rQIdDiBU6S04P33VZSi7V5bsIw3dVDN9NGb7taT2i057pqVDHIueyVSU3aoRJoGAaWzBJlC7h0feHjVAwOQzxJa54xBuCKeJgwRQrQDDpeXJOijAZygatPUyFpeRiVuNOt0WYfEX4l6pilpwWTOMci+JKD5OIJX0uUzAVziTplTcstUlGhYLJYWx4FejfDIQbgdn7wpUEa60Ik/V5G3bw4N2QSz1M2vBdjGByW1pOe5iKjzAFqyQlV2ezYIq4Jx1XW2veRiO9tQAZIhQCJljDidvbuWdyQMHkMN5/aKidgBR2uDnCFI16IyXnxLYC6dGSfE3fNW4VTEbxg3erwvQ9aG+EKeAm03cuw7dG7xuavkdCH1PeUDA5jPfuN5fbfBSuJZWSi1lRHAeavourkoPjDN9++NQtH8QwnTJ+u8jHNGT6Li4ll276llSmZyNMtnmYLNO3GzxM+Ri+0yJM0u2bjCKYOmT2JxkLCiYH0b8FWPOM+fN2x8C1pCJMMedHmPKqkrM8TBEHRpjyTccNT8sNuCjCNJ4u3+kRpuGpTM9QMg+ThyJMNH3n9jExJZcTCiYH8f6Dpum7dRHQPBeuRXuYtMDQKS1HRpjymEGUijBZETNnVcgVJphSzStdmJIrpst3uofJs8bviN0eJhem5HJGmHRKjhGmETAllzcUTA7ivfvM5XbHwtUErAhTLOF803c+SR4t+JwUYRrqwVTYW1iPR4m4KSU3zgiTpCwD1n6KetHHVM1VcgWm5MCU3OgRJqbkckLB5BCScTPC5AnBZA07jyUtD5MTI0yWYAjnEWFyYluBQrt8uzklN14Pk+dbC9jsYdKNKyWyZzj9PMk7JUfT96gwwpQ3FEwOYfXTwGAnUDcFmLUPXE0gbEWYrM9aJ3f6dq/pu7A5cm4ej6IjHcVWyXm+23fE3k7f6cLU8c0rC40wMSU3EgqmvKFgcgjv3Gsut/0o4HegwCiEQM0wwRR0t2AaGo1iOC4lV2iESafk3FQlZ+jGlUWm5DwfYbI5JefzyRvW5w4fU8EeJhm+SzJgSi5vKJgcgFy737nb/Hm7j8H1BK3+cVpfONHDFCugSi41GsUDKbmaKk3JDTWvdNBBdGjjSmk/kUrLuUUw5ezDlDZ810XnfllghClvKJgcwKY3gfb3Te/PtkfD9eiUnL40OTnClI9gcqKHaSglF6iClNz4TN+enydnc4Qp3fidcLrxu9A+TEYSvrjDRWC5oWDKGwomB7D07+Zy68PNkShuR6fk4laTQCcLpsI8TIYD+zAVVyVXTZ2+vZ+SG7DV9J05gNcjEaZwrahA9aNPC0xiwpRc3lAwOYClfzGXCz8JTzAkmJxr+o66fDSKjjAVWyXnJg/TUIRpPCk5L5u++0oWYXJNSi5XhEnOeyst59MpTDIywuSiL1KVgIKpwrQtATa+Dki2YeFx8AS6rUDc0iLuT8lZz3GQYCo2wuTGlJw2fY8vwhT0ZoQpEQfiUVs9TK7qxZRvSi7N+O2nYMoeYZLhnwNWtJJkhYKpwrx+29AolDpL6HslwpS0hEbI8gA5McKUl2AKOXc0SnX0YRpfp+/MCJODDqIdpKeXwva0FUgfwJtwcoRJzuF8U3Jpgonz5IbR2AgErQ9rjkcZEwqmCiJjUJbcbv686HR4Bi2YEkHDUyk5J41GKbatQK0L2wrYmZLzXIRJR0uCIfNmE3oAr6NTcoODQCxWQITJTMn5o4yiZCCfgTR+5wUFUwVZ8RjQtQqoaXJ/d+90AtZ1LRlw7iy5QlJyXmxcqbffXW0FaPoeNcJkY3QpY56ckxtX6uiSfAmQKEkuLI8XI0xZoPE7LyiYKsiLN5jLRWcM9S7yAj6/2VpAC6aQy6vknGj6LjYlV+fClJyhO33b0FbAc6Zvm7t8u8r0nZ6Oy+N9zAjTGDDClBcUTBWiZx3wttWscq8vw3OIANQeJic3rsxPMPkcPHzX2yk5w0jAsKJpvnHNktOmbwcdRDvQ6SWbBVPADX2YCjF8p/diilpVhWQICqa8oGCqEC/+CjASwNyDgNad4TmkUi4R8EaVnF7/WEK+cTsjMhNLtRXwdpWcTscJjDCN1VKgRCk5t0SY8kFXybEP00iYkssLCqYKMNABPHet+fPe58KTmBEm55q+CxFMtWmCL5pweYTJZSk5bfiW2Wa+Are1KhpXpppW2iyYtOnb8GKEiX2YRsAIU15QMFWAZ34CRLrMyNKOJ8CzgikRdG6EqZAqufT1jwwFPBwSYSouJecW03d6l2+ZcVYsnq2SK1mEyUUeprwFEyNMo8IIU15QMJWZjhXAcz8zfz7kCtMg7UUkJadN32GXm76DARlGaj0v7u4IkzZ9u8bDZENLgczhu14TTKXyMHkxJccI06gwwpQXHr1cO5NEFLj700C0F5h7oHc6e7vN9B03tI04v5ScE+fJDfVh8ns7JWdDS4HMlJxDFK9LIkxeNH2z03cWKJjygoKpTA0qO94N4E/H+rDqKXPA7nG/8250SfDXGDD8zowwpaej8hVMTmstoFNyhUaYalw2fFeP5vCNo6WAp9sKREvtYfJQhIl9mEaHKbm8cNilzHvIdem67XzoXNGifg81ACf9BZi0AJ7Gl/b57TTTt/YvFSOYnJKSG+rD5C8qJSf7IGEYCIzDF1TeCNP4UnLeNX2XukouCsMwxuUfc46HSafk2Ol7BIww5YWHYxzOQD5npmwrKSoDWx1q4KwngW2OhPdJa8QZcmiESVYrX8HgtF5M462Sc4vxOyWYxh1hMk/CJAwkUglZD1DixpWAkRp+7P6UnGX6jkfMocVkCAqmvHDYpcybfPxWAz3xNsyY1Qq/34Hf1EqAYQkm2dqg372Gbyd6mAwYqdEohVbJpW+zpOXsvcyWLiVnl4dJp+XqvPJdsUSNK9P3t/iYxmu6d0ZKrjEzMhdy4DZVOiUnIjSRAAIOSws4BI98ajibxmlAwL65mO7AEkyiM5wWzi+ky7cTPUxaLBUzS87v8w01r3RBpZyOboyny7cQgB9+Jd89ZvwuUUpO3rOOH8BbaIQpEIARsj6YBntLt15uFkzpQpSMgIKJlIbaobSXm5tWOtHDpNNxxUSY0oWiGyrldOPK8abkPGv8LlHjyswBvA4VTIV6mNJ8TBRMwwiFhgYYd3TYc3w8CAUTKQmGFRDwimAKO8jDpCvkzN7Xhb+FU72Y3CCY0hpXjhdPGr9L5GFKnyen06KuT8llCCbOkxsBfUw5oWAipcHyjFrTUVzb5VtTa12vozHDQYbv4t6+bhrAa2+EyYPNK6OlE0xDvZgcGGGKx4G+viIiTKbxmxGmLFAw5YSCiZSEpCWYAkln+ZcyIkyWcCjE9D3oiAhTcRVybhzAOxRhGr9B13PNK8WcG4uUUDA5uNu39i8JTU2FCybt/SJDsBdTTiiYSEkwQubFOOCRCJMTTd/F+JfcJpgMw9zhPhtScp7zMKUPkS2Fh8nJA3i1YGpoMP03+WI1r2RKLguMMOWEgomUhKT2MDnw2uR+D5M9KTl3mL6tCJMNZe1hKyXnGQ+T9i9JCW7Q/jJcRw/gLcbwnd68klVyI6FgygkFEykJhvX57XegTSZqeXeKiTA5oQ/TUJfvcUaY3OBhsmmWXHpKLuqVlFwJDd/pA3gd6WEqxvAt0PQ9OkzJ5YSCiZSEpJWLCyQc7GFybUpufILJVVVybCtQEcN3ZoTJwSm5AiNMhk7JRdiHaQSMMOWEgomUNsLkAIFhR6dvLZgGY87xMBWdknORYDJsNX17NCVXKsFk7XNHp+QYYbIPRphyQsFESkI86FzBVFynb2torQO2Z9wpuSptK+DZlFwJDN8ZESYnmr6L9jCxrcCoMMKUEwomUhKSAedHmEIunSVX7OBdN0aY9MXanio5j/VhKrmHycGm7yJTckOCiW0FRkDBlBMKJlJaweSAFJadKTlnRJh0W4HxpeRcUSWXMn2zD1O55shp/F42fbMP00iYkssJBRMpCQnrzPLHfJ7owxS2AhxOaCsw7ghT1afkEt6aI6eNzDYzNHw36p0IU6oPE03fY0aYXPBlqhJQMJGSkPCbbzifAz9ri6mSq3WUhylpS5Wc3g9OJWmIsEnabvr2TkpOR5jqSuxh8l4fJpXOdIGHryKCKRIBBiwxTjKgYCIlIW6dWU4UTEVFmFKjUTwwS84lKTnDMnwLPltmyXnU9F2iCJPuw+TICFPRKTlzX/mMJBClKMigsREIWF/COjpsOUxeg4KJlIS4z/mCqVr7MNXolJzDBdNQdZYffl9x2+rttgKl9jANDd81nHauFJuSC9bA8FvnEn1MmcjnIY3fY0LBREpCSldEvNW4MuKglFxovI0rHZ6SsLOlgMAIU3GCSdKihkqPeiAl5/MhGaaPaVRo/B4TCiZSEnSDb9+gN6rknDhLzutVcjrCZMdYlMw+TA67+Du103eab8xxPqZiBZPq9m15vmj8HgkjTGNCwURKgrb6+GJAMuF+D1Otdc2OOsrDNL4qOaebvg0bWwp4MyVXWsHk8/lSYtVRvZgkMlpsSk7Oq1SEib2YRkDBNCYUTKQkxGHNkosDCQd91hbrYUqZvh3QV0pf8JmSKy7CJPvPsM5PV1NiwZTpY3KQGbG3d6jCrQjBlAwzwjQqTMmNCQUTKQkx63rkTwDxQS94mLzTVqDGZSk5n80RJs9EmUps+s4cwBtxXjqupgaorS346akBvIwwjYQRpjGhYCIlIWpdj/xxH+IO+qwdb1sB8TBVumJovCm5lOnb6YLJZtN3uufLE60FStxWIGMAr5M8TOPwLwlJPXuPHqaRUDCNCQUTKQkxSzAFHBxhKmY0Svq2uTUll+5hSjpYNA2NRbFHMPng847xOx4FEvEyRpiinhFMht5fFEwjYUpuTCiYSEnQqSsZvus0wTSePkxOqJQbt2BK224nR5n0RVrPNLMDzwzg1dElQXtySjiA11Hz5OyKMLEP00gYYRoTCiZS2pRcwnmm72I8TKGA2dfNa4LJyZVyhs0RJmEowuTylJy+2IdrAd2IsQRosepID1OxESam5EaHEaYxoWAiJUGX3wfEw+TQCFMhKTkpsU41r9SOdpcKJr/PlxKLAy5IyflsFUweaS1QBv9ShofJiSm5QseiWCRTKTm2FRgBI0xjQsFESoL2+TitSk4M28VEmNTjHdDtO4Gk9F0el2BKjzI5udv3UErOPsHkmW7fZWgp4NgBvOOOMLHT96hQMI0JBRMpCZF0D5ODPmslZqFjKoVEmJwyTy49MlLs8F23VMoNmb7t8zCl92LyhGDS6aUS4UkPE03fuVNy0hg04fL3SAmgYCIlIRZ3ZpVcLE0gFCqYnDAeRV/oZU0C43j76ko5J6fkDJvbCgieqZIrW4TJgSm5cXT5zvAw0fQ9umCSzwW9n4n7BFNfXx8ikbG/5USjUWzevLnifXLIsD5MDhJM6SbnUNERJsMR/iUpkx9vSi7i5JRcCT1M7k/Jlb5ppWfbCtD0PTrhMNDYaP7c3l7U/vUyjhdMt912G3bbbTfMmDEDEydOxD777IMXXngh4zHJZBIXXnih+vetttoKs2fPxt///veKrXO1I5pEp62cNhpFC6aQZX4uhJTp2wERpvH4lzI8TA7+cpEavmtrWwGvRZhKbfr2nocplZKLx4CYg4SgU2ClnDsFUyKRwAMPPIBbb70VXV1d6OzsxK677oqjjz4a7Wnq95prrsFvf/tbPP300+ju7sZFF12EU045BUuXLq3o+lcrieSQT8hppu9iKuScJJji1lgUuwSTk1NyqU7frJKrWIQp4MW2AqG0vlWRXptWykNMmWIuN2+u9Jo4DkcLpkAggD/+8Y9KJKmy7poafPvb38aWLVsyokzXX389zj77bCxevBh+vx/nnXce5s6di5tuuqmi61+txNKyPE5rXJnq8m15eApBz5PzRITJ2n5HV8mVoA+Td6rkBsqaknPU8N1xCib4/ez2PRZTp5rLLVuK278extGCKRvvv/++Wk6fPl0t29rasHLlShxwwAEZjzvwwAPx/PPPV2Qdq51ofCh6o0zfEXd3+R7ZVsAZHqbx4IYqOaMEnb69Y/out4cp4h3BJNRaPh32YhpdMDHCNIK0gQ/Op7+/X0WPDj30UBV1EjZt2qSWU/VBtpDfJUU3GmIgTzeRSypP+6HkZifyemJEt/t1nYhsozZF+w3AZ/gQG5B9CkcwaJXKyiW40OMRDprbFYmax7ISxzUqjRH8QMDwI2kU/3d1SnIgz/O9Ets6FNUI2vZ3ldD0i3COj7r/3PB+9UX6lOU/KWNRxrGeubbVZ10iRDA5Yn8YBnydnea2NzUVvO16e7X3KznQM67952SKPY99U6ao/Wu0tcFwyb5Jlmk9XSOYpALuxBNPVKLpwQcfTN0vKTghHs8MscdiMZXSG40rr7wSV1xxxYj7RYANDg7afjDFgyUnr15fryLbuqVTvv1ORMCKXnS396OtzRlegY2WYPInEio6WRBx+TYfxpbOXrS1RSpyXLfUdsquhRFNoK2jwPVPw4iaYmRLTw/aclSfCpXYVt37p6O9FwF/8RWB6QzU9qn91xvtH3X/ueH9OqmnExL76Y4kMFjoeVzAtmqzt4EENm5cD5+vdGNY8sHX24tp1sWxTc7hArddb+9kf1jtv662dYhMKH7/OZliz+OG+npMkPfK6tXoHse5VU5kO8tB0E1i6d1338Xjjz+eSscJs2bNUssNGzZkPGfjxo2pf8vGJZdcggsuuCAjwjRnzhy0tLSgSb652HziigdLXtupH8B2buvqzi0ZZfs1gQa0tpY2dZAv9f396kO2IRRCa2trQc9tahRRnkSothGtrc0VOa6rYYr5hnBdweufziQpmujuRqC+Hq26u+8YlHtbDSOJLSvNL0EtLTMQDNhz/rQr0/wH8IUDo+4/N7xffYa5b5papqNpHOdBrm2V49Cx0vx5ytRm245D0Vji3giH0Tp37tCAxwK3NzRhErABaA77gXHsPydT9Hk8b55a1PX1odYl+yYs7RDKgOMFk0SKTjrpJLz11ltKLEnLgHRE3IjZ++GHH1aVcTra9Mgjj+Dcc88d9XXFQC634ciJVYoPSTlxS/XaTiOW9GecXImIbLs9EYLxopM8NUUci5qQL9VjSj+33MdVV8mFfQH4fePo9K1N32lR2lyUc1sTiSGTcTBYN65tTadGNZQAYr7EmK/p+Pdr1DR9+2sblIl5PIy9rX74fEEYSqDFK78/rEiCr7kZvjEyCLm211dvfin2D/aOe/85maLO45YW87mbN8Pnkn3jL9N6Bp2ukE899VQ8++yzuOeee9R9a9asUcvJkyejvt78tnP55ZcrsbTXXnthv/32w9VXX63u//KXv1zBta9e9Bw5HWFykuk7ZkNbASeMRvF6lZxOBfngh9/GNJD3TN+l7cOkjd+JhHi+HPBG1u1kdOl7sdRJ0knyTj3jXyevQdP3qPidnpd87rnnEAqFVEpu3333Td20gBKOP/541X7gd7/7HT75yU+q9NoTTzyhQpGkcl2+g9bZlXBQWwFdFVZol2+nDN+tliq5ocG7I6PA4yGU6vTtdsFUntEoQsCa5eeIbt9aMOWRRh4Lo86yXfSbxT4kDX3dZJWcuyJMkyZNSkWUciERJp2SI5UlljAvxiFLMDmpD5MWCPVFRZgq34cpbl3og+MUTDUOF0yJErQUyIwwubgPk0QFyzR8N7MXU8QzgmkowkTBNGYfJjnXXJKWKwfcE6RkKTnxUzotJTc4jpRcrcNmyXk6wmSlf/RoDruosb4jyn40Uv3oXYYWS+n9hKqlF5NdKTnLw0TBlAW9b0UsdXSMbz97DAomUl0RJsuzoz08xaTkBs0G1J7wMEkfJmen5MIlEUyujjINWr6bYBgIlb46SB8DR6TkdPdp2yJM9DCNQCrOdKU403IZUDCRknmYwlYKy1GCyYqo6AhL1Zq+nR5hsqIZdgumgJjIVVs+IOJawdSbedEvMY4awGtbSo4epjGhjykrFEykZKNRtMBIOOBz1o6UXNhqK1BZ03eySlJy0ZKk5HzwpaJMrhdMZUjHpQ/g9ZaHSafkelT3cDKKj8mapEFMKJiI7WhBoT0/XknJ1XjIw1Tj9LYCVvpHX6ztxPWCSaeRpAdTGRjyMEW9I5i0hykRA6IO+oByCmwtkBUKJmI7EcvDVGtFZLyWkvNCWwGnp+QSJUrJeUIw6YGxtWVKyaU8TBHneJjGa/oO1QIBs4kpjd9ZoGDKCgUTKVlKrjbkrSo5Lwmmau3DJIRTvZjcKpjKm5Ib8jB5KMIk5z9bC4wOPUxZoWAipUvJWdc670SYnOBhsrnTt0wzd6BoGmorwAjT6Cm5cnmYPNiHKaO1ACvlRkAPU1YomIjtRHVKLuw8waTL6LWHp7hO34ZnUnJCxImCqURtBbyRktNVco1l9jBV+I08MGDe7BJMOsLEbt8jYUouKxRMxHZ0n6K6Gp/jquS0OEgXDNXcVsD5gql0KTnXC6ayRZjq1DJR6RlHOrokQ3d1nyBbWguYA31JGhRMWaFgIiWLMNXVDkWYnHJNHk9KrtKz5KQz9ZBgGt9bN+DzwbKYYcApBycN7ZfRc8xKEWGihyk/AgHzjZxIWtEdJ6Tjinj/jtlagGT3MLGtQAYUTMR2tKCoM7+YKhIO8ItmpOSKGY1iVf1VKsKUsHow2RFhEuoc3FpgqHGl/REm76TkJpQ3wuQkwWQHHI+SWzC1tdmzrz0CBRMpWZVcvRVhclJaTqeftFgoJsKUSMr4l/JHZXR0yY7hu05vLVCq4bueEkxlTskZRhzJZNz9Y1E0HI8yOtOnm8u+PqDXOt8IBRMpXR+m+rqhKI5TjN+DNniYKhVl0oJJRnvIiI/xoveBI1Ny7MPknLYCaVG+ikaZ7Bq8q6GHaXQaG4dSBBs32rO/PQAjTMR2tJiQKrmAg1oLGIYxvtEoaUGdSviYojYZvoe3Fog4MSVXotEoQq3l3hpEBacoj4eB8gomn8+XlpYb9GBKjh6mEcjno44yUTCloGAithNJmyUX1ILJASm5qCG2aRSdkvP7fQgFKhdh0ikknVLyaoTJMJIq/VO6lFzIvSm5eAyIDZZVMAkBv5lfTzohwmSbYGo2l6ySy44WTBs22LO/PQAFE7GdSGLIJB1Mq5SrNOnCoJgIk3peBXsxRW0WTPWWaOx3WIQpfWZZKUzftdb+c2WEKWKNRSnjLDnBH9CtBSoomDZvtlcwNUw0l32d9rye15g2zVwywpSCgomUzPStIky1zjF9a8O3XC5DxQqmUGavqXKiIyK6j9B4abD2QZ/DIky6y7dyavnsST9mizANujHCpNNHNQ2iYsr2Zx2RktMVW/pCbpdgEk+YRO5IJowwjYCCiZRuNErIWR6m8Ri+ndC80u4IU4MVYepzWISplBVy6REm2Z/JVJLWbYbv8kWX0lNyFTV9a8HU2mrP68nwYp2aZ1puJPQwjYCCiZSscWV6hMkJgmk8Y1E04QrOk4uUKCXnNMFUygq5dNO3K31MZe7BpAkG6tUynuhHxdCpIbsiTHL+ax8T03Ij0fuZHqYUFEzE9kq0lOk73cPkoJRcMV2+R0aYDNcLpkbHCqbSVcgJ0pIhaH30RdzmYypzSwFNwBJMiUoKJrsjTELDJHPZ12Hfa3oFRphGQMFEbCU98lKbXiVX4SbB6aZvO1JyA/QwlQztk9EjOUqBa1sLaA9TuQWT3xJMyQoJJmmg2N9fAsFE43dOwbR+vX372+VQMJGSCSYxSAet3mcxBwimQRtScvVhU2z1V2DUS/V4mAYyfDOlYKhSzmUpOe210amkaknJ6ehSba3ZVNEuKJhGZ+ZMc7lunYR9QSiYiM3o6rGgHwgFfAhb3tRYWjW0m1NyDVbEbCBquL5KzrkeJjPC5Lcqs0rBUC+mmEsFk9V0sUwEAg2VTcmlV8jZMXhXQ8E0OjNmmPs6FhsaS1PlMMJEShJh0qmrkCWYon3eSMnVWz7kSkSY7PYwpdoKOEww6V4/pY0wubS1QJ8WTFYqqUwErZRcvFIpOW34tjMdl74fafoeSSg0tL/XrrV3v7sUCiZiK5GYNXoklCmYnBBhsqOtgE7J9UUM76TkHNaHKZWSs5ollgK9D13nYervzIyMVMD0LYUdnjB8Z0SYaPoeMy1HwaSgYCK2Mqh7MFnX9LCDIkzaw6RnqLk1whS2uUrOaZ2+U6ZvRphGjzA1NFdEMAFGZZpXlkowNVpVcr0UTFmZNWvIx0QomIi9RKwv7CMiTBWsRi5JhImm7zIIprqSm77d62Eqb4RJOq7rNg8V8THZ3eVbM2GqueylRycrjDBlwAgTKZGHyRQWTjR919pg+u6voOnb7saVvU71MLGtQCZy/uqUXJmr5MzjUcHWAqXyME2YYi5724GkNQSTjIwwMSWnoGAiJamSk7EoQqjeOYJpwMaU3IAHTN+NlnCUQxZ1kI+pHBGmOpgHst9NEabowNDMszKn5DJbC/R5yMM0yawEk88GjkcZCVNyGVAwEVsZ1KZvB1bJ6ZRczbgiTNr0jbJiwEAUCds7fes90Z1IVFUfpnqrSq4fDmhBny+6kitUA4RLJyYd2e27VIIpEBjq9t3DtNyogmnNGnv3u0uhYCIlG7zr1JTcePowDZm+jYpUyNlp+vb7fGiyom1dDknLSQVWOfow1aPGfRGmCjWtdERrgVJ5mNLTchRMI5k3z1yuXGn/fnchFEykJCk5mSPnxT5MdRUyfUes6JLEhPQcNDtodphg0mKp1B4mV0aYKiyYKhZhiseBzZtLE2FKF0zd1t8gQ8yday67uoBOK8JZxVAwkdJEmILOizDZ0VagoUIRJl3NJdElXyqRNn6aJSUhn4cOSclp/5LPF4TfZ08kLRsNVoRJGlcm4AyxmHdKrsw9mDRBq9t32T1MGzaYHqNgEGhpsf/1daUcI0wjaWgY2ucrGWWiYCKlaSvgYA+THZ2+y236ttu/pHFaSm7Iv1Raj47u9C0MoAIO/vEIpkql5ALmDLd4ore8f3j16iE/jSXwbYUpufzSch98gGqHgonYymB8WKfveuf1YbLL9F3Ojsd2V8iNSMk5JcKUKH2FnE5t1rutUq6/u8IRJkswxXsqI5hmzy7N66cEE1NyWdlqK3O5khEmCiZSkgiTE1NyPVYUZYINbQWSxlD6sdwpOTtJpeScFmEqoX9puI+pzy0+Jj2+o8xNKzXB4ITKRJh0hdacOaV5/Sam5MaEEaYUFEykNI0rh5m+JcJkVPiarEvndRqqGOqGMjllNX6XKiXXXKUpufReTANuiTB1bzKXzdYFvswEAxNSxyiZjJc/wlQqwcQI09gwwpSCgomUZJZczbAIkxAzr4UVQdJn3ZYoaBqHD8Lv96GuAj4mHWGyXTA5zfSdKJ9garAEk2siTLqKS5uUy4z0xfL5AuWPMpU6JdfUOjRPLu4SP1s5YYQpBQUTsZWI1bhyeKfvSqflpKWA/k48nghTpXoxRUocYdJistLEE6Y/Jhg0/TKlxHUeJh1haipBpVge+Hy+NON3j3dScvVNQNhKAXdZ/Z7IyAjTBzR9UzCREs2SM5c+PxCsq3ylnBYEslr14zB9Cw1WL6beMgYmtOk77PGUnI5c6AtzOQSTK6rkBvvM0SjpnpsKpuUqEmEqlWCSz4OJ082fOzeU5m+4mfnzzWV7O9Bh+eiqFAomYisDw2bJOcX43Z1m+JZvyuNhgvVltGeox2LJ0Rf1urRyeC+m5OLx8gumPjcIJh1dqm2syFiU4YIpVq5KuVgMWL++tCk5odnqIN5BwTSCxsahESnvvINqhoKJ2Eq/FXWpt6IwTmktkDJ829DHZWK9uW3dA+VLyWmfjW646NUIU0xHmKyKrPKk5FwgmHTJewWjS0IoWOaUnIglad8RCpWmy7cmFWHaWLq/4WYWLjSXb7+NaoaCidhKlyUiJqZ5l5zQvDJl+B6nf0m9hvUFv7OMArDXuqg3Whd5uyNM0nIhUca+UqMZ8/WFOFSGCJMWn64wfVfY8K0JBc2mmbG4Naal1KxYMTSiw4b37qhMtCJMTMllZ/vtzSUjTITYR5e2WdQNRZhqrGBBxOq753bB1GxtmxaH5UDPPNNDY+1C7w8jrU9VpUgaERhGPCP1U0qaYOZWu1DB8k2XGL41oeAktYzGyuRlefddc7nttqX9O5PoYcorwvQOU3KE2EIsYaSM0M1pNou6yeZysMMbgmliXaY4LDUGDPRagqnRZsEU8vnQYHm6Kp2W0/4lv68Gfr+9Xq1sNKEuZajXbRscH2GqcEouHLIEU7xMb+b33jOX221X2r8zcYa57FhX2r/j9gjT20zJEWIL6SboprRGzbXmZywG2t3dtHJkhAlla1oZtwbE6t5BpUjLdVTY+J2qkCtDSwHdokHPlOtCGR38Lo4wha0IUyLRh0QyWr4IU6kF09Q5Q72YBso8+sVNgun99+WbDaoVepiIbegUVWM4iYDfNyLCNOCECJMNpu/m+vKm5LTHJoSA7W0FhFZrn2ys8AdhqgdTGfxLmma3pOW0Gbm5soJJRtZIA0shVo4oU7lScjX1QLNlKt/EmWkjkJYOdXVm1eLy5ahWKJiIbXRZJugJtZlCIiWY2r3iYUJZI0xDFXL2R5eEGUFThG2osGCKpVoKlN6/NDwt1+1kwZRMAO1W88YpJSytd5qPSSKey5aVJ8IktMwzlxRMI5HPzZ13Nn9+9VVUKxRMxDZ0xGVCTaZg0ik5r3iYym361n2C7G4poJmuBVPFU3JWhVyZUnJCsyWYHJ2Sk+7T8RgQCA2Vv1eQcGhyeQTTqlVANAqEw6VrWpnO1LnmkoIpO7vtZi5feQXVCgUTsQ0dcXFkhMlWD5P1mmWPMJVGME2zBFPlU3Lla1o5XDA5OsK02ep0PWUW4B9/Snm8hEMTy5OS0+m4bbaRXCBKDiNMY7MbBRMFE7ENHXFpGhZhqnNShMnGxpVSERhPuLcH04gIk2MEUzlTci7wMKUEUxmiLE5Kyb3xRmZJe6lptWamMcKUWzAZle3ZVikomIhtdPYbzo0w2ZiS06NRhJ7I+MasFBJhsrsHk2a6JSIrLpi0h6kCKbluJ6fktqzOrOSqMLVh03g+GC1xV+wXXzSXe+6JsqAjTJICHSjjrDy3sGiR6WVqaxsaiFxlUDAR+1NyNc4STNJBustGwSQVgFo0dZdRMJU6wrQpkUC8Qt8cDSOJaLw9o3S9vB6mASSs1g2OY/MqRwmmmvD0lOcsnugrvWDaay+UhboJwCSrH9PapeX5m26ivh7YfXfz5yefRDVCwURso3uUlFzK9N0JGBW4Jm1JJBA1DIi0abXEwXiZ1mQKpbae0r+FdPSj0Uof2c2UQEA1K0haoqkSRGPtMIwEfL4QQkHTI1OulJy0akjCwBZUcHZPPik5bUquMAF/GOHQFPXzYMQajGs3HR1DFXJ77IGyMWcnc7n6rfL9TTdxyCHm8vHHUY1QMJESmL6TWT1MIpYqMR5ltZVqkkhK2OpqPV7mTDZfZ123v+RdvjfDTA9MRWlSVX6fL2X8rlRaLhIzGzPWhKbCZ9MxygcffGiF6ZnaiArO7hmNSD/Qs8VRHiah1ooyDZRKML30krncemtg0qQKCKY3y/c33cQhFEyE2EKnjjAN8zAFa4FgXeWaV66RZmsAZtsUXRLmWoJpbWdpq3dkJIqM7pC/NhlpE41tptKCaTDappY14RJOpB+F6U4WTG3W8NnGSUBd+bxduaitMQXTYHRDaf7ACy+UNx2nmbOjuVyzFKjwqCBHcuCBpo9JOn5XoY+JESZScg9Tho/J+rJciQjT3FDIdsFU6gjTJiu6NAn1CKJ04myuJZhWWOKy3ESimzIMxeVkGprUciMcOBLjg9cyIx8OoS48o7QpuX/9y1wecADKSusCIFwLRPqGxCoZorl5yIR///1Vt2comIhtxur2vuwRJnWf1aC4Y4VHIkxTLMHUVdq30JYSp+M020lzQBlGHrGmJ1dIMNVUVDB1O1cwbbUYTqKuZpZKaMoQ3mis094X7+wEnnrK/PmYY1BWpGJ03i7mz+88U96/7RZOOMFc/vnPqDYomIgtrOs0MBAFgn5g+oSRoewW6wty25LKRZhm2xphMt8667v9SCRLV1lWav+SZvsas2XBO9JZucwkjQSisc3q55pQ+VNy2sMk6U9dkegIEnFgldWLaKtd4SRkplx9remp6um3GkzaxYMPmmNRdtoJmD8fZWeHg8zl0uqsBMvJyScPGb/XlyjC6FAomIgtvLvRFA1bt/gQzJI5arUE06Y3KxdhmmNjhGlaExAKAPGkD+u7UPKUXMkFkxVhEnHZV2bvRv/AShhIIhhoQCjYjHIjVXLTLNG0DGakyxGsfRuIDgL1TUBrBYRDDhrrzYG4vf3v2fvC991nLo89FhVhoeXTWf8+0L6uMuvgZLbaCthvP7N55R/+gGqCgonYKpi2nZa9wqmlQoJpMJlEm1UqP8fGCJP0YppjFe+sbjdKViHXZvlqSi2YJgUCaLUaWL5b5ihTT/87atlYv11ZK+TS2Q7T1PJtlLgZYyG88ai5nL+7eQF3GBPqzYG4fYMrkEjaFJnr7R3yxlRKMDU0A/OsiN4rD1ZmHZzO2Weby5/8BBhwcJd8m3Heu3AcrF69Gi+++CK6ux3oRfA47240oxLbjSKYWq1B11veA+JlzHroFJM0rGy2+aIzv8Xc1ldWlSYiswod6EcUNQhiuuWzKSWLrLTck/39KKf3Tad09AW4EizE9FSEKYbKDiFWRAaA1x42f979aDiRmlCLagMh/bM6uq0mk+PlhhtMD5PMj5MoRqXY+xPm8rm/AwMOLAaoNGecAcydC2zcCNx4I6oFTwimwcFBnHDCCdh+++1x5plnYvr06fjFL35R6dWqKt7dYIwpmCbMBGqaASMBbDEDCmXhoT6zGeEBdXW2Ry8O3d58+zz8VlJd+O3mLZjpgO0xraQVcppjGs0o1j96epAsU8fvweh6xOKd8PkCaKhbgEohglS6fotYWooSlcoXwqsPmZVak2cBC8rYuLEA5P00daJZxba56xkkk+OssGxvB66+2vz5ssvKM3B3rLTctAXmMXiiutJOeREOA5deav4sy7eqo9GnJwTTFVdcgeeffx7Lli3D0qVLcfvtt+O8887Dc889V+lVqwp6Bw2sbB9bMIlW0T6mtVaLlVIjF/2HJMQP4GhLDNjJIdv7EfIbWL4ZeL/NXoEhYzr0hXtHWOMaSswh9fUqErchkcDTZQizi8jcsOUh9XNTw46qg3SlkAaWe8DspP2Y7x1EfRWMMolv5pFfmz/v80lHpuM0zY2LlO8skejD+s33F//FQaKap5xizinbdlvgtNNQUWSff8RKOz3zF+DNJyq7Pk5Nyx1+uJmSk/Sp9GbyOM59JxbAb3/7W5x99tmYMcO8sBx33HHYeeed1f2k9Pzqibjy/82b4sOUxtGjOAuOMJf/+QEQL8Os0wf6+tTFv9Hnw4F1VudMG5lQ68Oec80KvBsej9tWLSfepQfwpqraqkcYCzAV5aDG709Fmf5v0yYsL6GXSaIRbe2PoH9wFXy+IFonfxiVZl/MV/2uenwRPDxxWfkr5uRNtOJV4PffMDt8z100lBpyKBIZnDn140pydva+hrWb7kYsXkAKS/yFjz1mNkT8978BeZ/eeSdgo9+waLbbF9jXKqG/6zvAQzeag3nJkKj8/e+BBQuAFSvMOXPf/S6wciW8is8oRS6hjKxbtw6zZs3Cvffei2PTTIKf+9znsGTJklGjTJFIRN00XV1dmDt3LlauXImmJnv9IslkEps3b8bUqVPhd/C3xUJ4aEkCb603sLbTwNPLzFPo6pOC2Hc+Rt3WaC/w67186Nngw9QdDMw9AGjZ0cDis+xbr993dWF9PI618TieHzRV2f80NeH8EoxXkOP6xJJOfOuBRsQNYPYkYMcZfjTWAvUh4KwDA6gL5ZcGfAkr0eHrVyJJKuM6fAOinHCisRgLUL7eRF2JBM5ta1PGb6kp3LW2FjOCQUz1+/HRaBSzW1oKPoeli3dP35tIJKNIJAeRTEYQiW5AImlGsVonfhiTmss0kT4Hq9COv/peQcyXhN/wYSaaVapOfGQhBHCwYVaGjZvn74ZPLr4ijNStD+hYD1+P2V7BaJ4G43++D0wsbZsFuz6bOrtfxsaOfyu5L4RDLQiFJiLor1eCuPbB59H0Rjf8vX2msbunx7y9+y584lmSZ06eDEMuwCVsVlnw9ibi8D10A3yvW34yWU8Z0DtpJlDfDIRqgGAIxqwdgIVlbrLplOvOxo3wnXkmfLo7u+wjCV7IWJuJEwG5nsrgXkmxhkIwRFTZTGdnJ+bPn6+WzdJcs1QYLueNN96Qd6jx9NNPZ9z/jW98w9hmm21Gfd63vvUt9TzeuA94DvAc4DnAc4DngPvPgWXLlpVUb9jXmKZChKzQrRi/0xkYGEDY6i2TjUsuuQQXXHBBhhpvb2/HlClTbDcHS9XenDlzVBWf3dErp8Ft9SY8rt6kmo5rtW1vNW1rl5UhmjzZmsFVIlwvmOSEkHDj2rVrM+6X32UHjkZNTY26pTNRwoclRE5ar5+4Gm6rN+Fx9SbVdFyrbXuraVv9Jba8uN5QU19fj/333x//+Mc/Uvf19fXh3//+Nw4XBz8hhBBCSLVHmITvfe97ShxJmm2//fZTPZhaW1vxhS98odKrRgghhBAP4PoIk3DwwQfjscceUxVu1157LXbaaSf85z//QWMJeu8Ug6T+vvWtb41IAXoRbqs34XH1JtV0XKtte7mt9uP6tgKEEEIIIaXGExEmQgghhJBSQsFECCGEEJIDCiZCCCGEkGqokqsE7733Hnp6erDjjjuitrZ2zMe+8cYbqrFWOtKufuHCheN63XIhQ42l5fwOO+yg2jiMRiKRwDPPPJP136Qnlu6L9dZbb6kmoelMmjRJmfUrjTR5k+KB3XbbDQ0NDXk954MPPlAjCOR4jlZokM9jKjFWaPny5dhll13y6tMix/edd95RzWJlDEEwmPnx8f7772PDBnNgsEa2dfHixag0GzduVO8tmTGZq9/aihUrRvR1q6urwx577DHisWvWrFHbvM0225S8j1u+yHn29ttvq/erNOIdixdffHFE019BnifPF1atWqVu6UhT4L333huVROy3cv7KiKutt946byO3nAuyPXIOy+dwsY8p97bKZ0h/f7/a1nyuDbmes379evXZPpwDZa5fhVm5cqVqvCnrPdY1R2iTUU7vvjvifmk3NLwv05YtW9Q5I/0bp0+fXviKlbSPuAfZuHGjse+++xoTJ05Uo1cmTZpk3HPPPWM+5+CDDzbmzJljHHDAAanbZZddNu7XLTXt7e1q3SdMmGBsu+22RlNTk3HHHXeM+vienp6MbZTbLrvsolrWX3/99anHHXPMMcbMmTMzHnfhhRcaleQ///mPceyxxxpTp05V6/vKK6/kfI5s75FHHmk0NDQY22+/vVr+9re/Lfgx5ea5554zPvnJTxotLS1qW5966qkxH59MJo3vfOc7Rmtrq7HDDjsY8+bNU+fzP//5z4zHfe5zn1P7L/24fuYznzEqiRzHk08+Wa27bOsDDzyQ8znnn3++ev+lb8cpp5yS8ZhIJKLuq6urU/uktrbW+PGPf2xUkiVLlhinn366MX36dLWtd911V87nnHjiiRnbuf/++6vnfv7zn0895tJLL1Xv/fTHffzjHzcqya9+9St1Hm699dbqfSXH65Zbbsl5Hn/lK18xampqjB133FEtL7roooIfU25+97vfqe2cP3++Oteam5uN6667btzP+cUvfqHO3+Gf2ZXkz3/+szqec+fONXbaaSejsbEx5/tKPk/D4fCI7ejv78943P/7f/8v47jK51UikSho/SiYCuS4444z9txzT6Ovr0/9fuWVVxr19fXG+vXrR32OiA750LH7dUvNGWecYey8885GV1dX6g0mJ+aKFSvyfo0f/ehH6uTcsmVLhmCSi5KTuOGGG5RAffXVV/MWTF/60peUkNTbJm/cQCBgvPXWWwU9ptzIheUvf/mL8d577+UlmEQcXH755UpA64uKCH4RfyL0NfIBNFxYVJo//vGPxp/+9Cdj7dq1BQkmOUfH4tvf/rYSJqtWrVK/i3j0+XzGE088YVSKO++80/j9739vdHZ25i2YhvOvf/1LPfe///1v6j757JLPMCchAn716tWp3+V95ff7jZdffnnU59x4443qy58IS/3FQT7P5CJdyGPKzQ9+8IOMz1w5znKuyZe88TxHPs9FnDiJH//4x8a7776b+v3+++9X6/3QQw+N+hw59rNmzRrzde+++24jFAqlzuu3335bichrr722oPWjYCqATZs2qTdlepRlYGBAvcF++tOfjvo8+bA599xzjeeffz7jTT7e1y0lEhmRD4pf//rXqfvi8biKIHz3u9/N+3UWLlxonHbaaRn3ycVILq4vvPCCsXLlSnUBdtow51yCKRqNqm8/P/vZzzLul29G+htpPo+pJPKBmo9gysaaNWvUc9M/yOSYfuITnzBefPFFNQSz0G9vpUTeY4UIpsMPP9x46aWXlKiU8344cgwvvvjijPvkC8+nP/1po9LIZ0exgkkEr3wDT0cEk0Se5D3xzjvvGLFYzHAiEi1Jj2QPZ++99x4R8ZSoskSAC3mME5DP4R/+8Ifjeo4IJslmvP766+oLnHxeOZGtttpKfWEbSzDNmDFDfXaL0JUveMORiOhRRx2Vcd/ZZ59t7LrrrgWtC03fBfD666+rIb3pXgbJCy9atAivvPLKmM+9+eab8fnPf155KMQz8vLLL9vyuqVCfEbRaDRjnQKBAHbfffe81+m///2v8lLIdg/nj3/8I84++2zlbxGvxGjeJ6cifpje3t4RvpY999wztX/yeYxbeeGFF9RSPAbp/POf/8RZZ52FfffdV/k/HnroIbiRRx99FJ/+9KeVn0P8Dvfcc0/q38R/J/6W4cdVPD1uPq6yXXfffXfW9+uzzz6LM844A4cccghmzpyJP//5z3ASS5YsUQPXxUuWDQkOvPbaa2Mes3we4wTEgyPHarRtLeQ54mE6+eSTcdRRRymv1o033ggnsW7dOnXLta3ixzrhhBNw7LHHqgG8P/3pTzP+XY5ftuMq500sFst7fSiYCkAblYcbKeX34SbmdOQDSIyYr776qjr422+/PT7xiU8oc/d4XreU2LFOt9xyC7bddlvViT0d+eAVo57sDznR99lnHxx33HHKkOcW8tk/TjyudiDH7vzzz8dpp52WIZg++tGPKrO0fAGQ8/zEE09UH2JiPHUThx12mDJzS7GGbMfnPvc5nHLKKVi6dKmnj6t8iRHOPPPMEeZZMeHKxUWO7wUXXKDew04RESKURKTLWKyPfOQjWR8j80XFHD7WMcvnMZVGLu6f+cxn1Jfuj33sY+N6jnx5ly+0cl7L8f3Zz36GL3/5y/jXv/4FJ5BIJPDZz35WffESUTcaco2Rc1MKUqRg4ze/+Q0uvPBC/P3vf089Ro5ftuMqf0PM5flCwVQAUh0kDK8qkTesVI2Mxumnn56quBLHv6hf+UCW8S3jed1SMt51EjF45513qiiSz+fL+LdTTz01VZUllS0yzkYuwvKt3i3ks3+ceFzHS0dHh/o2Onv2bNx0000Z/3b88cejpaVF/SwVdD/84Q/Vsb/33nvhJj7+8Y+nKmikyuaKK65Q56tEX7x6XPUXHDmGwy8sIoTleAtyPC+++GL1+1/+8hdUGomCizCXKt6//vWvo06r98L7VS7u8iVFxI2ci3p9i32ORAu322671O8iOuXLqxOih8lkUoklifjJ58dYVYEHHHBARoW1iCv50nPHHXek7pPtznZchUKOLQVTAcybN08th5ccy++6ZD4fZDCwfPDo17Hrde1kvOskbzr5MJO0Ri6am5vVG2L433Iy+ewfJx7X8SAXpSOOOEIdqwcffDBn2wURTRIed9NxzYZchEUI6u2QlJR8AHvluOr2AhIZzJaOG+0zrNLHVYsliSzILNEZM2aM+lj5YjZt2rQxj1k+j6kUInzki/dzzz2ntlV/ttj9nGzbX24Mw1BftCXSJestEaRCGb4dsu3Zjqu0ApkwYULer0vBVADiKZID8Y9//CN1n/R/kJDm4YcfnrpPQvkS6hRE1cqJm87DDz+sTgoJiRbyuuVEcsYSCk1fJ4mKvfTSSxnr9Oabb6rbcH7961+rb+qyXcM/5OLxeMZ9Tz75pNpPen84FTmmcmwFiUDI+qbvH0kpim9L7598HuNUxH8lKVON9BETsSQiSMTS8A8Z+Uaov7Gl7y/pa+X04yr+DjmvNZKaSUdSirqHkyBiSdLM6cdVzl/xazn9uEqk4fnnn8/6fpX3vEQdhjN8f0gaXVIglTyukmY66aSTlNfy8ccfT0XA0pFzL90bKccmPdopn8v33XdfxjHL5zHlRtZBUqBPP/202tYFCxaMeIykjnXGIt/nDD+ukpoScVXJ42pYYkm8kJJxyNarUHpkybbKZ0627ZDPIfn39O2Q4yevmX4tFl9iwce1IIs4USXZUj32k5/8RJVmL1q0SFXBpVd6SQ+IE044IVW+uMcee6iydakouuaaa4zJkycbJ510UsGvW26kai8YDKoWB3/7299UFdBee+2VUTUk1SPDK0ikUkFOrQcffHDEa0qV4OLFi1VPENkfP//5z1WPnI9+9KMV3VYpO5dqMSnLlnWXygv5Xe7XyDFN71Ny7733qhYBV1xxhfH3v/9d/Zsct/QqjXweU242bNigtk2qqGRbf/nLX6rfdYm8INVeuoJE1lV6hEkZvZT5ymP1TbcVkJ4nUl0l568cd+mTI5Vk++yzT0W3VarjZD3vu+8+ta1XX321+v2DDz5IPearX/2q6lmTXtkp5c1SUSfvS6kkknNWt/wQnnnmGfV+lf5h0o7i6KOPVtvb0dFhVApp+yDb9sgjj6htlWpW+V0qFjVSnTlt2rSM58mxkxLrq666KuvryrbLZ4C0Trj11ltVXx/ZR9K+oFLI56e0tZCWEenno1TdamT75TEa+SyWymOp5vzHP/5hnHrqqcaUKVMyzvt8HlNuzjrrLNWaRXorpW/r8uXLU4+Raur0y3k+zzn00EONb33rW+q9cfvtt6vP99mzZ2d85pWbc889V5X/33TTTRnrLdWqmptvvlltq1RyC3LtkEpO+ayV9g/yGSvXlPRtXbdunbpP+o7Jcf3iF7+o2vZIZV0h+OR/hevA6kZywb///e+VT0fyp9/4xjcy0hNf+cpXlA/gu9/9buqb9g033KCWEnUQT4CYSAt93UrwwAMPKG+DpGMkv/3Nb35TpdA0//u//6uWV199deo+ebwY7uQbeDZPgVRmXH/99SoyJREoiVxI6Hi416mc3HXXXcpLNRwxN8s3WeHyyy9XEaJf/vKXqX9/5JFH8Ktf/UrdL1UY4u+QNFQ6+TymnMg35quuumrE/V/4whfwqU99Sv38gx/8QEVVfvvb3yrDpEQLs3HppZfi6KOPToW4r7vuOhWZks7tEoURw/TwjuDlRPb9t771rRH3y7fvL33pS+pn8RTKN2vteRA/3S9+8QsVdZJzXd6Lsm+Gex3kOfI4ibiIh+Kiiy7CrFmzUCkkmiDvz+GI8f7rX/+6+lmqoOQ9nV7198QTT+Cyyy5TnqThEWFBzlvZTqmMlM7tUgEp5uBKTiKQzwzpYD0csQDotKJ8loqRPd3ELJ8511xzjYq0ScGC7K/hFVj5PKacSIFQtoIY8eqcd955GZ9fOsqUz3PkOiOfZRLxlnNbKqDPOeecvLr+lwrxt0omYzhiVpf3V/rnl2RqpAO/nAdyXst5LJXcu+66q9pG+QxKRwzhP/rRj1QKV1Ks8p6QxxYCBRMhhBBCSA7oYSKEEEIIyQEFEyGEEEJIDiiYCCGEEEJyQMFECCGEEJIDCiZCCCGEkBxQMBFCCCGE5ICCiRBCCCEkBxRMhBDH8ZOf/CTVbLHSSCO9PffcUzWoLBRp0nrkkUeqUR6lHop86KGHqiajhJDSQMFESBUiQy332msvNT9qeFdo6aKcjlzs99tvP9WJvlysWrVKdRovN9ItWXdCTp8TJ12/I5FIwa93wQUXKCGTz2T58SBdjbfffnv8v//3/0r6dwipZiiYCKlCdthhBzWh/qmnnkrdt2nTJjXORkZsSGQkfQTIs88+i+222w5eRwa2yuBrO5DBsDKQV4/qKDUyrkTGEmUbiUEIGT8UTIRUITLTUESTRJo0MtVcZit96EMfyrhffpYZYzvuuKP6/Ytf/KJKUUmESmY8SVQmHo+nUkN77723isikI7/L/fpiLlEbmev0kY98REW0ZN7b8Knjw5Hp5TKD8aCDDlIzw15++eXUvy1dulStk9wnAuWQQw5Rc+xEAKUjwk+iaIcddhguvPBCJRBle4Xf/e53avaYTLiX15KbzKfSyGwxESXy2jJzL11UZkPm8El0SeZKamR0p6x/+mR5QWYp/ulPf0rN57viiivUjDuZCSbrevPNN6t9LDPOPvzhD+OYY45RM7XSkWM3e/bs1Ew8Qoi9UDARUqXIxXy4MBIxIENzh98vj01PM8mwSxncKcJBBgtrv5GkhmQoqww+TUfEiAz4FPGQSCTUAOp///vf6nky3FQGu4p4SiaTWddVhMz//M//qPWTwcA777yzEh7yPEHElogyEVSy/pKaErEkgk7PF5fIkWyHiEUZNiuDZGXYpxZe4jU6/PDD1SBd2T65pQ/nlG0Vkfjtb39bDS7N5U0SASoDq9NZvny5EksibDSyP/72t79h6tSp6ncRYt///vfxxhtvqOHPMvhYhv+K4JQ0pay7bPtxxx2nBommI6lTEZaEkBJgEEKqkrvuusvw+/1GR0eH+n3hwoXGvffeazzzzDPGjBkz1H2Dg4NGbW2tcdNNN436Ok8//bQRCoWMeDyufv/Vr35ltLa2pn6Xpfx+ww03qN/vuOMOY+bMmeq1Nf39/UZTU5Pxr3/9S/1+/vnnG8ccc4z6ORaLGS0tLcadd96Z8XfPOecc4/jjj1c/v/DCC6KKjAceeCD170uXLlX3rVixQv1+9tlnGwcddFDGa5xxxhlGQ0ND6vcLL7zQOPLIIzMe895776nX+dOf/pS6b/369eq+V155ZdT9MnnyZOPmm2/OuO8vf/mLMXHixIz73njjDfVabW1t6vdTTjnFWLRokZFMJlOP2WuvvdQtnR122MH46U9/mnHfJZdcYuy6666jrhMhpHiCpRBhhBDnI9Eaib48+eSTqeiFRC4aGhqUGVwiMlIZJumz9AiTGLIlDScREEnBRaNRFWmRarJ58+bhpJNOwrnnnqsiSBKFefjhh9HZ2YmTTz45FXmRiJBEguTv6wiQvM7bb7+tojzpvPnmm8pfJZElSUnp52zcuFFFidKRNJpm1qxZaimP22qrrVQkSaI16Uh66+9//3te+yv9tSVKFQgE1GuPhpjEJaqWzquvvorFixePuG/mzJloaWlJ3bf77rvD5/Olfpd/l7+Zjtw3/O9LdE+OFyHEfiiYCKlSJAUkqS1JufX396sLeXNzs/q3/fffX90vgmnOnDnYZptt1P29vb1KVO27776qmkwu8nLRFq/NwMBAKi0nKbfbbrtNCSZZHn300Zg8ebL6dxFLCxcuxHXXXTdineRvDUd7myQVpkVQukBIJxgc+kjTgkMLMln3+vr6jMeLOMyX9NfW6NfOhvi+Nm/ePEIc7bbbbiPuS0/9jfa38vn78veGCytCiD1QMBFSxYihWAsmiThptI9JBFN6dEl8QnKfeIp0qfwDDzww4nXFxHzWWWepyJC0IxADtGbbbbdV1WOLFi1CTU1NznUUsSbiRwRZepSnUBYsWDDC8yMRrXT8fv+YIqgQxO8kYigd+f3YY4/NuE8icGLitoNXXnkFBxxwgC2vRQjJhKZvQqoYEUOvv/66qrhKF0zy8yOPPKJaCoio0kiUSNJvr732mvpdqt4uv/zyEa8rZmtJWX32s59Vy3SR8JnPfEaJHzF8a9O0pON+/vOfq3TfcFpbW5WZW6rH0kv+Zd1EuOWL/F2pIJPtFeRviWE9HYnOSGrRDj75yU+qfaiN7NJUUl5bUpkaqYST9ZGKxfHS1dWlTPDydwkh9kPBREgVI5Ekid5s2LBBpdrSoyOSChMfTrpgkqjQ1772NRXFkDYD8+fPV/cNRyJHUr4vQuzEE0/MSJ1J2k2iUuJlkqo5EQuS2luxYkWGjycdKas/8MAD1d+SflDyOKnWK0RoiIfqjDPOUFEqafK4xx57KGGYnuoS/5X4t8TzNLytQKHI9otYfPDBB1PRH/E0iSdr6623VpVyIgBFhJ5zzjlFdRJPR9oS7LLLLiMq8wgh9uAT57dNr0UIcSE64iIX23Tkwi6CSQzIw5FUm1zgRVjU1dWpiJP4odKFkfhpPvjgA/UYXTI/HOltJOlASbuld8OWlgDyt7V3SiNiRp4jXibtiRLkNaRRpPiDRKQIEtkRo7eIqnSvkohDeR1J0UlU69e//rV6rkaiXiLe5DHy92X7JCok+yfdxC3pSUkvNjU1jbpvb7/9dvziF79QvZ3EsC4RMVknSQ1K5Ey2QaJ0EmGbMWNGqvWAbIMY6DXSakD2z9y5c1P3idiS7ZJ9Ic8XX9itt96a6itFCLEXCiZCSNUgKThpbCleJRFFkpKU/k5XXnllyf6mCCsRWzo9KaLGbiQaKKJquOglhNgHU3KEkKpBRIWk8yQaIzeJxkgjyFIiqT+JDmVrKWAXEmmiWCKktDDCRAipKiR9J2k9SW8V0lZgvIhgkjSbtF0ghLgPCiZCCCGEkBwwJUcIIYQQkgMKJkIIIYSQHFAwEUIIIYTkgIKJEEIIISQHFEyEEEIIITmgYCKEEEIIyQEFEyGEEEJIDiiYCCGEEEJyQMFECCGEEIKx+f9lN9tqtJbbtAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Set up the Roman WFI object and retrieve the throughput\n",
+    "filters = ['f062', 'f087', 'f106', 'f129', 'f158', 'f184', 'f213']\n",
+    "roman_filter = 'F062 F087 F106 F129 F158 F184 F213'.lower().split()\n",
+    "print(roman_filter)\n",
+    "\n",
+    "# Create a fine wavelength grid (common practice)\n",
+    "waves = np.arange(0.5, 2.5, 0.001) * u.micron\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "colors = plt.cm.rainbow(np.linspace(0, 1, len(roman_filter)))\n",
+    "for i,f in enumerate(filters):\n",
+    "    band = stsyn.band(f'roman,wfi,{f}')\n",
+    "    clean = np.where(band(waves) > 0)\n",
+    "    thru = band(waves) * 100  # percent\n",
+    "    ax.plot(waves[clean], thru[clean], color=colors[i])\n",
+    "\n",
+    "# Set plot axis labels, ranges, and add grid lines\n",
+    "ax.set_xlabel(r'Wavelength ($\\mu$m)')\n",
+    "ax.set_ylabel('Throughput')\n",
+    "ax.set_ylim(0, 100.05)\n",
+    "ax.set_xlim(0.4, 2.5)\n",
+    "ax.grid(':', alpha=0.3)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c9a36d6",
+   "metadata": {},
+   "source": [
+    "## About this Notebook\n",
+    "**Author:** R. Diaz\n",
+    "\n",
+    "**Updated On:** 2026-07-06"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45fb919f",
+   "metadata": {},
+   "source": [
+    "<table width=\"100%\" style=\"border:none; border-collapse:collapse;\">\n",
+    "\n",
+    "  <tr style=\"border:none;\">\n",
+    "    <td style=\"border:none; width:180px; white-space:nowrap;\">\n",
+    "       <a href=\"#top\" style=\"text-decoration:none; color:#0066cc;\"> Top of page</a>\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:center;\">\n",
+    "        <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/roman_logo.png\" alt=\"roman_logo\" width=\"50px\">\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:right;\">\n",
+    "       <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/stsci_logo2.png\" width=\"90\">\n",
+    "    </td>\n",
+    "  </tr>\n",
+    "</table>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Roman Research Nexus 2026.2",
+   "language": "python",
+   "name": "roman_cal"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/crds_reference_files/psf_reffile.ipynb
+++ b/notebooks/crds_reference_files/psf_reffile.ipynb
@@ -5,7 +5,7 @@
    "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
    "metadata": {},
    "source": [
-    "# Understanding the Roman WFI Dark Current Reference File "
+    "# Understanding the Roman WFI ePSF Reference File"
    ]
   },
   {
@@ -27,9 +27,11 @@
    "metadata": {},
    "source": [
     "## Introduction\n",
-    "The purpose of this notebook is to understand the content and purpose of the **Dark Current** (`DARK`) reference file.\n",
+    "The purpose of this notebook is to understand the content and purpose of the **Empirical PSF** (`PSF` / `ePSF`) reference file.\n",
     "\n",
-    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)"
+    "The ePSF reference file contains high-fidelity empirical point spread function stamps. It is used by the `source_catalog` step for accurate photometry and morphology measurements.\n",
+    "\n",
+    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)."
    ]
   },
   {
@@ -112,13 +114,11 @@
    "id": "11b5ca61-dfe0-4031-8f4d-172f4a135b52",
    "metadata": {},
    "source": [
-    "### Darks \n",
+    "### Empirical PSF Reference File\n",
     "\n",
-    "The DARK reference file is selected based on the WFI mode (imaging or spectroscopy) used to obtain the science data. During the `romancal.dark_current.DarkCurrentStep()` step, the dark current is subtracted on a pixel-by-pixel and resultant-by-resultant basis. Pixels that are undefined in the dark reference file will not be subtracted from the science data.\n",
+    "The ePSF reference file contains empirical PSF stamps (including versions with and without inter-pixel capacitance). It is used for source detection and photometry.\n",
     "\n",
-    "The dark reference files are created from dark calibration datasets.  A set of dark files are sigma clipped, and stacked resultant-by-resultant to create a super dark.\n",
-    "\n",
-    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/dark_current/index.html) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook-home/roman-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-dark_current) for dark current subtraction.\n"
+    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/psf_reffile.html#psf-reference-file).\n"
    ]
   },
   {
@@ -167,11 +167,10 @@
     "\n",
     "As you run the exposure pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, retrieve those from `crds` Python API and feed these to the Exposure Level or Mosaic Pipeline, see the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb) for more details. \n",
     "\n",
-    "For the dark files in particular, the keywords that will identify the best reference file to use are:\n",
+    "In CRDS the PSF reference files are refered as the Empirial PSF or ePSF. The keywords that will identify the best reference file to use are:\n",
     "\n",
     "- ROMAN.META.INSTRUMENT.NAME\n",
-    "- ROMAN.META.INSTRUMENT.DETECTOR\n",
-    "- ROMAN.META.EXPOSURE.TYPE\n",
+    "- ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT\n",
     "- ROMAN.META.EXPOSURE.START_TIME\n",
     "\n",
     "These keywords may be combined into a single dictionary to find and download the file using `crds.getreferences()`.  "
@@ -185,12 +184,11 @@
    "outputs": [],
    "source": [
     "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
-    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
-    "        'ROMAN.META.EXPOSURE.TYPE': 'WFI_IMAGE',\n",
+    "        'ROMAN.META.INSTRUMENT.OPTICAL_ELEMENT': 'F158',\n",
     "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
     "       }\n",
     "\n",
-    "ref_files = crds.getreferences(meta, reftypes=['dark'], observatory='roman')\n",
+    "ref_files = crds.getreferences(meta, reftypes=['epsf'], observatory='roman')\n",
     "ref_files"
    ]
   },
@@ -211,8 +209,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dark = rdm.open(ref_files['dark'])\n",
-    "dark.info()"
+    "epsf = rdm.open(ref_files['epsf'])\n",
+    "epsf.info()"
    ]
   },
   {
@@ -220,31 +218,7 @@
    "id": "021a3635-5642-48b8-9c96-f4a6f9d758ee",
    "metadata": {},
    "source": [
-    "We see that the dark reference file contains metadata plus several arrays:\n",
-    "- The `data` array contains a cube of dark values up-the-ramp. This is used in the current version of the Exposure Pipeline, however changes are being made towards a dark rate subtraction post-ramp-fitting. \n",
-    "- The `dark_slope` array contains the dark rate per pixel\n",
-    "- The `dark_slope_error` contains the uncertainty in the dark rate. \n",
-    "- The `dq` array is present to flag effects in the dark current (such as hot pixels)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "868eed54-c552-4324-bae3-4622ef81c4a9",
-   "metadata": {},
-   "source": [
-    "Let's take a look at the dark for this detector. First, lets check the shape of the data array:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "30f444a2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"dark.data shape:\", dark.data.shape)\n",
-    "print(\"dark.dq shape:\", dark.dq.shape)\n",
-    "print(\"dark.dark_slope shape:\", getattr(dark, 'dark_slope', None).shape if hasattr(dark, 'dark_slope') else \"No dark_slope\")"
+    "We see that the gain reference file contains metadata plus the `data`,  a 2D array with the gain value (electrons per DN) for each pixel."
    ]
   },
   {
@@ -252,7 +226,50 @@
    "id": "b4f0262f",
    "metadata": {},
    "source": [
+    "### Basic Statistics\n",
+    "\n",
     "Now lets get some basic statistics on the cube (or a representative slice)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73bd5d09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for name in ['psf', 'extended_psf', 'psf_noipc', 'extended_psf_noipc']:\n",
+    "    if hasattr(epsf, name):\n",
+    "        data = getattr(epsf, name)\n",
+    "        print(f\"\\n{name} shape: {data.shape}\")\n",
+    "        print(f\"  Min: {data.min():.2e}   Max: {data.max():.2e}\")\n",
+    "        print(f\"  Mean: {data.mean():.2e}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d433e836",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"PSF array shape:\", epsf.psf.shape)\n",
+    "print(\"Suggested slices to try:\")\n",
+    "\n",
+    "for d0 in range(epsf.psf.shape[0]):\n",
+    "    for d1 in range(epsf.psf.shape[1]):\n",
+    "        for d2 in [0, 4, 8]:   # edges and middle\n",
+    "            print(f\"  epsf.psf[{d0}, {d1}, {d2}]\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a805ab5e",
+   "metadata": {},
+   "source": [
+    "### Visualization\n",
+    "\n",
+    "Let's check this reference file"
    ]
   },
   {
@@ -262,107 +279,122 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Quick stats on saturation thresholds\n",
-    "data = dark.data\n",
-    "print(\"\\nDark threshold stats:\")\n",
-    "print(\"  Min:\", data.min(), \"Max:\", data.max())\n",
-    "print(\"  Mean:\", data.mean(), \"Median:\", np.median(data))\n",
-    "print(\"  Std:\", data.std())\n",
+    "fig = plt.figure(figsize=(14, 10))\n",
     "\n",
-    "# DQ stats (reuse/adapt from your MASK statistics code)\n",
-    "dq = dark.dq\n",
-    "total = dq.size\n",
-    "flagged = np.sum(dq > 0)\n",
-    "print(f\"\\nDQ: {flagged:,} / {total:,} pixels flagged ({flagged/total*100:.3f}%)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "44fec9cb",
-   "metadata": {},
-   "source": [
-    "Note that in this case the pre-launch darks are all zero, so the plot will be rather flat."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "437d9346",
-   "metadata": {},
-   "source": [
-    "Let's get a quick histogram of a slice:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2c76715a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Select a slice of the data for histogram plotting\n",
-    "data_slice = dark.data[3:10]\n",
+    "# Extended PSF (large stamp)\n",
+    "if hasattr(epsf, 'extended_psf'):\n",
+    "    ax1 = plt.subplot(2, 2, 1)\n",
+    "    data = epsf.extended_psf\n",
+    "    norm = simple_norm(data, stretch='log', percent=99.5)\n",
+    "    im1 = ax1.imshow(data, cmap='viridis', norm=norm, origin='lower')\n",
+    "    ax1.set_title('Extended PSF')\n",
+    "    plt.colorbar(im1, ax=ax1, fraction=0.046, pad=0.04)\n",
     "\n",
-    "plt.figure(figsize=(8,5))\n",
-    "plt.hist(data_slice.flatten(), bins=100, range=(data_slice.min(), np.percentile(data_slice, 99.5)), log=True)\n",
-    "plt.xlabel('Dark Current Value')\n",
-    "plt.ylabel('Pixel Count (log)')\n",
-    "plt.title('Pixel Value Distribution (slice)')\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9b893996",
-   "metadata": {},
-   "source": [
-    "Note: In flight data the dark current will be non-zero and these visualizations\n",
-    "will show clear structure (hot pixels, gradients, etc.).\n",
+    "# Extended PSF no IPC\n",
+    "if hasattr(epsf, 'extended_psf_noipc'):\n",
+    "    ax2 = plt.subplot(2, 2, 2)\n",
+    "    data = epsf.extended_psf_noipc\n",
+    "    norm = simple_norm(data, stretch='log', percent=99.5)\n",
+    "    im2 = ax2.imshow(data, cmap='viridis', norm=norm, origin='lower')\n",
+    "    ax2.set_title('Extended PSF (no IPC)')\n",
+    "    plt.colorbar(im2, ax=ax2, fraction=0.046, pad=0.04)\n",
     "\n",
-    "Now let's check the dark image"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f732d453-7394-4fec-b0e9-e9111a243e63",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, axs = plt.subplots(1, 3, figsize=(18, 6))  # Add a third panel for dark_slope if available\n",
+    "# Central slice of the small PSF stamp (e.g., central oversampled PSF)\n",
+    "if hasattr(epsf, 'psf'):\n",
+    "    ax3 = plt.subplot(2, 2, 3)\n",
+    "    data = epsf.psf[1, 1, 4]          # middle slice (adjust indices as needed)\\\n",
+    "    data = epsf.psf[2,2,0]\n",
+    "    norm = simple_norm(data, stretch='log', percent=99.5)\n",
+    "    im3 = ax3.imshow(data, cmap='viridis', norm=norm, origin='lower')\n",
+    "    ax3.set_title('PSF Stamp (central slice)')\n",
+    "    plt.colorbar(im3, ax=ax3, fraction=0.046, pad=0.04)\n",
     "\n",
-    "slice_idx = 10  # You can change this index to visualize a different slice of the dark current data\n",
-    "data_slice = dark.data[slice_idx]\n",
-    "\n",
-    "my_cmap = copy.copy(cm.get_cmap('nipy_spectral'))\n",
-    "my_cmap.set_bad('black')\n",
-    "\n",
-    "norm = simple_norm(data_slice, stretch='sqrt', percent=99.5, min_percent=0.5)\n",
-    "\n",
-    "im0 = axs[0].imshow(data_slice, cmap=my_cmap, norm=norm, origin='lower')\n",
-    "divider = make_axes_locatable(axs[0])\n",
-    "cax = divider.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
-    "fig.colorbar(im0, cax=cax, label='DN/s or electrons')\n",
-    "axs[0].set_title(f'Dark Current (slice {slice_idx})')\n",
-    "\n",
-    "# DQ panel\n",
-    "axs[1].imshow(np.bool_(dark.dq), cmap='binary_r', origin='lower')\n",
-    "axs[1].set_title('Dark Current DQ Flags')\n",
-    "\n",
-    "# dark_slope (rate image) \n",
-    "if hasattr(dark, 'dark_slope') and dark.dark_slope is not None:\n",
-    "    slope_norm = simple_norm(dark.dark_slope, stretch='sqrt', percent=99)\n",
-    "    im2 = axs[2].imshow(dark.dark_slope, cmap=my_cmap, norm=slope_norm, origin='lower')\n",
-    "    divider2 = make_axes_locatable(axs[2])\n",
-    "    cax2 = divider2.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
-    "    fig.colorbar(im2, cax=cax2, label='DN/s or electrons')\n",
-    "    axs[2].set_title('Dark Slope (Rate)')\n",
-    "\n",
-    "for ax in axs:\n",
-    "    ax.set_xlabel('Science X (pixels)')\n",
-    "    ax.set_ylabel('Science Y (pixels)')\n",
+    "# Same for no IPC\n",
+    "if hasattr(epsf, 'psf_noipc'):\n",
+    "    ax4 = plt.subplot(2, 2, 4)\n",
+    "    data = epsf.psf_noipc[1, 1, 4]\n",
+    "    norm = simple_norm(data, stretch='log', percent=99.5)\n",
+    "    im4 = ax4.imshow(data, cmap='viridis', norm=norm, origin='lower')\n",
+    "    ax4.set_title('PSF Stamp no IPC (central slice)')\n",
+    "    plt.colorbar(im4, ax=ax4, fraction=0.046, pad=0.04)\n",
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89bd5c3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(14, 10))\n",
+    "\n",
+    "# Extended PSF (large stamp)\n",
+    "if hasattr(epsf, 'extended_psf'):\n",
+    "    ax1 = plt.subplot(3, 2, 1)\n",
+    "    data = epsf.extended_psf\n",
+    "    norm = simple_norm(data, stretch='log', percent=99.5)\n",
+    "    im1 = ax1.imshow(data, cmap='viridis', norm=norm, origin='lower')\n",
+    "    ax1.set_title('Extended PSF')\n",
+    "    plt.colorbar(im1, ax=ax1, fraction=0.046, pad=0.04)\n",
+    "\n",
+    "# Extended PSF no IPC\n",
+    "if hasattr(epsf, 'extended_psf_noipc'):\n",
+    "    ax2 = plt.subplot(3,2,2)\n",
+    "    data = epsf.extended_psf_noipc\n",
+    "    norm = simple_norm(data, stretch='log', percent=99.5)\n",
+    "    im2 = ax2.imshow(data, cmap='viridis', norm=norm, origin='lower')\n",
+    "    ax2.set_title('Extended PSF (no IPC)')\n",
+    "    plt.colorbar(im2, ax=ax2, fraction=0.046, pad=0.04)\n",
+    "\n",
+    "# Central slice of the small PSF stamp\n",
+    "if hasattr(epsf, 'psf'):\n",
+    "    ax3 = plt.subplot(3,2, 3)\n",
+    "    data = epsf.psf[1, 1, 4]          # middle slice (adjust indices as needed)\n",
+    "    norm = simple_norm(data, stretch='log', percent=99.5)\n",
+    "    im3 = ax3.imshow(data, cmap='viridis', norm=norm, origin='lower')\n",
+    "    ax3.set_title('PSF Stamp (central slice)')\n",
+    "    plt.colorbar(im3, ax=ax3, fraction=0.046, pad=0.04)\n",
+    "\n",
+    "# Central slice of the small PSF stamp\n",
+    "if hasattr(epsf, 'psf'):\n",
+    "    ax5 = plt.subplot(3,2,5)\n",
+    "    data = epsf.psf[0,0, 0]          # middle slice (adjust indices as needed)\n",
+    "    norm = simple_norm(data, stretch='log', percent=99.5)\n",
+    "    im5 = ax5.imshow(data, cmap='viridis', norm=norm, origin='lower')\n",
+    "    ax5.set_title('PSF Stamp (No defocus [0,0,0])')\n",
+    "    plt.colorbar(im5, ax=ax5, fraction=0.046, pad=0.04)\n",
+    "\n",
+    "# Central slice of the small PSF stamp\n",
+    "if hasattr(epsf, 'psf'):\n",
+    "    ax6 = plt.subplot(3,2,6)\n",
+    "    data = epsf.psf[2, 2, 8]          # middle slice (adjust indices as needed)\n",
+    "    norm = simple_norm(data, stretch='log', percent=99.5)\n",
+    "    im6 = ax6.imshow(data, cmap='viridis', norm=norm, origin='lower')\n",
+    "    ax6.set_title('PSF Stamp (Defocused [2,2,8])')\n",
+    "    plt.colorbar(im6, ax=ax6, fraction=0.046, pad=0.04)\n",
+    "\n",
+    "# Same for no IPC\n",
+    "if hasattr(epsf, 'psf_noipc'):\n",
+    "    ax4 = plt.subplot(3, 2, 4)\n",
+    "    data = epsf.psf_noipc[1, 1, 4]\n",
+    "    norm = simple_norm(data, stretch='log', percent=99.5)\n",
+    "    im4 = ax4.imshow(data, cmap='viridis', norm=norm, origin='lower')\n",
+    "    ax4.set_title('PSF Stamp no IPC (central slice)')\n",
+    "    plt.colorbar(im4, ax=ax4, fraction=0.046, pad=0.04)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd8a15e3",
+   "metadata": {},
+   "source": [
+    "**Note:** The small PSF stamps have shape `(3, 3, 9, 361, 361)`. The first three dimensions are parameters (defocus, other conditions, oversampling). You can explore other slices by changing the indices `[1, 1, 4]`.\n"
    ]
   },
   {
@@ -371,7 +403,7 @@
    "metadata": {},
    "source": [
     "## About this Notebook\n",
-    "**Author:** T. Desjardins & R. Diaz\n",
+    "**Author:** R. Diaz\n",
     "\n",
     "**Updated On:** 2026-07-06"
    ]

--- a/notebooks/crds_reference_files/readnoise_reffile.ipynb
+++ b/notebooks/crds_reference_files/readnoise_reffile.ipynb
@@ -5,7 +5,7 @@
    "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
    "metadata": {},
    "source": [
-    "# Understanding the Roman WFI Dark Current Reference File "
+    "#  Understanding the Roman WFI Read Noise Reference File"
    ]
   },
   {
@@ -26,10 +26,11 @@
    "id": "0e739398-0b70-40fa-8a46-5319d7066c73",
    "metadata": {},
    "source": [
-    "## Introduction\n",
-    "The purpose of this notebook is to understand the content and purpose of the **Dark Current** (`DARK`) reference file.\n",
+    "The purpose of this notebook is to understand the content and purpose of the **Read Noise** (`READNOISE`) reference file.\n",
     "\n",
-    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)"
+    "The READNOISE reference file provides the read noise (in electrons) for each pixel. It is used during ramp fitting for accurate noise variance calculation.\n",
+    "\n",
+    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/readnoise_reffile.html#readnoise-reffile)."
    ]
   },
   {
@@ -112,14 +113,32 @@
    "id": "11b5ca61-dfe0-4031-8f4d-172f4a135b52",
    "metadata": {},
    "source": [
-    "### Darks \n",
+    "### Read Noise Reference File\n",
     "\n",
-    "The DARK reference file is selected based on the WFI mode (imaging or spectroscopy) used to obtain the science data. During the `romancal.dark_current.DarkCurrentStep()` step, the dark current is subtracted on a pixel-by-pixel and resultant-by-resultant basis. Pixels that are undefined in the dark reference file will not be subtracted from the science data.\n",
+    "The READNOISE reference file contains a pixel-by-pixel map of readnoise, which is used in estimating the expected noise in each pixel.\n",
     "\n",
-    "The dark reference files are created from dark calibration datasets.  A set of dark files are sigma clipped, and stacked resultant-by-resultant to create a super dark.\n",
-    "\n",
-    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/dark_current/index.html) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook-home/roman-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-dark_current) for dark current subtraction.\n"
+    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/readnoise_reffile.html#readnoise-reffile) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook/roman-wfi-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-ramp_fitting) for the Ramp Fitting and Jump Detection."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef82cf55",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41c56ddc",
+   "metadata": {},
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bd92faf",
+   "metadata": {},
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -167,7 +186,7 @@
     "\n",
     "As you run the exposure pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, retrieve those from `crds` Python API and feed these to the Exposure Level or Mosaic Pipeline, see the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb) for more details. \n",
     "\n",
-    "For the dark files in particular, the keywords that will identify the best reference file to use are:\n",
+    "For the readnoise files in particular, the keywords that will identify the best reference file to use are:\n",
     "\n",
     "- ROMAN.META.INSTRUMENT.NAME\n",
     "- ROMAN.META.INSTRUMENT.DETECTOR\n",
@@ -190,7 +209,7 @@
     "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
     "       }\n",
     "\n",
-    "ref_files = crds.getreferences(meta, reftypes=['dark'], observatory='roman')\n",
+    "ref_files = crds.getreferences(meta, reftypes=['readnoise'], observatory='roman')\n",
     "ref_files"
    ]
   },
@@ -211,8 +230,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dark = rdm.open(ref_files['dark'])\n",
-    "dark.info()"
+    "readnoise = rdm.open(ref_files['readnoise'])\n",
+    "readnoise.info()"
    ]
   },
   {
@@ -220,31 +239,7 @@
    "id": "021a3635-5642-48b8-9c96-f4a6f9d758ee",
    "metadata": {},
    "source": [
-    "We see that the dark reference file contains metadata plus several arrays:\n",
-    "- The `data` array contains a cube of dark values up-the-ramp. This is used in the current version of the Exposure Pipeline, however changes are being made towards a dark rate subtraction post-ramp-fitting. \n",
-    "- The `dark_slope` array contains the dark rate per pixel\n",
-    "- The `dark_slope_error` contains the uncertainty in the dark rate. \n",
-    "- The `dq` array is present to flag effects in the dark current (such as hot pixels)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "868eed54-c552-4324-bae3-4622ef81c4a9",
-   "metadata": {},
-   "source": [
-    "Let's take a look at the dark for this detector. First, lets check the shape of the data array:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "30f444a2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"dark.data shape:\", dark.data.shape)\n",
-    "print(\"dark.dq shape:\", dark.dq.shape)\n",
-    "print(\"dark.dark_slope shape:\", getattr(dark, 'dark_slope', None).shape if hasattr(dark, 'dark_slope') else \"No dark_slope\")"
+    "The READNOISE reference file is typically a 2D array with read noise values (in electrons) for each pixel."
    ]
   },
   {
@@ -252,7 +247,35 @@
    "id": "b4f0262f",
    "metadata": {},
    "source": [
+    "### Basic Statistics\n",
+    "\n",
     "Now lets get some basic statistics on the cube (or a representative slice)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73bd5d09",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Readnoise array shape:\", readnoise.data.shape)\n",
+    "print(\"\\nReadnoise statistics (electrons):\")\n",
+    "print(f\"  Min: {readnoise.data.min():.4f}\")\n",
+    "print(f\"  Max: {readnoise.data.max():.4f}\")\n",
+    "print(f\"  Mean: {readnoise.data.mean():.4f}\")\n",
+    "print(f\"  Median: {np.median(readnoise.data):.4f}\")\n",
+    "print(f\"  Std: {readnoise.data.std():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a805ab5e",
+   "metadata": {},
+   "source": [
+    "### Visualization\n",
+    "\n",
+    "Let's check this reference file"
    ]
   },
   {
@@ -262,104 +285,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Quick stats on saturation thresholds\n",
-    "data = dark.data\n",
-    "print(\"\\nDark threshold stats:\")\n",
-    "print(\"  Min:\", data.min(), \"Max:\", data.max())\n",
-    "print(\"  Mean:\", data.mean(), \"Median:\", np.median(data))\n",
-    "print(\"  Std:\", data.std())\n",
+    "fig, ax = plt.subplots(figsize=(10, 8))\n",
     "\n",
-    "# DQ stats (reuse/adapt from your MASK statistics code)\n",
-    "dq = dark.dq\n",
-    "total = dq.size\n",
-    "flagged = np.sum(dq > 0)\n",
-    "print(f\"\\nDQ: {flagged:,} / {total:,} pixels flagged ({flagged/total*100:.3f}%)\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "44fec9cb",
-   "metadata": {},
-   "source": [
-    "Note that in this case the pre-launch darks are all zero, so the plot will be rather flat."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "437d9346",
-   "metadata": {},
-   "source": [
-    "Let's get a quick histogram of a slice:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2c76715a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Select a slice of the data for histogram plotting\n",
-    "data_slice = dark.data[3:10]\n",
-    "\n",
-    "plt.figure(figsize=(8,5))\n",
-    "plt.hist(data_slice.flatten(), bins=100, range=(data_slice.min(), np.percentile(data_slice, 99.5)), log=True)\n",
-    "plt.xlabel('Dark Current Value')\n",
-    "plt.ylabel('Pixel Count (log)')\n",
-    "plt.title('Pixel Value Distribution (slice)')\n",
-    "plt.show()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "9b893996",
-   "metadata": {},
-   "source": [
-    "Note: In flight data the dark current will be non-zero and these visualizations\n",
-    "will show clear structure (hot pixels, gradients, etc.).\n",
-    "\n",
-    "Now let's check the dark image"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f732d453-7394-4fec-b0e9-e9111a243e63",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fig, axs = plt.subplots(1, 3, figsize=(18, 6))  # Add a third panel for dark_slope if available\n",
-    "\n",
-    "slice_idx = 10  # You can change this index to visualize a different slice of the dark current data\n",
-    "data_slice = dark.data[slice_idx]\n",
-    "\n",
-    "my_cmap = copy.copy(cm.get_cmap('nipy_spectral'))\n",
+    "my_cmap = copy.copy(cm.get_cmap('viridis'))\n",
     "my_cmap.set_bad('black')\n",
     "\n",
-    "norm = simple_norm(data_slice, stretch='sqrt', percent=99.5, min_percent=0.5)\n",
+    "norm = simple_norm(readnoise.data, stretch='sqrt', percent=99.5)\n",
+    "im = ax.imshow(readnoise.data, cmap=my_cmap, norm=norm, origin='lower')\n",
+    "ax.set_title('Read Noise Map (electrons)')\n",
+    "ax.set_xlabel('Science X (pixels)')\n",
+    "ax.set_ylabel('Science Y (pixels)')\n",
     "\n",
-    "im0 = axs[0].imshow(data_slice, cmap=my_cmap, norm=norm, origin='lower')\n",
-    "divider = make_axes_locatable(axs[0])\n",
+    "divider = make_axes_locatable(ax)\n",
     "cax = divider.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
-    "fig.colorbar(im0, cax=cax, label='DN/s or electrons')\n",
-    "axs[0].set_title(f'Dark Current (slice {slice_idx})')\n",
-    "\n",
-    "# DQ panel\n",
-    "axs[1].imshow(np.bool_(dark.dq), cmap='binary_r', origin='lower')\n",
-    "axs[1].set_title('Dark Current DQ Flags')\n",
-    "\n",
-    "# dark_slope (rate image) \n",
-    "if hasattr(dark, 'dark_slope') and dark.dark_slope is not None:\n",
-    "    slope_norm = simple_norm(dark.dark_slope, stretch='sqrt', percent=99)\n",
-    "    im2 = axs[2].imshow(dark.dark_slope, cmap=my_cmap, norm=slope_norm, origin='lower')\n",
-    "    divider2 = make_axes_locatable(axs[2])\n",
-    "    cax2 = divider2.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
-    "    fig.colorbar(im2, cax=cax2, label='DN/s or electrons')\n",
-    "    axs[2].set_title('Dark Slope (Rate)')\n",
-    "\n",
-    "for ax in axs:\n",
-    "    ax.set_xlabel('Science X (pixels)')\n",
-    "    ax.set_ylabel('Science Y (pixels)')\n",
+    "fig.colorbar(im, cax=cax, label='Read Noise (e-)')\n",
     "\n",
     "plt.tight_layout()\n",
     "plt.show()"
@@ -371,7 +310,7 @@
    "metadata": {},
    "source": [
     "## About this Notebook\n",
-    "**Author:** T. Desjardins & R. Diaz\n",
+    "**Author:** R. Diaz\n",
     "\n",
     "**Updated On:** 2026-07-06"
    ]

--- a/notebooks/crds_reference_files/reference_pixel_reffile.ipynb
+++ b/notebooks/crds_reference_files/reference_pixel_reffile.ipynb
@@ -175,7 +175,7 @@
     "- `ROMAN.META.INSTRUMENT.DETECTOR`\n",
     "- `ROMAN.META.EXPOSURE.START_TIME`\n",
     "\n",
-    "These keywords may be combined into a single dictionary that is later fed to the  `crds.getrecommendations` function. This function returns a dictionary of file names that match the criteria that you supply. "
+    "These keywords may be combined into a single dictionary to find and download the file using `crds.getreferences()`"
    ]
   },
   {
@@ -192,60 +192,7 @@
     "    'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
     "}\n",
     "\n",
-    "ref_files = crds.getreferences(meta, reftypes=['refpix'], observatory='roman')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "f44a02e4",
-   "metadata": {},
-   "source": [
-    "And once again we can examine the output of `ref_files`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d58aa3d5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ref_files"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2916910d-6152-4db7-abfd-e69a3d3e8eac",
-   "metadata": {},
-   "source": [
-    "We can also use `crds.getreferences()` to accomplish the same thing; however, `getreferences()` goes one step further beyond `getrecommendations()` and will download the reference files if they are not already in your local cache. Using the same example as above:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b09c9bd3-57a5-4fbf-87ce-ebcf22ac999a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ref_files = crds.getreferences(meta, reftypes=['refpix'], observatory='roman')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a60dab9f-c70d-44cb-b6b8-932918e97e49",
-   "metadata": {},
-   "source": [
-    "And once again we can examine the output of `ref_files`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9ffe7a81-c9cf-4750-a962-41a52dff27fc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "ref_files = crds.getreferences(meta, reftypes=['refpix'], observatory='roman')\n",
     "ref_files"
    ]
   },
@@ -267,7 +214,7 @@
    "outputs": [],
    "source": [
     "refpix = rdm.open(ref_files['refpix'])\n",
-    "refpix.info()"
+    "refpix.info(max_rows=50)"
    ]
   },
   {
@@ -412,20 +359,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.figure(figsize=(10, 6))\n",
-    "if hasattr(refpix, 'alpha') and refpix.alpha is not None:\n",
-    "    plt.plot(refpix.alpha, label='Alpha (Amp 33)', alpha=0.8)\n",
-    "if hasattr(refpix, 'gamma') and refpix.gamma is not None:\n",
-    "    plt.plot(refpix.gamma, label='Gamma (Left)', alpha=0.8)\n",
-    "if hasattr(refpix, 'zeta') and refpix.zeta is not None:\n",
-    "    plt.plot(refpix.zeta, label='Zeta (Right)', alpha=0.8)\n",
-    "\n",
-    "plt.xlabel('Frequency Bin Index')\n",
-    "plt.ylabel('Correction Coefficient')\n",
-    "plt.title('REFPIX Frequency-Dependent Coefficients')\n",
-    "plt.legend()\n",
-    "plt.grid(True, alpha=0.3)\n",
-    "plt.show()"
+    "#plt.figure(figsize=(10, 6))\n",
+    "#if hasattr(refpix, 'alpha') and refpix.alpha is not None:\n",
+    "#    plt.plot(refpix.alpha, label='Alpha (Amp 33)', alpha=0.8)\n",
+    "#if hasattr(refpix, 'gamma') and refpix.gamma is not None:\n",
+    "#    plt.plot(refpix.gamma, label='Gamma (Left)', alpha=0.8)\n",
+    "#if hasattr(refpix, 'zeta') and refpix.zeta is not None:\n",
+    "#    plt.plot(refpix.zeta, label='Zeta (Right)', alpha=0.8)\n",
+    "#\n",
+    "#plt.xlabel('Frequency Bin Index')\n",
+    "#plt.ylabel('Correction Coefficient')\n",
+    "#plt.title('REFPIX Frequency-Dependent Coefficients')\n",
+    "#plt.legend()\n",
+    "#plt.grid(True, alpha=0.3)\n",
+    "#plt.show()"
    ]
   },
   {
@@ -434,7 +381,7 @@
    "metadata": {},
    "source": [
     "## About this Notebook\n",
-    "**Author:** T. Desjardins & R. Diaz\n",
+    "**Author:** R. Diaz\n",
     "\n",
     "**Updated On:** 2026-07-06"
    ]
@@ -463,9 +410,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "roman_cal",
+   "display_name": "Roman Research Nexus 2026.2",
    "language": "python",
-   "name": "python3"
+   "name": "roman_cal"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/crds_reference_files/reference_pixel_reffile.ipynb
+++ b/notebooks/crds_reference_files/reference_pixel_reffile.ipynb
@@ -1,0 +1,485 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
+   "metadata": {},
+   "source": [
+    "# Understanding the Roman WFI Reference Pixel Reference File"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "620243a9-7836-4594-9c0e-c952166fe365",
+   "metadata": {},
+   "source": [
+    "## Kernel Information and Read-Only Status\n",
+    "\n",
+    "To run this notebook, please select \"Roman Research Nexus {VERSION}\" kernel at the top right of your window. For example \"Roman Research Nexus 2026.1\".\n",
+    "\n",
+    "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it.\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e739398-0b70-40fa-8a46-5319d7066c73",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "The purpose of this notebook is to understand the content and purpose of the **Reference Pixel** (`REFPIX`) reference file.\n",
+    "\n",
+    "The REFPIX file contains frequency-dependent coefficients used by the `romancal.refpix.RefPixStep` to correct for correlated 1/f noise (horizontal banding) using the Improved Roman Reference Correction (IRRC) algorithm. It leverages the reference pixels (border reference rows/columns and amplifier 33) present in every WFI exposure.\n",
+    "\n",
+    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1beac9c",
+   "metadata": {},
+   "source": [
+    "### Local Run Settings\n",
+    "\n",
+    "If you want to run the notebook in your local machine, refer to the information in [local installation](../../markdown/local-run.md) instructions before proceeding with the notebook. The instructions provide important information about setting up your environment and installing dependencies."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd1a0491-6dcc-475e-9118-e22a9e2a31c2",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "Libraries used:\n",
+    "- *astropy* for image normalization\n",
+    "- *copy* for making copies of Python objects\n",
+    "- *crds* for access to calibration reference files\n",
+    "- *matplotlib* and *mpl_toolkits* for plotting images\n",
+    "- *numpy* for array manipulation\n",
+    "- *roman_datamodels* for opening Roman WFI ASDF files\n",
+    "- *asdf* for opening Roman WFI ASDF files\n",
+    "- *os* for operating system functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53a4bf0b-4a5d-4aa1-974f-fbc5ca87c9c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from astropy.visualization import simple_norm\n",
+    "import copy\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import colors, colormaps as cm\n",
+    "from mpl_toolkits.axes_grid1 import make_axes_locatable\n",
+    "import numpy as np\n",
+    "import roman_datamodels as rdm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bb19274-2253-455f-b116-f49509ab7c3c",
+   "metadata": {},
+   "source": [
+    "### The Calibration Reference Data System (CRDS)\n",
+    "\n",
+    "The reference files, developed and validated by STScI’s Science Operations Center, are continually updated as new WFI data become available. For more information about how CRDS works and how it assigns the most appropriate reference file for each calibration step, refer to the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb). \n",
+    "\n",
+    "**IMPORTANT NOTE:** Reference files are a work in progress and will be updated several times before Roman launch. If you notice irregularities or missing information, please understand that they may be a known issue. If you have questions, please contact the [Roman Help Desk](https://romanhelp.stsci.edu)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8fcb955",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import crds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4fce2f6d",
+   "metadata": {},
+   "source": [
+    "Now let's dive into this reference file type."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11b5ca61-dfe0-4031-8f4d-172f4a135b52",
+   "metadata": {},
+   "source": [
+    "### Reference Pixels\n",
+    "\n",
+    "The REFPIX reference file is used in the `romancal.refpix.RefPixStep()` to remove correlated 1/f noise from the raw data. The correction uses the reference pixels (4-pixel-wide border rows/columns on all four sides and the virtual 33rd amplifier) together with frequency-dependent coefficients stored in this reference file.\n",
+    "\n",
+    "The current reference files were derived from TVAC1 data and significantly reduce the 1/f noise (typically by a factor of ~20).\n",
+    "\n",
+    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/refpix/index.html) and the technical report on the IRRC algorithm and\n",
+    "[Rdox documentation](https://roman-docs.stsci.edu/data-handbook/roman-wfi-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-refpix) for the reference pixel correction.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eec6339e",
+   "metadata": {},
+   "source": [
+    "Before proceeding, let's check the environmental variables set for CRDS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "89da1bcd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"CRDS server location: {os.environ.get('CRDS_SERVER_URL')}\")\n",
+    "print(f\"CRDS context file: {os.environ.get('CRDS_CONTEXT')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5e2646d0",
+   "metadata": {},
+   "source": [
+    "If we want to change the context, we can do it in the next cell. In this case, we choose context `roman_0055.pmap`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eb9d4df5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['CRDS_CONTEXT']='roman_0055.pmap'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0b9d0830",
+   "metadata": {},
+   "source": [
+    "### Retrieving Reference Files\n",
+    "\n",
+    "As you run the exposure pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, these can be retrieved through the `crds` Python API.\n",
+    "\n",
+    "For the REFPIX files, the required keywords are typically:\n",
+    "- `ROMAN.META.INSTRUMENT.NAME`\n",
+    "- `ROMAN.META.INSTRUMENT.DETECTOR`\n",
+    "- `ROMAN.META.EXPOSURE.START_TIME`\n",
+    "\n",
+    "These keywords may be combined into a single dictionary that is later fed to the  `crds.getrecommendations` function. This function returns a dictionary of file names that match the criteria that you supply. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8f3dc8a-bcb3-4948-8d6d-0ccf99c2ac6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {\n",
+    "    'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "    'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "    'ROMAN.META.EXPOSURE.TYPE': 'WFI_IMAGE',\n",
+    "    'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "}\n",
+    "\n",
+    "ref_files = crds.getreferences(meta, reftypes=['refpix'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f44a02e4",
+   "metadata": {},
+   "source": [
+    "And once again we can examine the output of `ref_files`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d58aa3d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2916910d-6152-4db7-abfd-e69a3d3e8eac",
+   "metadata": {},
+   "source": [
+    "We can also use `crds.getreferences()` to accomplish the same thing; however, `getreferences()` goes one step further beyond `getrecommendations()` and will download the reference files if they are not already in your local cache. Using the same example as above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b09c9bd3-57a5-4fbf-87ce-ebcf22ac999a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files = crds.getreferences(meta, reftypes=['refpix'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a60dab9f-c70d-44cb-b6b8-932918e97e49",
+   "metadata": {},
+   "source": [
+    "And once again we can examine the output of `ref_files`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ffe7a81-c9cf-4750-a962-41a52dff27fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44b65450-a2e1-40c6-ab75-144c28480778",
+   "metadata": {},
+   "source": [
+    "### Examining Reference Files\n",
+    "\n",
+    "Reference files use `roman_datamodels` just like WFI science data products. Let's take a closer look at the REFPIX file:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80ad3211-188d-45ef-b5f1-2ef6bf466450",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "refpix = rdm.open(ref_files['refpix'])\n",
+    "refpix.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "021a3635-5642-48b8-9c96-f4a6f9d758ee",
+   "metadata": {},
+   "source": [
+    "The REFPIX reference file typically contains metadata and arrays of frequency-dependent coefficients (weights) used by the IRRC algorithm for the different reference signals:\n",
+    "* `alpha`: Reference output (amplifier 33) correction coefficients\n",
+    "* `gamma`: Left column correction coefficients\n",
+    "* `zeta`: Right column correction coefficients"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "868eed54-c552-4324-bae3-4622ef81c4a9",
+   "metadata": {},
+   "source": [
+    "Let's check the shape of these arrays:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30f444a2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"refpix shape information:\")\n",
+    "for attr in ['data', 'alpha', 'gamma', 'zeta', 'coefficients']:\n",
+    "    if hasattr(refpix, attr):\n",
+    "        arr = getattr(refpix, attr)\n",
+    "        if arr is not None:\n",
+    "            print(f\"  {attr}: {arr.shape if hasattr(arr, 'shape') else type(arr)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b4f0262f",
+   "metadata": {},
+   "source": [
+    "Now let's get some basic statistics on the coefficient arrays (example using a representative array):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86caf99b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Example: inspect one of the coefficient arrays \n",
+    "print(\"Coefficient statistics:\")\n",
+    "for name in ['alpha', 'gamma', 'zeta']:\n",
+    "    if hasattr(refpix, name) and getattr(refpix, name) is not None:\n",
+    "        arr = getattr(refpix, name)\n",
+    "        print(f\"  {name}: shape={arr.shape}, min={arr.min():.4f}, max={arr.max():.4f}, \"\n",
+    "              f\"mean={arr.mean():.4f}, std={arr.std():.4f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "437d9346",
+   "metadata": {},
+   "source": [
+    "Let's get a quick histogram of the coefficient values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c5019e4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "if hasattr(refpix, 'alpha') and refpix.alpha is not None:\n",
+    "    plt.figure(figsize=(8, 5))\n",
+    "    plt.hist(refpix.alpha.flatten(), bins=100, log=True)\n",
+    "    plt.xlabel('Coefficient Value')\n",
+    "    plt.ylabel('Count (log)')\n",
+    "    plt.title('Distribution of REFPIX Coefficients (alpha example)')\n",
+    "    plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14fed834",
+   "metadata": {},
+   "source": [
+    "Now let's plot a fast visualization example of the REFPIX coefficients"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "104c6292",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(12, 8))\n",
+    "\n",
+    "# Representative subset (first 5000 bins or all if small)\n",
+    "max_points = 5000\n",
+    "\n",
+    "for i, name in enumerate(['alpha', 'gamma', 'zeta']):\n",
+    "    if hasattr(refpix, name) and getattr(refpix, name) is not None:\n",
+    "        arr = getattr(refpix, name).flatten() \n",
+    "        x = np.arange(len(arr))\n",
+    "        \n",
+    "        plt.subplot(3, 1, i+1)\n",
+    "        # Downsample for speed if very long\n",
+    "        if len(arr) > max_points:\n",
+    "            step = len(arr) // max_points\n",
+    "            plt.plot(x[::step], arr[::step], label=name.capitalize(), alpha=0.8)\n",
+    "            plt.title(f'{name.capitalize()} Coefficients (downsampled)')\n",
+    "        else:\n",
+    "            plt.plot(x, arr, label=name.capitalize())\n",
+    "            plt.title(f'{name.capitalize()} Coefficients')\n",
+    "        \n",
+    "        plt.xlabel('Frequency Bin')\n",
+    "        plt.ylabel('Coefficient Value')\n",
+    "        plt.grid(True, alpha=0.3)\n",
+    "        plt.legend()\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1c91a24",
+   "metadata": {},
+   "source": [
+    "We can also plot the full set of coefficient arrays (note generating this plot will take some time)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81301a91",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(10, 6))\n",
+    "if hasattr(refpix, 'alpha') and refpix.alpha is not None:\n",
+    "    plt.plot(refpix.alpha, label='Alpha (Amp 33)', alpha=0.8)\n",
+    "if hasattr(refpix, 'gamma') and refpix.gamma is not None:\n",
+    "    plt.plot(refpix.gamma, label='Gamma (Left)', alpha=0.8)\n",
+    "if hasattr(refpix, 'zeta') and refpix.zeta is not None:\n",
+    "    plt.plot(refpix.zeta, label='Zeta (Right)', alpha=0.8)\n",
+    "\n",
+    "plt.xlabel('Frequency Bin Index')\n",
+    "plt.ylabel('Correction Coefficient')\n",
+    "plt.title('REFPIX Frequency-Dependent Coefficients')\n",
+    "plt.legend()\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c9a36d6",
+   "metadata": {},
+   "source": [
+    "## About this Notebook\n",
+    "**Author:** T. Desjardins & R. Diaz\n",
+    "\n",
+    "**Updated On:** 2026-07-06"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45fb919f",
+   "metadata": {},
+   "source": [
+    "<table width=\"100%\" style=\"border:none; border-collapse:collapse;\">\n",
+    "\n",
+    "  <tr style=\"border:none;\">\n",
+    "    <td style=\"border:none; width:180px; white-space:nowrap;\">\n",
+    "       <a href=\"#top\" style=\"text-decoration:none; color:#0066cc;\"> Top of page</a>\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:center;\">\n",
+    "        <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/roman_logo.png\" alt=\"roman_logo\" width=\"50px\">\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:right;\">\n",
+    "       <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/stsci_logo2.png\" width=\"90\">\n",
+    "    </td>\n",
+    "  </tr>\n",
+    "</table>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "roman_cal",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/crds_reference_files/requirements.txt
+++ b/notebooks/crds_reference_files/requirements.txt
@@ -1,0 +1,7 @@
+roman_datamodels>= 1,0,<1.1 
+astropy>=7.2.0,<9
+asdf-astropy>=0.11.0
+gwcs>=1.0.3,<2
+crds==13.1.15
+matplotlib>=3.10.s90
+numpy>=2.4.4

--- a/notebooks/crds_reference_files/requirements.txt
+++ b/notebooks/crds_reference_files/requirements.txt
@@ -1,7 +1,12 @@
-roman_datamodels>= 1,0,<1.1 
+roman_datamodels>= 1.0,<1.1 
+requests>=2.32.5
+synphot>=1.7.0
+stsynphot>=1.5.1
+stpsf>=2.1.0
 astropy>=7.2.0,<9
 asdf-astropy>=0.11.0
 gwcs>=1.0.3,<2
 crds==13.1.15
-matplotlib>=3.10.s90
+matplotlib>=3.10.9
 numpy>=2.4.4
+pandas>=3.0.3 

--- a/notebooks/crds_reference_files/saturation_reffile.ipynb
+++ b/notebooks/crds_reference_files/saturation_reffile.ipynb
@@ -163,17 +163,15 @@
    "source": [
     "### Retrieving Reference Files\n",
     "\n",
-    "As you run the `RomanCal` pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, these can be retrieved through the `crds` Python API and the ELP run with those files (more on that later). Let's begin with how to access reference files from CRDS.\n",
-    "\n",
-    "First, let's start by looking at the `crds.getrecommendations()` function. This function returns a dictionary of file names that match the criteria that you supply. Selection criteria are specified in a dictionary of key-value pairs. Each Roman WFI metadata keyword in the dictionary is all-caps and always begins with \"ROMAN.META.\". The remaining parts of the string correspond to the metadata keyword locations in the science data file schema. Different reference file types require different combinations of science metadata to match to the reference files. In general, all reference file types will require the instrument name (\"INSTRUMENT.NAME\") and start time (\"EXPOSURE.START_TIME\"). Most file types require the detector name (\"INSTRUMENT.DETECTOR\"), and some file types require the exposure type (\"EXPOSURE.TYPE\") or optical element (\"INSTRUMENT.OPTICAL_ELEMENT\").\n",
+    "AAs you run the exposure pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, retrieve those from `crds` Python API and feed these to the Exposure Level or Mosaic Pipeline, see the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb) for more details. \n",
     "\n",
     "For the saturation files in particular, the required keywords are:\n",
-    "- saturation\n",
-    "    - ROMAN.META.INSTRUMENT.NAME\n",
-    "    - ROMAN.META.INSTRUMENT.DETECTOR\n",
-    "    - ROMAN.META.EXPOSURE.START_TIME\n",
     "\n",
-    "These keywords may be combined into a single dictionary to find multiple reference file types using `crds.getreferences()`. For example, if you would like to find the name of the dark and flat reference files used by the pipeline, you could run the following example:"
+    "- ROMAN.META.INSTRUMENT.NAME\n",
+    "- ROMAN.META.INSTRUMENT.DETECTOR\n",
+    "- ROMAN.META.EXPOSURE.START_TIME\n",
+    "\n",
+    "These keywords may be combined into a single dictionary to find and download the file using `crds.getreferences()`."
    ]
   },
   {
@@ -188,65 +186,7 @@
     "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
     "       }\n",
     "\n",
-    "ref_files = crds.getrecommendations(meta, reftypes=['saturation'], observatory='roman')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "99ec8fd5-c73a-488a-86ad-52d032dd543c",
-   "metadata": {},
-   "source": [
-    "The `ref_files` variable now contains a dictionary for the MASK reference file. This is the reference file that correspond to a science observation taken at midnight UTC on January 1, 2026 in the WFI imaging mode with optical element F158 and detector WFI01. Let's take a look at the names of the files CRDS returned:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "db5933f4-2af7-4106-b2ab-a89b7a8fd7f3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ref_files"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "2916910d-6152-4db7-abfd-e69a3d3e8eac",
-   "metadata": {},
-   "source": [
-    "We can also use `crds.getreferences()` to accomplish the same thing; however, `getreferences()` goes one step further beyond `getrecommendations()` and will download the reference files if they are not already in your local cache. Using the same example as above:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b09c9bd3-57a5-4fbf-87ce-ebcf22ac999a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
-    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
-    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
-    "       }\n",
-    "\n",
-    "ref_files = crds.getreferences(meta, reftypes=['saturation'], observatory='roman')"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "a60dab9f-c70d-44cb-b6b8-932918e97e49",
-   "metadata": {},
-   "source": [
-    "Once again we can examine the output of `ref_files`:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9ffe7a81-c9cf-4750-a962-41a52dff27fc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "ref_files = crds.getreferences(meta, reftypes=['saturation'], observatory='roman')\n",
     "ref_files"
    ]
   },
@@ -397,7 +337,7 @@
    "metadata": {},
    "source": [
     "## About this Notebook\n",
-    "**Author:** T. Desjardins. & R. Diaz\n",
+    "**Author:** R. Diaz\n",
     "\n",
     "**Updated On:** 2026-07-06"
    ]
@@ -426,9 +366,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "roman_cal",
+   "display_name": "Roman Research Nexus 2026.2",
    "language": "python",
-   "name": "python3"
+   "name": "roman_cal"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/crds_reference_files/saturation_reffile.ipynb
+++ b/notebooks/crds_reference_files/saturation_reffile.ipynb
@@ -1,0 +1,448 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "60f5f465-e3a4-43b4-9eb4-6b43b49212ca",
+   "metadata": {},
+   "source": [
+    "# Understanding the Roman WFI Saturation Reference File "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "620243a9-7836-4594-9c0e-c952166fe365",
+   "metadata": {},
+   "source": [
+    "## Kernel Information and Read-Only Status\n",
+    "\n",
+    "To run this notebook, please select \"Roman Research Nexus {VERSION}\" kernel at the top right of your window. For example \"Roman Research Nexus 2026.1\".\n",
+    "\n",
+    "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it.\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e739398-0b70-40fa-8a46-5319d7066c73",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "The purpose of this notebook is to understand the the content and purpose of the **Saturation Threshold** (`SATURATION`) reference file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "739a90d1",
+   "metadata": {},
+   "source": [
+    "The SATURATION reference provides a per-pixel saturation threshold (in DN).\n",
+    "During RomanCal processing, the SATURATION file is used in the `romancal.saturation.saturationStep()` step  to populate an array called `groupdq` in the science exposure. The step compares science data values against these thresholds and sets the SATURATED DQ flag (bit 1, value 2) when exceeded.\n",
+    "\n",
+    "For more details, see the [romancal documentation](https://roman-pipeline.readthedocs.io/en/latest/roman/saturation/index.html) and [Rdox documentation](https://roman-docs.stsci.edu/data-handbook/roman-wfi-data-pipelines/exposure-level-pipeline#ExposureLevelPipeline-saturation) for SATURATION detection.\n",
+    "\n",
+    "\n",
+    "More details about this and other reference files can be found in the [Reference File Information](https://roman-pipeline.readthedocs.io/en/stable/roman/references_general/index.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1beac9c",
+   "metadata": {},
+   "source": [
+    "### Local Run Settings\n",
+    "\n",
+    "If you want to run the notebook in your local machine, refer to the information in [local installation](../../markdown/local-run.md) instructions before proceeding with the notebook. The instructions provide inportant information about setting up your environment and installing dependnecies."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cd1a0491-6dcc-475e-9118-e22a9e2a31c2",
+   "metadata": {},
+   "source": [
+    "## Imports\n",
+    "Libraries used:\n",
+    "- *astropy* for image normalization\n",
+    "- *copy* for making copies of Python objects\n",
+    "- *crds* for access to calibration reference files\n",
+    "- *matplotlib* and *mpl_toolkits* for plotting images\n",
+    "- *numpy* for array manipulation\n",
+    "- *roman_datamodels* for opening Roman WFI ASDF files\n",
+    "- *asdf* for opening Roman WFI ASDF files\n",
+    "- *os* for operating system functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53a4bf0b-4a5d-4aa1-974f-fbc5ca87c9c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "from astropy.visualization import simple_norm\n",
+    "import copy\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib import colors, colormaps as cm\n",
+    "from mpl_toolkits.axes_grid1 import make_axes_locatable\n",
+    "import numpy as np\n",
+    "import roman_datamodels as rdm"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5bb19274-2253-455f-b116-f49509ab7c3c",
+   "metadata": {},
+   "source": [
+    "### The Calibration Reference Data System (CRDS)\n",
+    "\n",
+    " The reference files, developed and validated by STScI’s Science Operations Center, are continually updated as new WFI data become available. For more information about how CRDS works and how it assigns the most appropriate reference file for each calibration step, refer to the notebook [Understanding CRDS and How to Select Calibration Reference files](crds_reference_files.ipynb). \n",
+    "\n",
+    "**IMPORTANT NOTE:** Reference files are a work in progress and will be updated several times before Roman launch. If you notice irregularities or missing information, please understand that they may be a known issue. If you have questions, please contact the [Roman Help Desk](https://romanhelp.stsci.edu)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8fcb955",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import crds"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "aaf56d81",
+   "metadata": {},
+   "source": [
+    "Now let's dive into this reference file."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d5d16bd8",
+   "metadata": {},
+   "source": [
+    "Let's check the environmental variables set for CRDS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e352faad",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"CRDS server location: {os.environ.get('CRDS_SERVER_URL')}\")\n",
+    "print(f\"CRDS context file: {os.environ.get('CRDS_CONTEXT')}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2a72c7ea",
+   "metadata": {},
+   "source": [
+    "If we want to change the context, we can do it in the next cell. In this case, we choose context `roman_0055.pmap`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0a3076f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "os.environ['CRDS_CONTEXT']='roman_0055.pmap'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "80b3db81-1b7a-448f-a462-16eff6ed8f9a",
+   "metadata": {},
+   "source": [
+    "### Retrieving Reference Files\n",
+    "\n",
+    "As you run the `RomanCal` pipeline, the most up-to-date reference files will be automatically selected for each step. However, if you would like to use a specific reference file, these can be retrieved through the `crds` Python API and the ELP run with those files (more on that later). Let's begin with how to access reference files from CRDS.\n",
+    "\n",
+    "First, let's start by looking at the `crds.getrecommendations()` function. This function returns a dictionary of file names that match the criteria that you supply. Selection criteria are specified in a dictionary of key-value pairs. Each Roman WFI metadata keyword in the dictionary is all-caps and always begins with \"ROMAN.META.\". The remaining parts of the string correspond to the metadata keyword locations in the science data file schema. Different reference file types require different combinations of science metadata to match to the reference files. In general, all reference file types will require the instrument name (\"INSTRUMENT.NAME\") and start time (\"EXPOSURE.START_TIME\"). Most file types require the detector name (\"INSTRUMENT.DETECTOR\"), and some file types require the exposure type (\"EXPOSURE.TYPE\") or optical element (\"INSTRUMENT.OPTICAL_ELEMENT\").\n",
+    "\n",
+    "For the saturation files in particular, the required keywords are:\n",
+    "- saturation\n",
+    "    - ROMAN.META.INSTRUMENT.NAME\n",
+    "    - ROMAN.META.INSTRUMENT.DETECTOR\n",
+    "    - ROMAN.META.EXPOSURE.START_TIME\n",
+    "\n",
+    "These keywords may be combined into a single dictionary to find multiple reference file types using `crds.getreferences()`. For example, if you would like to find the name of the dark and flat reference files used by the pipeline, you could run the following example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8f3dc8a-bcb3-4948-8d6d-0ccf99c2ac6a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "       }\n",
+    "\n",
+    "ref_files = crds.getrecommendations(meta, reftypes=['saturation'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99ec8fd5-c73a-488a-86ad-52d032dd543c",
+   "metadata": {},
+   "source": [
+    "The `ref_files` variable now contains a dictionary for the MASK reference file. This is the reference file that correspond to a science observation taken at midnight UTC on January 1, 2026 in the WFI imaging mode with optical element F158 and detector WFI01. Let's take a look at the names of the files CRDS returned:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "db5933f4-2af7-4106-b2ab-a89b7a8fd7f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2916910d-6152-4db7-abfd-e69a3d3e8eac",
+   "metadata": {},
+   "source": [
+    "We can also use `crds.getreferences()` to accomplish the same thing; however, `getreferences()` goes one step further beyond `getrecommendations()` and will download the reference files if they are not already in your local cache. Using the same example as above:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b09c9bd3-57a5-4fbf-87ce-ebcf22ac999a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta = {'ROMAN.META.INSTRUMENT.NAME': 'WFI',\n",
+    "        'ROMAN.META.INSTRUMENT.DETECTOR': 'WFI01',\n",
+    "        'ROMAN.META.EXPOSURE.START_TIME': '2026-01-01 00:00:00'\n",
+    "       }\n",
+    "\n",
+    "ref_files = crds.getreferences(meta, reftypes=['saturation'], observatory='roman')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a60dab9f-c70d-44cb-b6b8-932918e97e49",
+   "metadata": {},
+   "source": [
+    "Once again we can examine the output of `ref_files`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ffe7a81-c9cf-4750-a962-41a52dff27fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ref_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "44b65450-a2e1-40c6-ab75-144c28480778",
+   "metadata": {},
+   "source": [
+    "### Examining Reference Files\n",
+    "\n",
+    "Reference files use `roman_datamodels` just like WFI science data products and can be accessed in the same way (see the tutorial [Working with ASDF](../working_with_asdf/working_with_asdf.ipynb) for more information). Let's take a closer look at the files we retrieved from our `crds.getreferences()` example starting with the mask file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80ad3211-188d-45ef-b5f1-2ef6bf466450",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "saturation = rdm.open(ref_files['saturation'])\n",
+    "saturation.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "63708d3e",
+   "metadata": {},
+   "source": [
+    "We see that the SATURATION file contains metadata and a `data` and `dq` arrays. For this file, the `data` array contains the Saturation Thresholds. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2ce5af2",
+   "metadata": {},
+   "source": [
+    "Let's take a look at the saturation data for this detector. First, lets check the shape of the data array:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fe283637",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"saturation.data shape:\", saturation.data.shape)\n",
+    "print(\"saturation.dq shape:\", saturation.dq.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "64561544",
+   "metadata": {},
+   "source": [
+    "Now lets get some basic statistics on the cube (or a representative slice)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "493f0bb8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"sat.data shape:\", saturation.data.shape)\n",
+    "print(\"sat.dq shape:\", saturation.dq.shape)\n",
+    "\n",
+    "# Quick stats on saturation thresholds\n",
+    "data = saturation.data\n",
+    "print(\"\\nSaturation threshold stats:\")\n",
+    "print(\"  Min:\", data.min(), \"Max:\", data.max())\n",
+    "print(\"  Mean:\", data.mean(), \"Median:\", np.median(data))\n",
+    "print(\"  Std:\", data.std())\n",
+    "\n",
+    "# DQ stats \n",
+    "dq = saturation.dq\n",
+    "total = dq.size\n",
+    "flagged = np.sum(dq > 0)\n",
+    "print(f\"\\nDQ: {flagged:,} / {total:,} pixels flagged ({flagged/total*100:.3f}%)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cc38368c",
+   "metadata": {},
+   "source": [
+    "Now lets get a histobran of the saturation threshold values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf4645df",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.figure(figsize=(8, 5))\n",
+    "plt.hist(saturation.data.flatten(), bins=100, log=True)\n",
+    "plt.xlabel('Saturation Threshold (DN)')\n",
+    "plt.ylabel('Number of Pixels (log scale)')\n",
+    "plt.title('Distribution of Saturation Thresholds')\n",
+    "plt.grid(True, alpha=0.3)\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cf654d4c-522d-473e-b016-6b9a19be539d",
+   "metadata": {},
+   "source": [
+    "Now, let's plot two versions of the file, one with ethe threshold map and another flattened version with DQ map:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f51c3ac5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, axs = plt.subplots(1, 2, figsize=(14, 7))\n",
+    "\n",
+    "# Saturation threshold map\n",
+    "norm = simple_norm(saturation.data, stretch='sqrt', percent=99)\n",
+    "im0 = axs[0].imshow(saturation.data, cmap='viridis', norm=norm, origin='lower')\n",
+    "axs[0].set_title('Saturation Threshold (DN)')\n",
+    "divider = make_axes_locatable(axs[0])\n",
+    "cax = divider.append_axes(\"right\", size=\"5%\", pad=0.05)\n",
+    "fig.colorbar(im0, cax=cax, label='DN')\n",
+    "\n",
+    "# DQ map\n",
+    "axs[1].imshow(np.bool_(saturation.dq), cmap='binary_r', origin='lower')\n",
+    "axs[1].set_title('Saturation Reference DQ Flags')\n",
+    "\n",
+    "for ax in axs:\n",
+    "    ax.set_xlabel('Science X (pixels)')\n",
+    "    ax.set_ylabel('Science Y (pixels)')\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c9a36d6",
+   "metadata": {},
+   "source": [
+    "## About this Notebook\n",
+    "**Author:** T. Desjardins. & R. Diaz\n",
+    "\n",
+    "**Updated On:** 2026-07-06"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "45fb919f",
+   "metadata": {},
+   "source": [
+    "<table width=\"100%\" style=\"border:none; border-collapse:collapse;\">\n",
+    "\n",
+    "  <tr style=\"border:none;\">\n",
+    "    <td style=\"border:none; width:180px; white-space:nowrap;\">\n",
+    "       <a href=\"#top\" style=\"text-decoration:none; color:#0066cc;\"> Top of page</a>\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:center;\">\n",
+    "        <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/roman_logo.png\" alt=\"roman_logo\" width=\"50px\">\n",
+    "    </td>\n",
+    "    <td style=\"border:none; text-align:right;\">\n",
+    "       <img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/stsci_logo2.png\" width=\"90\">\n",
+    "    </td>\n",
+    "  </tr>\n",
+    "</table>"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "roman_cal",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Added 15 new CRDS notebooks to Nexus:

- dark_reffile.ipynb
- linearity_reffile.ipynb
- readnoise_reffile.ipynb	
- area_reffile.ipynb
- distortion_reffile.ipynb	
- reference_pixel_reffile.ipynb
- bad_pixels_mask_reffile.ipynb
- flat_reffile.ipynb
- photom_reffile.ipynb
- requirements.txt
- crds_reference_files.ipyn
- gain_reffile.ipynb
- psf_reffile.ipynb
- saturation_reffile.ipynb

These notebooks allow users to explore available reference files and their content