### PR TITLE
Catalog database access notebook: Changes to work with astroquery/mast-beta branch

### DIFF
--- a/markdown/workflows/wfi-data-analysis.md
+++ b/markdown/workflows/wfi-data-analysis.md
@@ -4,7 +4,7 @@ This science workflow guides users through the discovery and access of data whil
 
 ## Workflow Description
 
-- [**Catalog Database Access**](../notebooks/cayalog_database_access/catalog_database_access.ipynb)  
+- [**Catalog Database Access**](../notebooks/catalog_database_access/catalog_database_access.ipynb)  
 
    Access and query, from MAST databases, a wide diversity of Roman multiband photometric source catalogs from WFI imaging; spectral catalogs derived from WFI grism and prism spectroscopy; microlensing event variability and light curve catalogs; and Project Infrastructure team created catalogs, enabling efficient filtering and sample selection across both spatial location and miriad other properties
 

--- a/notebooks/catalog_database_access/catalog_database_access.ipynb
+++ b/notebooks/catalog_database_access/catalog_database_access.ipynb
@@ -117,6 +117,15 @@
     "\n",
     "Roman catalogs are [Level 4 (L4) extracted products](https://roman-docs.stsci.edu/data-handbook/wfi-data-levels-and-products#WFIDataLevelsandProducts-Level4-ExtractedDataLevel4), and are produced by multiple Roman data pipelines. For full details about the data processing and detailed contents of Roman catalogs, please see [RDox](https://roman-docs.stsci.edu/data-handbook/roman-wfi-data-pipelines).\n",
     "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "<b>Note:</b> MAST's <a href=\"https://mast.stsci.edu/schema_browser\">Catalog Schema Browser</a> enables to search and explore information about the schemas (names, units, and descriptions of catalogs/tables) of a number of catalogs available from MAST. As Roman catalogs become available, their schemas will be made available through this Schema Browser.\n",
+    "<p>\n",
+    "\n",
+    "The MAST Catalog Schema Browser is **integrated into RRN:** A button on the Launcher (bottom; same row as the Credits Dashboard button) will open the Schema Browser in a new Jupyter tab.\n",
+    "\n",
+    "The Schema Browser is also accessible via URL: [https://mast.stsci.edu/schema_browser](https://mast.stsci.edu/schema_browser)\n",
+    "</div>\n",
+    "\n",
     "In the future, user-contributed catalogs (L5) are anticipated to be made available through similar methods; these will be documented separately."
    ]
   },
@@ -140,7 +149,8 @@
     "\n",
     "Though the specifics of the PanSTARRS and forthcoming Roman catalogs differ (in terms of filters, specific columns stemming from different processing pipelines, etc.), similar queries combining spatial, point vs. resolved source, and multiband color/magnitude criteria will be possible with Roman WFI multiband catalogs.\n",
     "\n",
-    "Based on the `astroquery.mast` PanSTARRS [catalog information](https://catalogs.mast.stsci.edu/docs/panstarrs.html) and the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs), \n",
+    "\n",
+    "Based on documentation about PanSTARRS catalogs — the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs), the `astroquery.mast` PanSTARRS [catalog information](https://catalogs.mast.stsci.edu/docs/panstarrs.html), and the [MAST Catalog Schema Browser](https://mast.stsci.edu/schema_browser/#/ps1_dr2/mean_object) — \n",
     "we will use the `MeanObject` catalog provided by `astroquery.mast`. This table provides relevant photometric information in the columns `gMeanPSFMag`, `iMeanPSFMag`, `yMeanPSFMag` (magnitudes optimized for point sources), and `iMeanKronMag` (used to distinguish between point and resolved sources), as well as position information (`raMean`, `decMean`).\n",
     "\n",
     "Also, with `astroquery`, we can directly filter for some of these constraints. However, we will need to post-process the returned results to apply other constraints."
@@ -188,33 +198,35 @@
     "# Query MAST for matching observations in \n",
     "# the PanSTARRS DR2 Mean catalog\n",
     "results_aq = Catalogs.query_criteria(\n",
-    "    catalog=\"Panstarrs\",\n",
-    "    data_release=\"dr2\",\n",
-    "    table=\"mean\",\n",
+    "    collection=\"ps1_dr2\",\n",
+    "    catalog=\"mean_object\",\n",
     "    coordinates=c0,\n",
     "    radius = 1.5*u.arcmin,\n",
-    "    columns=[\"objID\", \"raMean\",\"decMean\",\n",
+    "    select_cols=[\"objID\", \"raMean\",\"decMean\",\n",
     "             \"gMeanPSFMag\",\"iMeanPSFMag\",\"yMeanPSFMag\",\n",
     "             \"iMeanKronMag\"],    # List of columns to return\n",
