### PR TITLE
Update jdaviz notebook for new version constraint >5.0

### DIFF
--- a/notebooks/data_visualization/data_visualization.ipynb
+++ b/notebooks/data_visualization/data_visualization.ipynb
@@ -80,11 +80,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "asdf_dir_uri = \"s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.1/\"\n",
-    "fs = s3fs.S3FileSystem(anon=True)\n",
+    "file_system = s3fs.S3FileSystem(anon=True)\n",
     "\n",
-    "asdf_file_uri = asdf_dir_uri + 'r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
-    "file = rdm.open(fs.open(asdf_file_uri, 'rb'))"
+    "s3_bucket = \"s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.1/\"\n",
+    "image_prefix = s3_bucket + 'r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
+    "file = rdm.open(\n",
+    "    file_system.open(image_prefix, 'rb')\n",
+    ")"
    ]
   },
   {
@@ -112,9 +114,11 @@
     "\n",
     "fig, ax = plt.subplots(figsize=(8, 6))\n",
     "sc = ax.imshow(file.data, norm=norm, origin='lower')\n",
-    "ax.set_xlabel('X Science Axis (pixels)')\n",
-    "ax.set_ylabel('Y Science Axis (pixels)')\n",
-    "ax.set_title('Roman I-Sim Simulation WFI01')\n",
+    "ax.set(\n",
+    "    xlabel='X Science Axis (pixels)',\n",
+    "    ylabel='Y Science Axis (pixels)',\n",
+    "    title='Roman I-Sim Simulation WFI01'\n",
+    ")\n",
     "plt.colorbar(sc, ax=ax)\n",
     "plt.tight_layout();"
    ]
@@ -123,7 +127,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can see a bright, extended source in the right portion of the image. We isolate and examine that region a little more closely. Based on the image above, let's isolate science Y coordinates 2000 – 2500 and science X coordinates 3500 - 4000."
+    "We can see a bright, extended source near the center of this image. We isolate and examine that region a little more closely. Based on the image above, let's isolate science Y coordinates 2600 - 3500 and science X coordinates 3000 - 3950."
    ]
   },
   {
@@ -135,14 +139,16 @@
     "# Close the previous figure\n",
     "plt.close()\n",
     "\n",
-    "# Make new figure zoomed in on 1750 <= X <= 2250 and 500 <= Y <= 1000:\n",
+    "# Make new figure zoomed in on 3000 <= X <= 3950 and 2600 <= Y <= 3500:\n",
     "fig, ax = plt.subplots(figsize=(8, 6))\n",
     "sc = ax.imshow(file.data, norm=norm, origin='lower')\n",
-    "ax.set_xlabel('X Science Axis (pixels)')\n",
-    "ax.set_ylabel('Y Science Axis (pixels)')\n",
-    "ax.set_title('Roman I-Sim Simulation (Data) WFI01')\n",
-    "ax.set_xlim(3500, 4088)\n",
-    "ax.set_ylim(2000, 2588)\n",
+    "ax.set(\n",
+    "    xlabel='X Science Axis (pixels)',\n",
+    "    ylabel='Y Science Axis (pixels)',\n",
+    "    title='Roman I-Sim Simulation WFI01',\n",
+    "    xlim=(3000, 3950),\n",
+    "    ylim=(2600, 3500)\n",
+    ")\n",
     "plt.colorbar(sc, ax=ax)\n",
     "plt.tight_layout();"
    ]
@@ -169,11 +175,13 @@
     "# using binary_r to ease visibility of flagged pixels.\n",
     "fig, ax = plt.subplots(figsize=(8, 6))\n",
     "ax.imshow(np.bool(file.dq), origin='lower', cmap='binary_r')\n",
-    "ax.set_xlabel('X Science Axis (pixels)')\n",
-    "ax.set_ylabel('Y Science Axis (pixels)')\n",
-    "ax.set_title('Roman I-Sim Simulation (DQ) WFI01')\n",
-    "ax.set_xlim(3500, 4088)\n",
-    "ax.set_ylim(2000, 2588)\n",
+    "ax.set(\n",
+    "    xlabel='X Science Axis (pixels)',\n",
+    "    ylabel='Y Science Axis (pixels)',\n",
+    "    title='Roman I-Sim Simulation WFI01',\n",
+    "    xlim=(3000, 3950),\n",
+    "    ylim=(2600, 3500)\n",
+    ")\n",
     "plt.tight_layout();"
    ]
   },
@@ -201,8 +209,12 @@
     "ax.imshow(file.data, norm=norm, origin='lower')\n",
     "plt.colorbar(sc, ax=ax)\n",
     "ax.grid(color='white', alpha=0.3)\n",
-    "ax.set_xlabel('Right Ascension (deg)')\n",
-    "ax.set_ylabel('Declination (deg)')\n",
+    "\n",
+    "ax.set(\n",
+    "    xlabel='Right Ascension (deg)',\n",
+    "    ylabel='Declination (deg)',\n",
+    ")\n",
+    "\n",
     "plt.show()"
    ]
   },
@@ -238,7 +250,7 @@
    "source": [
     "## About this Notebook\n",
     "**Author:** Tyler Desjardins, Brett Morris, R. Diaz  \n",
-    "**Updated On:** 2025-12-13"
+    "**Updated On:** 2026-07-14"
    ]
   },
   {
@@ -277,7 +289,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.14"
   }
  },
  "nbformat": 4,

