### PR TITLE
Update to s3 new data location and local data

### DIFF
--- a/notebooks/aperture_photometry/aperture_photometry.ipynb
+++ b/notebooks/aperture_photometry/aperture_photometry.ipynb
@@ -148,6 +148,8 @@
    },
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
     "from astropy.table import Table\n",
     "from astropy.stats import SigmaClip, sigma_clipped_stats\n",
     "import asdf\n",

--- a/notebooks/data_discovery_and_access/data_discovery_and_access.ipynb
+++ b/notebooks/data_discovery_and_access/data_discovery_and_access.ipynb
@@ -247,8 +247,7 @@
    "outputs": [],
    "source": [
     "fs = s3fs.S3FileSystem(anon=True)\n",
-    "\n",
-    "asdf_dir_uri = 's3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.1/'\n",
+    "asdf_dir_uri = 's3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.2/'\n",
     "fs.ls(asdf_dir_uri)"
    ]
   },

--- a/notebooks/data_visualization/data_visualization.ipynb
+++ b/notebooks/data_visualization/data_visualization.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "## Kernel Information and Read-Only Status\n",
     "\n",
-    "To run this notebook, please select \"Roman Research Nexus {VERSION}\" kernel at the top right of your window. For example \"Roman Research Nexus 2026.1\".\n",
+    "To run this notebook, please select \"Roman Research Nexus {VERSION}\" kernel at the top right of your window. For example \"Roman Research Nexus 2026.2\".\n",
     "\n",
     "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it."
    ]
@@ -55,6 +55,7 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
+    "import os\n",
     "from astropy.visualization import simple_norm\n",
     "from astropy.wcs import WCS\n",
     "import matplotlib.pyplot as plt\n",
@@ -80,11 +81,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "asdf_dir_uri = \"s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.1/\"\n",
-    "fs = s3fs.S3FileSystem(anon=True)\n",
+    "# Looks for local data first\n",
+    "if os.path.exists('r0003201001001001004_0001_wfi01_f106_cal.asdf'):\n",
+    "    file = rdm.open('r0003201001001001004_0001_wfi01_f106_cal.asdf')\n",
+    "else:    \n",
+    "    asdf_dir_uri = \"s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.2/\"\n",
+    "    fs = s3fs.S3FileSystem(anon=True)\n",
     "\n",
-    "asdf_file_uri = asdf_dir_uri + 'r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
-    "file = rdm.open(fs.open(asdf_file_uri, 'rb'))"
+    "    asdf_file_uri = asdf_dir_uri + 'r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
+    "\n",
+    "    file = rdm.open(fs.open(asdf_file_uri, 'rb'))"
    ]
   },
   {
@@ -263,9 +269,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Research Nexus 2026.2",
    "language": "python",
-   "name": "python3"
+   "name": "roman_cal"
   },
   "language_info": {
    "codemirror_mode": {
@@ -277,7 +283,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.14"
   }
  },
  "nbformat": 4,

--- a/notebooks/grism_spectral_extraction/grism_spectral_extraction.ipynb
+++ b/notebooks/grism_spectral_extraction/grism_spectral_extraction.ipynb
@@ -151,7 +151,7 @@
    "outputs": [],
    "source": [
     "fs = s3fs.S3FileSystem(anon=True)\n",
-    "asdf_dir_uri = \"s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.1/\"\n",
+    "asdf_dir_uri = \"s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.2/\"\n",
     "\n",
     "# Read in the direct image\n",
     "asdf_file_uri = asdf_dir_uri + 'r0007601002004013001_0001_wfi01_f158_cal.asdf'\n",
@@ -205,7 +205,7 @@
     "    cmap=plt.cm.Greys,\n",
     "    origin=\"lower\",\n",
     ")\n",
-    "ax1.set_title(\"Direct Image\", fontsize=18, fontweight=600)\n",
+    "ax1.set_title(\"Direct Image\", fontsize=18, fontweight=700)\n",
     "\n",
     "### Plot the grism image\n",
     "vmin, vmax = get_vmin_vmax(grism_img)\n",

--- a/notebooks/roman_cutouts/roman_cutouts.ipynb
+++ b/notebooks/roman_cutouts/roman_cutouts.ipynb
@@ -114,7 +114,7 @@
     "            data = deepcopy(dm.data)  # Loads the WFI data into memory\n",
     "            gwcs = deepcopy(dm.meta.wcs)  # Loads the WCS information into memory\n",
     "else:\n",
-    "    asdf_dir_uri = \"s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.1/\"\n",
+    "    asdf_dir_uri = \"s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.2/\"\n",
     "    asdf_file_uri = asdf_dir_uri + 'r0003201001001001004_0001_wfi02_f106_cal.asdf'\n",
     "\n",
     "    # Read the relevant data into memory\n",


### PR DESCRIPTION
This commit updates notebooks:

- aperture Photometry,
-  grisim_spectra, 
- data_discovery notebook, 
- data visualization, and 
- roman_cutouts 
 
 to use new data location
‘s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.2/'

It also updates the data _visulaization notebook to add option to look in local directory for a file first. 
The grisim_spectra had a minor update to a font weight to prevent warning message 