-    "    gMeanPSFMag=[(\"gt\",-999)],   # mag > -999; missing magnitudes are -999\n",
-    "    iMeanPSFMag=[(\"gt\",-999)],   # mag > -999; missing magnitudes are -999\n",
-    "    yMeanPSFMag=[(\"gt\",-999)],   # mag > -999; missing magnitudes are -999\n",
-    "    iMeanKronMag=[(\"gt\",-999)],  # mag > -999; missing magnitudes are -999\n",
+    "    gMeanPSFMag=\">-999\",   # mag > -999; missing magnitudes are -999\n",
+    "    iMeanPSFMag=\">-999\",   # mag > -999; missing magnitudes are -999\n",
+    "    yMeanPSFMag=\">-999\",   # mag > -999; missing magnitudes are -999\n",
+    "    iMeanKronMag=\">-999\",  # mag > -999; missing magnitudes are -999\n",
     ")\n",
+    "\n",
+    "# Note: the returned table column names are all lower case, \n",
+    "# which we use below.\n",
     "\n",
     "# Post-process cuts:\n",
     "# 1. Distinguish stars from extended objects using\n",
     "#    difference of PSF, Kron magnitudes\n",
     "results_aq = results_aq[\n",
-    "    (results_aq['iMeanPSFMag'] - results_aq['iMeanKronMag']) <= 0.05\n",
+    "    (results_aq['imeanpsfmag'] - results_aq['imeankronmag']) <= 0.05\n",
     "]\n",
     "\n",
     "# 2. Apply color, magnitude cuts\n",
     "# Copy original catalog for reference:\n",
     "results_aq_all = results_aq.copy()\n",
     "results_aq = results_aq[\n",
-    "    ((results_aq['gMeanPSFMag'] - results_aq['yMeanPSFMag']) < 0.8) \n",
-    "    & (results_aq['iMeanPSFMag'] < 18)\n",
+    "    ((results_aq['gmeanpsfmag'] - results_aq['ymeanpsfmag']) < 0.8) \n",
+    "    & (results_aq['imeanpsfmag'] < 18)\n",
     "]\n",
     "\n",
     "# Final sample selection\n",
@@ -241,16 +253,16 @@
     "\n",
     "# Stars meeting the color/magnitude cuts\n",
     "ax.scatter(\n",
-    "    results_aq['gMeanPSFMag']-results_aq['yMeanPSFMag'],\n",
-    "    results_aq['iMeanPSFMag'], \n",
+    "    results_aq['gmeanpsfmag']-results_aq['ymeanpsfmag'],\n",
+    "    results_aq['imeanpsfmag'], \n",
     "    s=15,lw=0, color='red',\n",
     "    label='Bright blue stars',\n",
     ")\n",
     "\n",
     "# Plot the full set of stars for comparison\n",
     "ax.scatter(\n",
-    "    results_aq_all['gMeanPSFMag']-results_aq_all['yMeanPSFMag'],\n",
-    "    results_aq_all['iMeanPSFMag'], \n",
+    "    results_aq_all['gmeanpsfmag']-results_aq_all['ymeanpsfmag'],\n",
+    "    results_aq_all['imeanpsfmag'], \n",
     "    s=5,lw=0,zorder=-1, color='gray',\n",
     "    label='All stars in region',\n",
     ")\n",
@@ -272,7 +284,9 @@
     "\n",
     "For this second demonstration, we will apply the same selection criteria as above to select bright, blue stars near NGC 6535 from the PanSTARRS DR2 catalog.\n",
     "\n",
-    "First, we connect to the MAST PanSTARRS DR2 TAP service.\n"
+    "First, we connect to the MAST PanSTARRS DR2 TAP service. \n",
+    "\n",
+    "*(Note: A full list of MAST TAP services is available via [https://mast.stsci.edu/vo-tap/](https://mast.stsci.edu/vo-tap/).)*"
    ]
   },
   {
@@ -291,38 +305,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Again, we will access the mean object catalog (`mean_object` here; see the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs)), which contains all the columns we will need."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that it is possible to use the TAP service to directly access catalog/table \n",
-    "schemas, which describe the tables and columns. \n",
-    "An example of this is provided here, commented out as we have pre-identified \n",
-    "the relevent columns from the documentation\n",
+    "Again, we will access the mean object catalog (`mean_object` here; see the [PanSTARRS DR2 catalogs documentation](https://outerspace.stsci.edu/spaces/PANSTARRS/pages/298812351/PS1+Source+extraction+and+catalogs) and [MAST Catalog Schema Browser](https://mast.stsci.edu/schema_browser/#/ps1_dr2/mean_object)), which contains all the columns we will need.\n",
     "\n",
-    "An overview description of methods, capabilities, and \n",
-    "maximum result set sizes is available via:\n",
+    "\n",
+    "*Note:* As a reference when constructing queries, an overview description of methods, capabilities, and maximum result set sizes is available via:\n",
     "```python\n",
     "TAP_service.describe()\n",