--- a/notebooks/data_visualization/jdaviz_data_visualization.ipynb
+++ b/notebooks/data_visualization/jdaviz_data_visualization.ipynb
@@ -40,7 +40,6 @@
    "metadata": {},
    "source": [
     "## Imports\n",
-    "- *astropy.visualization.simple_norm* for automatically scaling image arrays\n",
     "- *astropy.coordinates.SkyCoord* to create Python objects containing sky coordinate transforms\n",
     "- *astropy.table.Table* to create Astropy tables\n",
     "- *numpy* for array calculations and manipulation\n",
@@ -56,7 +55,6 @@
    "outputs": [],
    "source": [
     "%matplotlib inline\n",
-    "from astropy.visualization import simple_norm\n",
     "from astropy.coordinates import SkyCoord\n",
     "from astropy.table import Table\n",
     "import numpy as np\n",
@@ -208,9 +206,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that the second image has been displayed, we can blink between the two using the \"b\" button. Make sure that your cursor is placed over the image to make it the active window, then blink between the images. Try identifying a few sources that are common between the two images to see the effect of dithering between exposures.\n",
+    "Now that the second image has been displayed, we can alternate between the two images with the following API call."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# toggle the visibililty between each of the two images\n",
+    "viewer = jd.viewers['Image']\n",
+    "viewer.blink_once()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you run the cell above multiple times, you'll switch between the two loaded images.\n",
     "\n",
-    "Similarly to [the matplotlib notebook](ADD-ANOTHER-LINK-IF-NEEDED), let's investigate a region of interest and focus on the extended source in the right portion of the first image. In this case, we know the galaxy has science pixel coordinates of (X, Y) ~ (3480, 3030) pixels in the first image. We can use the WCS from the first image (which we saved as the variable `wcs1`) to transform this to sky coordinates:"
+    "Similar to the other notebook in this directory, let's investigate a region of interest and focus on the extended source in the right portion of the first image. In this case, we know the galaxy has science pixel coordinates of (X, Y) ~ (3480, 3030) pixels in the first image. We can use the WCS from the first image (which we saved as the variable `wcs1`) to transform this to sky coordinates:"
    ]
   },
   {
@@ -227,7 +243,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we center the viewer at this position. We can use either the sky coordinates, or alternatively the pixel coordinates (which have been commented out). Note that the centering occurs on the currently displayed image, so if you have the second image actively displayed and use the pixel coordinates, it will center to the incorrect location when using pixel coordinates from the first image. Using sky coordinates is independent of which image is actively displayed."
+    "Next, we center the viewer at this position. By default, jdaviz overlays images so that their pixel grids align, and uses pixel coordinates to specify the viewer's `zoom_center_x`, `zoom_center_y`, and `zoom_radius` attributes.\n",
+    "\n",
+    "\n",
+    "Note that the centering occurs on the currently displayed image, so the cell below "
    ]
   },
   {
@@ -238,32 +257,45 @@
    "source": [
     "# Center the image on given sky coordinates.\n",
     "sky = SkyCoord(ra=ra, dec=dec, unit='deg')\n",
-    "viewer = jd.viewers['Image']\n",
-    "viewer.center_on(sky)\n",
     "\n",
-    "# Center the image on given pixel coordinates.\n",
-    "# viewer.center_on((3480, 3030))"
+    "# set the viewer's center and zoom level in pixel units\n",
+    "plot_options.layer = 'WFI01_POS1'\n",
+    "plot_options.zoom_center_x = 3480\n",
+    "plot_options.zoom_center_y = 3030\n",
+    "plot_options.zoom_radius = 500"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can also set the zoom level to better display the region around the extended source. The zoom level settings are such as:\n",
+    "We can also set the zoom level to better display the region around the extended source. The `zoom_radius` attribute allows us to define the length of the smallest axis on the viewer in pixel units.\n",
     "\n",
-    "* 1: real-pixel-size.\n",
-    "* 2: zoomed in by a factor of 2.\n",
-    "* 0.5: zoomed out by a factor of 2.\n",
-    "* 'fit' means zoomed to fit the whole image into display.\n",
-    "\n",
-    "In this case, we will set the zoom level to 1.2 so we can better see the extended source."
+    "In this case, we will set `plot_options.zoom_radius = 500` (pixels) so we can better see the extended source."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Recall that to blink the images, you need to place the cursor over the viewer and press the \"b\" key on your keyboard. As you can see, when blinking the images in detector coordinates, the extended source is only visible in one image due to dithering between the exposures. Next, we will link the images by their WCS information so that the sources remain fixed in the display. Linking the images by WCS will reset the center and zoom, so let's reapply that as well.\n",
+    "Now let's blink a few times by running the cell one or more times."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# toggle the visibililty between each of the two images\n",
+    "viewer.blink_once()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When blinking the images in detector coordinates, the extended source is only visible in one image due to dithering between the exposures. Next, we will link the images by their WCS information so that the sources remain fixed in the display. Linking the images by WCS will reset the center and zoom, so let's reapply that as well.\n",
     "\n",
     "**Important note:** Roman WFI ASDF files use a Generalized World Coordinate System (GWCS) object in Python to store the WCS transformation. The transformation is only well-defined within a bounding box, and moving outside that bounding box produces unexpected behavior, particularly due to the polynomial terms in the transformation between pixel and sky coordinates."
    ]
@@ -277,16 +309,34 @@
     "orientation = jd.plugins['Orientation']\n",
     "orientation.align_by = 'WCS'\n",
     "\n",
-    "viewer.zoom_level = 1000\n",
-    "viewer.center_on(sky)"
+    "plot_options.zoom_center_x = sky.ra.deg\n",
+    "plot_options.zoom_center_y = sky.dec.deg\n",
+    "plot_options.zoom_radius = 0.005  # [deg]"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can pan and zoom manually to locate our galaxy of interest. With the cursor over the image, press the `b` key to blink between the two images. Blinking between the two images in any region where they overlap on the sky shows that we have succesfully aligned the images using sky coordinates.\n",
+    "To locate our galaxy of interest, we can also pan and zoom with your mouse by selecting the \"box-zoom\" and \"pan-zoom\" icons just above the upper right of the image, which are shaped like a magnifying glass and perpendicular arrows.   \n",
     "\n",
+    "Blinking between the two images in any region where they overlap on the sky shows that we have succesfully aligned the images using sky coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# toggle the visibililty between each of the two images\n",
+    "viewer.blink_once()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "You can also save the current view to a PNG file on your Nexus storage:"
    ]
   },
