### PR TITLE
Add symlink to notebook_data_dependencies.py for masuring galaxy shapes

### DIFF
--- a/notebooks/measuring_galaxy_shapes/notebook_data_dependencies.py
+++ b/notebooks/measuring_galaxy_shapes/notebook_data_dependencies.py
@@ -1,0 +1,1 @@
+../../shared/notebook_data_dependencies.py


### PR DESCRIPTION
The directory in this branch didn't have the symlink to the file notebook_data_dependencies.py. Adding it here