-    "```\n",
-    "\n",
-    "Additionally, the `pyvo` TAPService class objects contain \n",
-    "metadata information about the full catalog schema, including tables and columns.\n",
-    "It's possible to iterate through the tables and print column names \n",
-    "as in this code snippet (here, only printing columns for the `mean_object` table).\n",
-    "```python\n",
-    "TAP_tables = TAP_service.tables\n",
-    "for tablename in TAP_tables.keys():\n",
-    "    # This can be refined by table name to print columns only for subsets of tables.\n",
-    "    if (tablename.startswith(\"ps1_dr2.mean_object\")):  # Include only PS1 tables \n",
-    "        ####\n",
-    "        # The table descriptions only include an overview, so this also prints the column names\n",
-    "        TAP_tables[tablename].describe() \n",
-    "        print(\"Columns={}\".format(sorted([k.name for k in TAP_tables[tablename].columns])))\n",
-    "        print(\"----\")\n",
     "```"
    ]
   },
@@ -343,7 +331,9 @@
     "* the $g-y$ color and $i$ magnitude cuts.\n",
     "\n",
     "\n",
-    "We then submit this query to the TAP service, and retrieve and display the table with the query results."
+    "We then submit this query to the TAP service, and retrieve and display the table with the query results.\n",
+    "\n",
+    "*(Note: This MAST PanSTARRS TAP service, and the Roman catalog TAP service, are case-insensitive for column names.)*"
    ]
   },
   {
@@ -403,10 +393,10 @@
    "outputs": [],
    "source": [
     "# Sort both by objid\n",
-    "results_aq.sort('objID')\n",
+    "results_aq.sort('objid')\n",
     "results_tap.sort('objid')\n",
     "# Check the ID lists are the same:\n",
-    "print(np.all(results_aq['objID'] == results_tap['objid']))"
+    "print(np.all(results_aq['objid'] == results_tap['objid']))"
    ]
   },
   {
@@ -470,7 +460,7 @@
     "The information about TAP access is based on the TIKE MAST PanSTARRS DR2 TAP notebook by Rick White & Theresa Dower, with edits from T. Dutkiewicz. \n",
     "\n",
     "**Author:**  Sedona Price\\\n",
-    "**Updated On:** 2026-04-08"
+    "**Updated On:** 2026-08-03"
    ]
   },
   {

--- a/notebooks/catalog_database_access/catalog_database_access.ipynb
+++ b/notebooks/catalog_database_access/catalog_database_access.ipynb
@@ -117,14 +117,7 @@
     "\n",
     "Roman catalogs are [Level 4 (L4) extracted products](https://roman-docs.stsci.edu/data-handbook/wfi-data-levels-and-products#WFIDataLevelsandProducts-Level4-ExtractedDataLevel4), and are produced by multiple Roman data pipelines. For full details about the data processing and detailed contents of Roman catalogs, please see [RDox](https://roman-docs.stsci.edu/data-handbook/roman-wfi-data-pipelines).\n",
     "\n",
-    "<div class=\"alert alert-block alert-info\">\n",
-    "<b>Note:</b> MAST's <a href=\"https://mast.stsci.edu/schema_browser\">Catalog Schema Browser</a> enables to search and explore information about the schemas (names, units, and descriptions of catalogs/tables) of a number of catalogs available from MAST. As Roman catalogs become available, their schemas will be made available through this Schema Browser.\n",
-    "<p>\n",
-    "\n",
-    "The MAST Catalog Schema Browser is **integrated into RRN:** A button on the Launcher (bottom; same row as the Credits Dashboard button) will open the Schema Browser in a new Jupyter tab.\n",
-    "\n",
-    "The Schema Browser is also accessible via URL: [https://mast.stsci.edu/schema_browser](https://mast.stsci.edu/schema_browser)\n",
-    "</div>\n",
+    "Users can also search and explore information about Roman catalogs using **MAST's <a href=\"https://mast.stsci.edu/schema_browser\">Catalog Schema Browser</a>**.  The schema browser provides searchable listings of column names, units, and descriptions for a number of catalogs available at MAST. As Roman catalogs become available, their schemas will be made available through this Schema Browser.\n",
     "\n",
     "In the future, user-contributed catalogs (L5) are anticipated to be made available through similar methods; these will be documented separately."
    ]

--- a/notebooks/catalog_database_access/requirements.txt
+++ b/notebooks/catalog_database_access/requirements.txt
@@ -1,4 +1,4 @@
 astropy>=7.2.0,<9
-astroquery>=0.4.11
+astroquery @ git+https://github.com/snbianco/astroquery.git@2026.2
 pyvo>=1.8.1
 matplotlib>=3.9


### PR DESCRIPTION
This PR includes changes to the Catalog Database Access notebook:
* Updating usage of astroquery.mast Catalogs module, to work with the re-designed Catalogs module in the astroquery/mast-beta branch being included in RRN 2026.2 (under testing).
* Updating markdown narrative to include points to the now-publicly-available MAST catalog schema browser (via URL, and which should also be integrated into RRN via Launcher button/Jupyter tab in 2026.2)
* Update to workflow markdown to fix a typo in the link to the catalog schema browser notebook.