@@ -296,7 +346,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.save('my_image.png')"
+    "export = jd.plugins['Export']\n",
+    "\n",
+    "export.export(\"my_image.png\", overwrite=True)"
    ]
   },
   {
@@ -367,6 +419,7 @@
    "outputs": [],
    "source": [
     "# Set up viewer marker parameters\n",
+    "viewer = jd.viewers['Image']\n",
     "viewer.marker = {'color': 'white', 'alpha': 0.8, 'markersize': 120, 'fill': False}\n",
     "\n",
     "# Overlay markers\n",

--- a/notebooks/data_visualization/jdaviz_data_visualization.ipynb
+++ b/notebooks/data_visualization/jdaviz_data_visualization.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Visualizing Data in Roman ASDF Files with `Imviz`"
+    "# Visualizing Data in Roman ASDF Files with `jdaviz`"
    ]
   },
   {
@@ -44,9 +44,8 @@
     "- *astropy.coordinates.SkyCoord* to create Python objects containing sky coordinate transforms\n",
     "- *astropy.table.Table* to create Astropy tables\n",
     "- *numpy* for array calculations and manipulation\n",
-    "- *jdaviz.Imviz* to examine Wide Field Instrument (WFI) images interactively\n",
+    "- *jdaviz* to examine Wide Field Instrument (WFI) images interactively\n",
     "- *roman_datamodels* for opening Roman WFI ASDF files\n",
-    "- *time* for creating pauses in the notebook cells\n",
     "- *s3fs* to access data in an AWS S3 bucket"
    ]
   },
@@ -62,23 +61,22 @@
     "from astropy.table import Table\n",
     "import numpy as np\n",
     "\n",
-    "from jdaviz import Imviz\n",
+    "import jdaviz as jd\n",
     "import roman_datamodels as rdm\n",
-    "import s3fs\n",
-    "import time"
+    "import s3fs"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Interactively Examine the Data Using Imviz\n",
+    "## Interactively Examine the Data Using jdaviz\n",
     "\n",
     "### Introduction and Setup\n",
     "\n",
-    "We will use Imviz, the 2-D image viewer from the Jdaviz package, to visualize and explore the 2-D arrays contained within WFI L2 ASDF files. We highly recommend that users consult the [Imviz documentation](https://jdaviz.readthedocs.io/en/latest/imviz/index.html), which describes many of the features in Imviz in detail. In this tutorial, we will cover the basics to get you started.\n",
+    "We will use jdaviz, an interactive data visualization and analysis package for Jupyter notebooks, to explore the 2-D image arrays contained within WFI L2 ASDF files. We highly recommend that users consult the [jdaviz documentation](https://jdaviz.readthedocs.io/en/stable/), which describes many of the features in jdaviz in detail. In this tutorial, we will cover the basics to get you started.\n",
     "\n",
-    "The first cell below loads Imviz."
+    "The first cell below will open jdaviz."
    ]
   },
   {
@@ -87,17 +85,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Load Imviz\n",
-    "imviz = Imviz()"
+    "# open jdaviz in a sidecar at the bottom of this jupyter lab workspace:\n",
+    "jd.show('sidecar:split-bottom', title='jdaviz')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Loading Data\n",
+    "### Streaming Data\n",
     "\n",
-    "Next, we load the image into Imviz. We use the same data file in both this notebook and [the static `matplotlib` notebook](ANOTHER-LINK-TO-POTENTIALLY-FILL-IN). By default, for Roman WFI data, Imviz only loads the data array in the viewer to improve performance. Additional arrays (e.g., the DQ array) may be loaded using the `ext` optional argument. An example demonstrating how to load the data quality array is provided in a commented line in the following cell. For more information on the arrays contained within WFI L2 files, please see the RDox article on WFI [Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products#DataLevelsandProducts-L2ScienceDataSpecifications)."
+    "Next, we load a Roman WFI image into jdaviz. We use the same data file in both this notebook and [the static `matplotlib` notebook](ANOTHER-LINK-TO-POTENTIALLY-FILL-IN). \n",
+    "\n",
+    "jdaviz only streams the `data` array in the viewer by default. Additional arrays (for example., the DQ array) may be loaded using the `extension` optional argument. \n",
+    "\n",
+    "An example demonstrating how to load the data quality array is provided in a commented line in the following cell. For more information on the arrays contained within WFI L2 files, please see the RDox article on WFI [Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products#DataLevelsandProducts-L2ScienceDataSpecifications)."
    ]
   },
   {
@@ -106,25 +108,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "asdf_dir_uri = \"s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.1/\"\n",
-    "fs = s3fs.S3FileSystem(anon=True)\n",
+    "s3_bucket = \"s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.1/\"\n",
     "\n",
-    "asdf_file_uri = asdf_dir_uri + 'r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
-    "file = rdm.open(fs.open(asdf_file_uri, 'rb'))\n",
-    "wcs1 = file.meta.wcs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# loading on Imviz\n",
-    "imviz.load(file, data_label='WFI01_POS1')\n",
-    "# imviz.load_data(file, ext='dq', data_label='WFI01 DQ')\n",
+    "file_system = s3fs.S3FileSystem(anon=True)\n",
     "\n",
-    "time.sleep(10)"
+    "image_1_prefix = s3_bucket + 'r0003201001001001004_0001_wfi01_f106_cal.asdf'\n",
+    "image_file_1 = file_system.open(image_1_prefix, 'rb')\n",
+    "position_1 = rdm.open(image_file_1)\n",
+    "wcs1 = position_1.meta.wcs"
    ]
   },
   {
@@ -133,9 +124,7 @@
    "source": [
     "### Programmatically Adjusting Display\n",
     "\n",
-    "Next, we load the image into Imviz. By default, for Roman WFI data, Imviz only loads the data array in the viewer to improve performance. Additional arrays (e.g., the DQ array) may be loaded using the `ext` optional argument. An example demonstrating how to load the data quality array is provided in a commented line in the following cell. For more information on the arrays contained within WFI L2 files, please see the RDox article on WFI [Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products#DataLevelsandProducts-L2ScienceDataSpecifications).\n",
-    "\n",
-    "In Jupyter Lab, the viewer will appear at the right of the notebook. Failing that, the viewer will be shown underneath the cell using the `inline` visualization tool."
+    "Next, we load the image into jdaviz. jdaviz loads the `data` array in the viewer by default. Additional arrays (e.g., like the data quality array array) may be loaded using the `extension` optional argument. An example demonstrating how to load the data quality array is provided in a commented line in the following cell. For more information on the arrays contained within WFI L2 files, please see the RDox article on WFI [Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products#DataLevelsandProducts-L2ScienceDataSpecifications)."
    ]
   },
   {
@@ -144,31 +133,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "inviz_display = None\n",
-    "try:\n",
-    "    imviz.show(loc=\"sidecar\", height=1000)\n",
-    "except Exception:\n",
-    "    imviz.show(loc=\"inline\")   # or \"popout\"\n",
-    "    inviz_display = \"inline\"\n",
-    "    print(f\"Using inline display\")"
+    "# load the image at \"position 1\" into jdaviz:\n",
+    "jd.load(position_1, data_label='WFI01_POS1', format='Image')\n",
+    "\n",
+    "# alternatively, one could load the DATA and DQ extensions like so:\n",
+    "# jd.load(position_1, extension=['data', 'dq'], data_label='WFI01 DQ')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using `loc=sidecar` creates a split panel to the right. You can control the height, or use a pop out window or an inline viewer. For more information, please see the [display options](https://jdaviz.readthedocs.io/en/latest/display.html) documentation.\n",
+    "The colormap, stretch, and scale limits may be adjusted interactively in the viewer by clicking the settings (cog) icon towards the upper left of jdaviz (tooltip labeled 'Settings and options'), and selecting the \"Plot Options\" tab beneath the settings icon. Note that there are additional options such as the minimum and maximum scale limits under the \"More Stretch Options\" expander.\n",
     "\n",
-    "**Note:** You may need to expand the Imviz window to see all of the menubar items. You can also minimize the viewer by clicking on the tab on the far-right of your browser that says \"imviz.\" Clicking the \"x\" symbol next to it will close the tab, but clicking on the word \"imviz\" will hide the viewer until it is clicked again."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The colormap, stretch, and scale limits may be adjusted interactively in the viewer by clicking the plot options icon (three vertically-stacked sliders to the far right of the teal bar above the image display, hereafter the \"tool bar\"), and expanding the \"Plot Options\" section. Note that there are additional options such as the minimum and maximum scale limits under the \"More Stretch Options\" expander.\n",
-    "\n",
-    "If we know the settings we want to apply, we can do so via the Imviz API as follows:"
+    "If we know the settings we want to apply, we can do so via the jdaviz API as follows:"
    ]
   },
   {
@@ -177,23 +155,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer = imviz.default_viewer\n",
-    "viewer.stretch_options\n",
-    "viewer.stretch = 'arcsinh'\n",
-    "viewer.set_colormap('Viridis')\n",
-    "viewer.cuts = (0.5, 4)\n",
-    "time.sleep(5)\n",
+    "plot_options = jd.plugins['Plot Options']\n",
     "\n",
-    "if inviz_display == \"inline\":\n",
-    "    imviz.show(loc=\"inline\")"
+    "# we'll adjust the plot options for the image with the following `data_label`:\n",
+    "plot_options.layer = 'WFI01_POS1'\n",
+    "\n",
+    "# Apply the viridis colormap with an Arcsinh stretch between (0.5, 4) counts:\n",
+    "plot_options.image_colormap = 'Viridis'\n",
+    "plot_options.stretch_function = 'arcsinh'\n",
+    "plot_options.stretch_vmin = 0.5\n",
+    "plot_options.stretch_vmax = 4"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "**Note:** We have added a few pauses in the notebook cells with, e.g., `time.sleep(5)`, which should cause the cell to pause for several seconds before completing. Some cells include a retry pattern with a longer wait period. This is to ensure that the previous cell has had enough time to complete its tasks before moving on to the next step. These pauses or retry patterns may make Imviz feel a little slow, but it is meant to slow you down so you don't try to issue new commands before the previous ones finish executing. You may still want to execute the following cells slowly to prevent errors. **Important:** if you do get an error message, try re-running the cell and waiting a moment.\n",
-    "\n",
     "Now we will display a second image, showing the same field but slightly dithered, and we will link the two images by their WCS. The second image is dithered by ~200 arcseconds compared to the first, so sources should move by ~1000 pixels between the two images."
    ]
   },
@@ -203,11 +180,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "asdf_file_uri = asdf_dir_uri + 'r0003201001001001004_0002_wfi01_f106_cal.asdf'\n",
-    "f2 = fs.open(asdf_file_uri, 'rb')\n",
-    "file2 = rdm.open(f2)\n",
-    "wcs2 = file2.meta.wcs\n",
-    "imviz.load(file2, data_label='WFI01_POS2')"
+    "image_2_prefix = s3_bucket + 'r0003201001001001004_0002_wfi01_f106_cal.asdf'\n",
+    "image_file_2 = file_system.open(image_2_prefix, 'rb')\n",
+    "position_2 = rdm.open(image_file_2)\n",
+    "wcs2 = position_2.meta.wcs\n",
+    "\n",
+    "jd.load(position_2, data_label='WFI01_POS2', format='Image')"
    ]
   },
   {
@@ -216,30 +194,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Adjust wating period for viewer\n",
-    "max_attempts = 20  # Allows up to ~2 minutes total wait\n",
-    "attempt = 0\n",
-    "while attempt < max_attempts:\n",
-    "    try:\n",
-    "        viewer = imviz.default_viewer\n",
-    "        viewer.stretch_options\n",
-    "        viewer.stretch = 'arcsinh'\n",
-    "        viewer.set_colormap('Viridis')\n",
-    "        viewer.cuts = (0.5, 4)  \n",
-    "        # If it succeeds without raising, break out of the loop\n",
-    "        break\n",
-    "    except ValueError as e:\n",
-    "        if 'Viewer is still loading' in str(e):\n",
-    "            attempt += 1\n",
-    "            print(f\"Viewer not ready yet (attempt {attempt}/{max_attempts}), waiting...\")\n",
-    "            time.sleep(5)  # Or 3-10 seconds per retry\n",
-    "        else:\n",
-    "            raise  # Re-raise if it's a different error\n",
-    "else:\n",
-    "    raise RuntimeError(\"Viewer failed to load after maximum attempts\")\n",
+    "# now adjust the plot options for the image with the following `data_label`:\n",
+    "plot_options.layer = 'WFI01_POS2'\n",
     "\n",
-    "if inviz_display == \"inline\":\n",
-    "    imviz.show(loc=\"inline\")"
+    "# Apply the same plot options as the first image:\n",
+    "plot_options.image_colormap = 'Viridis'\n",
+    "plot_options.stretch_function = 'arcsinh'\n",
+    "plot_options.stretch_vmin = 0.5\n",
+    "plot_options.stretch_vmax = 4"
    ]
   },
   {
@@ -265,7 +227,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Next, we can center the viewer at this position using the Imviz API as shown below. We can use either the sky coordinates, or alternatively the pixel coordinates (which have been commented out). Note that the centering occurs on the currently displayed image, so if you have the second image actively displayed and use the pixel coordinates, it will center to the incorrect location when using pixel coordinates from the first image. Using sky coordinates is independent of which image is actively displayed."
+    "Next, we center the viewer at this position. We can use either the sky coordinates, or alternatively the pixel coordinates (which have been commented out). Note that the centering occurs on the currently displayed image, so if you have the second image actively displayed and use the pixel coordinates, it will center to the incorrect location when using pixel coordinates from the first image. Using sky coordinates is independent of which image is actively displayed."
    ]
   },
   {
@@ -275,16 +237,12 @@
    "outputs": [],
    "source": [
     "# Center the image on given sky coordinates.\n",
-    "sky = SkyCoord(ra=ra, dec=dec, unit=('deg', 'deg'))\n",
+    "sky = SkyCoord(ra=ra, dec=dec, unit='deg')\n",
+    "viewer = jd.viewers['Image']\n",
     "viewer.center_on(sky)\n",
     "\n",
     "# Center the image on given pixel coordinates.\n",
-    "# viewer.center_on((3700, 2300))\n",
-    "\n",
-    "time.sleep(5)\n",
-    "\n",
-    "if inviz_display == \"inline\":\n",
-    "    imviz.show(loc=\"inline\")"
+    "# viewer.center_on((3700, 2300))"
    ]
   },
   {
@@ -298,35 +256,7 @@
     "* 0.5: zoomed out by a factor of 2.\n",
     "* 'fit' means zoomed to fit the whole image into display.\n",
     "\n",
-    "In this case, we will set the zoom level to 1.2 so we can better see the extended source. Making this plot takes time, so we adjust the wait time period to allow Imviz to catch up before rendering the images."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Adjust wating period for viewer\n",
-    "max_attempts = 20  # Allows up to ~2 minutes total wait\n",
-    "attempt = 0\n",
-    "while attempt < max_attempts:\n",
-    "    try:\n",
-    "        viewer.zoom_level = 1.2\n",
-    "        # If it succeeds without raising, break out of the loop\n",
-    "        break\n",
-    "    except ValueError as e:\n",
-    "        if 'Viewer is still loading' in str(e):\n",
-    "            attempt += 1\n",
-    "            print(f\"Viewer not ready yet (attempt {attempt}/{max_attempts}), waiting...\")\n",
-    "            time.sleep(5)  # Or 3-10 seconds per retry\n",
-    "        else:\n",
-    "            raise  # Re-raise if it's a different error\n",
-    "else:\n",
-    "    raise RuntimeError(\"Viewer failed to load after maximum attempts\")\n",
-    "\n",
-    "if inviz_display == \"inline\":\n",
-    "    imviz.show(loc=\"inline\")"
+    "In this case, we will set the zoom level to 1.2 so we can better see the extended source."
    ]
   },
   {
@@ -335,7 +265,7 @@
    "source": [
     "Recall that to blink the images, you need to place the cursor over the viewer and press the \"b\" key on your keyboard. As you can see, when blinking the images in detector coordinates, the extended source is only visible in one image due to dithering between the exposures. Next, we will link the images by their WCS information so that the sources remain fixed in the display. Linking the images by WCS will reset the center and zoom, so let's reapply that as well.\n",
     "\n",
-    "**Important note:** Roman WFI ASDF files use a Generalized World Coordinate System (GWCS) object in Python to store the WCS transformation. The transformation is only well-defined within a bounding box, and moving outside that bounding box produces unexpected behavior, particularly due to the polynomial terms in the transformation between pixel and sky coordinates. As a result, the current version of Imviz might have some difficulties with setting a position and zooming after linking the images by WCS."
+    "**Important note:** Roman WFI ASDF files use a Generalized World Coordinate System (GWCS) object in Python to store the WCS transformation. The transformation is only well-defined within a bounding box, and moving outside that bounding box produces unexpected behavior, particularly due to the polynomial terms in the transformation between pixel and sky coordinates."
    ]
   },
   {
@@ -344,19 +274,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "orientation = imviz.plugins['Orientation']\n",
+    "orientation = jd.plugins['Orientation']\n",
     "orientation.align_by = 'WCS'\n",
-    "time.sleep(5)\n",
     "\n",
-    "if inviz_display == \"inline\":\n",
-    "    imviz.show(loc=\"inline\")"
+    "viewer.center_on(sky)\n",
+    "viewer.zoom_level = 1.2"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can still pan and zoom manually to locate our galaxy of interest and use the 'b' button with the cursor on the Imviz window to blink between the two images. Blinking between the two images in any region where they overlap on the sky shows that we have succesfully aligned the images using sky coordinates.\n",
+    "We can pan and zoom manually to locate our galaxy of interest. With the cursor over the image, press the `b` key to blink between the two images. Blinking between the two images in any region where they overlap on the sky shows that we have succesfully aligned the images using sky coordinates.\n",
     "\n",
     "You can also save the current view to a PNG file on your Nexus storage:"
    ]
@@ -367,19 +296,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "viewer.save('my_image.png')\n",
-    "time.sleep(5)"
+    "viewer.save('my_image.png')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This should save the file to your current working directory on the Nexus. If you want to download this file, you can do so by right-clicking on the file in the file browser and selecting the \"Download\" option.\n",
+    "This will save the file to your current working directory on the Nexus. If you want to download this file, you can do so by right-clicking on the file in the file browser and selecting the \"Download\" option.\n",
     "\n",
     "### Overlaying Catalog Data\n",
     "\n",
-    "A common exercise is to mark sources of interest on an image. We can do this with Imviz as well. First, let's read in the catalog used to generate this image using Roman I-Sim:"
+    "A common workflow is to mark sources of interest on an image in jdaviz. First, let's read in the catalog used to generate this image using Roman I-Sim:"
    ]
   },
   {
@@ -389,8 +317,10 @@
    "outputs": [],
    "source": [
     "# Read in catalog data from S3\n",
-    "cat_uri = asdf_dir_uri + 'full_catalog.ecsv'\n",
-    "tab = Table.read(fs.open(cat_uri, 'rb'), format='ascii.ecsv')"
+    "cat_uri = s3_bucket + 'full_catalog.ecsv'\n",
+    "\n",
+    "with file_system.open(cat_uri, 'rb') as catalog_file:\n",
+    "    tab = Table.read(catalog_file, format='ascii.ecsv')"
    ]
   },
   {
@@ -415,8 +345,8 @@
     "coords = SkyCoord(ra = tab['ra'][bright].value, dec = tab['dec'][bright].value, unit = 'deg')\n",
     "\n",
     "# Filter the SkyCoord objects on the WCS objects for each image to find only things in the overlap region.\n",
-    "x1, y1 = wcs1.invert(coords)\n",
-    "x2, y2 = wcs2.invert(coords)\n",
+    "x1, y1 = wcs1.world_to_pixel(coords)\n",
+    "x2, y2 = wcs2.world_to_pixel(coords)\n",
     "mask = (x1 > 0) & (x1 < 4088) & (y1 > 0) & (y1 < 4088) & (x2 > 0) & (x2 < 4088) & (y2 > 0) & (y2 < 4088)\n",
     "\n",
     "final_coords = Table({'coord': coords[mask]})\n",
@@ -440,11 +370,7 @@
     "viewer.marker = {'color': 'white', 'alpha': 0.8, 'markersize': 120, 'fill': False}\n",
     "\n",
     "# Overlay markers\n",
-    "viewer.add_markers(final_coords, use_skycoord=True, marker_name='My_Markers')\n",
-    "time.sleep(5)\n",
-    "\n",
-    "if inviz_display == \"inline\":\n",
-    "    imviz.show(loc=\"inline\")"
+    "viewer.add_markers(final_coords, use_skycoord=True, marker_name='My_Markers')"
    ]
   },
   {
@@ -464,17 +390,14 @@
     "viewer.remove_markers(marker_name='My_Markers')\n",
     "\n",
     "# Remove ALL markers\n",
-    "# viewer.reset_markers()\n",
-    "\n",
-    "if inviz_display == \"inline\":\n",
-    "    imviz.show(loc=\"inline\")"
+    "# viewer.reset_markers()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For more advanced use cases such as interactive aperture photometry or analysis of line profiles, please consult the [Imviz documentation](https://jdaviz.readthedocs.io/en/latest/imviz/index.html)."
+    "For more advanced use cases such as interactive aperture photometry or analysis of line profiles, please consult the [jdaviz documentation](https://jdaviz.readthedocs.io/en/latest/)."
    ]
   },
   {
@@ -490,8 +413,7 @@
    "source": [
     "## Additional Resources\n",
     "\n",
-    "- [Imviz Documentation](https://jdaviz.readthedocs.io/en/latest/imviz/index.html)\n",
-    "- [Additional JDaviz Notebooks](https://github.com/spacetelescope/jdaviz/tree/main/notebooks)\n",
+    "- [jdaviz Documentation](https://jdaviz.readthedocs.io/en/stable/)\n",
     "- [RDox WFI Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products#DataLevelsandProducts-L2ScienceDataSpecifications)"
    ]
   },
@@ -501,7 +423,7 @@
    "source": [
     "## About this Notebook\n",
     "**Author:** Tyler Desjardins, Brett Morris, R. Diaz  \n",
-    "**Updated On:** 2025-12-13"
+    "**Updated On:** 2026-07-14"
    ]
   },
   {
@@ -526,9 +448,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Roman Research Nexus 2026.1",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "roman-cal"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -540,7 +462,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.13"
+   "version": "3.13.14"
   }
  },
  "nbformat": 4,

--- a/notebooks/data_visualization/jdaviz_data_visualization.ipynb
+++ b/notebooks/data_visualization/jdaviz_data_visualization.ipynb
@@ -210,7 +210,7 @@
    "source": [
     "Now that the second image has been displayed, we can blink between the two using the \"b\" button. Make sure that your cursor is placed over the image to make it the active window, then blink between the images. Try identifying a few sources that are common between the two images to see the effect of dithering between exposures.\n",
     "\n",
-    "Similarly to [the matplotlib notebook](ADD-ANOTHER-LINK-IF-NEEDED), let's investigate a region of interest and focus on the extended source in the right portion of the first image. In this case, we know the galaxy has science pixel coordinates of (X, Y) ~ (3700, 2300) pixels in the first image. We can use the WCS from the first image (which we saved as the variable `wcs1`) to transform this to sky coordinates:"
+    "Similarly to [the matplotlib notebook](ADD-ANOTHER-LINK-IF-NEEDED), let's investigate a region of interest and focus on the extended source in the right portion of the first image. In this case, we know the galaxy has science pixel coordinates of (X, Y) ~ (3480, 3030) pixels in the first image. We can use the WCS from the first image (which we saved as the variable `wcs1`) to transform this to sky coordinates:"
    ]
   },
   {
@@ -219,7 +219,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ra, dec = wcs1(3700, 2300)\n",
+    "ra, dec = wcs1(3480, 3030)\n",
     "print(f'RA = {ra} deg, Dec = {dec} deg')"
    ]
   },
@@ -242,7 +242,7 @@
     "viewer.center_on(sky)\n",
     "\n",
     "# Center the image on given pixel coordinates.\n",
-    "# viewer.center_on((3700, 2300))"
+    "# viewer.center_on((3480, 3030))"
    ]
   },
   {
@@ -277,8 +277,8 @@
     "orientation = jd.plugins['Orientation']\n",
     "orientation.align_by = 'WCS'\n",
     "\n",
-    "viewer.center_on(sky)\n",
-    "viewer.zoom_level = 1.2"
+    "viewer.zoom_level = 1000\n",
+    "viewer.center_on(sky)"
    ]
   },
   {

--- a/notebooks/data_visualization/jdaviz_data_visualization.ipynb
+++ b/notebooks/data_visualization/jdaviz_data_visualization.ipynb
@@ -20,7 +20,7 @@
    "source": [
     "## Kernel Information and Read-Only Status\n",
     "\n",
-    "To run this notebook, please select the \"Roman Research Nexus {VERSION}\"  kernel at the top right of your window. For example, \"Roman Research Nexus 2026.1\".\n",
+    "To run this notebook, please select the \"Roman Research Nexus {VERSION}\"  kernel at the top right of your window. For example, \"Roman Research Nexus 2026.2\".\n",
     "\n",
     "This notebook is read-only. You can run cells and make edits, but you must save changes to a different location. We recommend saving the notebook within your home directory, or to a new folder within your home (e.g. <span style=\"font-variant:small-caps;\">file > save notebook as > my-nbs/nb.ipynb</span>). Note that a directory must exist before you attempt to add a notebook to it."
    ]
@@ -94,10 +94,6 @@
     "### Streaming Data\n",
     "\n",
     "Next, we load a Roman WFI image into jdaviz. We use the same data file in both this notebook and [the static `matplotlib` notebook](ANOTHER-LINK-TO-POTENTIALLY-FILL-IN). \n",
-    "\n",
-    "jdaviz only streams the `data` array in the viewer by default. Additional arrays (for example., the DQ array) may be loaded using the `extension` optional argument. \n",
-    "\n",
-    "An example demonstrating how to load the data quality array is provided in a commented line in the following cell. For more information on the arrays contained within WFI L2 files, please see the RDox article on WFI [Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products#DataLevelsandProducts-L2ScienceDataSpecifications)."
    ]
   },
   {
@@ -106,7 +102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s3_bucket = \"s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.1/\"\n",
+    "s3_bucket = \"s3://stpubdata/roman/nexus/soc_simulations/tutorial_data/roman-2026.2/\"\n",
     "\n",
     "file_system = s3fs.S3FileSystem(anon=True)\n",
     "\n",
@@ -122,7 +118,9 @@
    "source": [
     "### Programmatically Adjusting Display\n",
     "\n",
-    "Next, we load the image into jdaviz. jdaviz loads the `data` array in the viewer by default. Additional arrays (e.g., like the data quality array array) may be loaded using the `extension` optional argument. An example demonstrating how to load the data quality array is provided in a commented line in the following cell. For more information on the arrays contained within WFI L2 files, please see the RDox article on WFI [Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products#DataLevelsandProducts-L2ScienceDataSpecifications)."
+    "Next, we load the image into jdaviz. jdaviz loads the `data` array in the viewer by default. Additional arrays (e.g., like the data quality or DQ array) may be loaded using the `extension` optional argument.",
+"\n",
+"An example demonstrating how to load the data quality array is provided in a commented line in the following cell. For more information on the arrays contained within WFI L2 files, please see the RDox article on WFI [Data Levels and Products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products#DataLevelsandProducts-L2ScienceDataSpecifications)."
    ]
   },
   {
@@ -501,9 +499,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Research Nexus 2026.2",
    "language": "python",
-   "name": "python3"
+   "name": "roman-cal"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
### Description

Recently, the jdaviz portions of the data visualization notebook were split into a separate data visualization notebook, which pins jdaviz > 5.0. This PR updates the jdaviz tutorial for v5.0+, which brings several API deprecations, UI reorganization, and call pattern changes. Most notably, jdaviz is now one app, merging all functionality that was previously split into imviz, cubeviz, rampviz, etc. 

The main changes to these visualization notebooks include: 
* all references to `imviz` are now `jdaviz`
   * **are there links elsewhere in the repo that need to be edited to match?**
* deprecated API calls are replaced with their equivalents in v5.0+
* blinking in jdaviz by using the `b` keypress isn't working as expected in the latest release, so I've revised the notebook to use the API equivalent.
* the latest simulated image file used in the visualization notebooks has sources at different positions than the notebooks were expecting (likely from a different, deprecated image file), so I've updated the extended source's location and zoom in both notebooks.
* it seems like the matplotlib notebook has recently been edited to download a local copy of the whole ASDF file. shouldn't we demonstrate streaming? I've done so here.

***


This notebook checklist has been made available to us by the [the Notebooks For All team](https://github.com/Iota-School/notebooks-for-all/blob/main/resources/event-hackathon/notebook-authoring-checklist.md).
Its purpose is to serve as a guide for both the notebook author and the technical reviewer highlighting critical aspects to consider when striving to develop an accessible and effective notebook.

### The First Cell

- [ ] The title of the notebook in a first-level heading (eg. `<h1>` or `# in markdown`).
- [ ] A brief description of the notebook.
- [ ] A table of contents in an [ordered list](https://www.markdownguide.org/basic-syntax/#ordered-lists) (`1., 2.,` etc. in Markdown).
- [ ] The author(s) and affiliation(s) (if relevant).
- [ ] The date first published.
- [ ] The date last edited (if relevant).
- [ ] A link to the notebook's source(s) (if relevant).

### The Rest of the Cells

- [ ] There is only one H1 (`#` in Markdown) used in the notebook.
- [ ] The notebook uses other [heading tags](https://www.markdownguide.org/basic-syntax/#headings) in order (meaning it does not skip numbers). 

## Text

- [ ] All link text is descriptive. It tells users where they will be taken if they open the link.
- [ ] All acronyms are defined at least the first time they are used. 
- [ ] Field-specific/specialized terms are used when needed, but not excessively.

## Code

- [ ] Code sections are introduced and explained before they appear in the notebook. This can be fulfilled with a heading in a prior Markdown cell, a sentence preceding it, or a code comment in the code section.
- [ ] Code has explanatory comments (if relevant). This is most important for long sections of code.
- [ ] If the author has control over the syntax highlighting theme in the notebook, that theme has enough color contrast to be legible.
- [ ] Code and code explanations focus on one task at a time. Unless comparison is the point of the notebook, only one method for completing the task is described at a time.

### Images

- [ ] All images (jpg, png, svgs) have an [image description](https://www.w3.org/WAI/tutorials/images/decision-tree/). This could be
    - [ ] [Alt text](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt) (an `alt` property) 
    - [ ] [Empty alt text](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/alt#decorative_images) for decorative images/images meant to be skipped (an `alt` attribute with no value)
    - [ ] Captions
    - [ ] If no other options will work, the image is decribed in surrounding paragraphs.

- [ ] Any [text present in images](https://www.w3.org/WAI/WCAG21/Understanding/images-of-text.html) exists in a text form outside of the image (this can be alt text, captions, or surrounding text.)

### Visualizations

- [ ] All visualizations have an image description. Review the previous section, Images, for more information on how to add it.
- [ ] [Visualization descriptions](http://diagramcenter.org/specific-guidelines-e.html) include
    - [ ] The type of visualization (like bar chart, scatter plot, etc.)
    - [ ] Title
    - [ ] Axis labels and range
    - [ ] Key or legend
    - [ ] An explanation of the visualization's significance to the notebook (like the trend, an outlier in the data, what the author learned from it, etc.)

- [ ] All visualizations and their parts have [enough color contrast](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html) ([color contrast checker](https://webaim.org/resources/contrastchecker/)) to be legible. Remember that transparent colors have lower contrast than their opaque versions.
- [ ] All visualizations [convey information with more visual cues than color coding](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html). Use text labels, patterns, or icons alongside color to achieve this.
- [ ] All visualizations have an additional way for notebook readers to access the information. Linking to the original data, including a table of the data in the same notebook, or sonifying the plot are all options.