### PR TITLE
update local_run file to add instructions for setting the refdata man…

### DIFF
--- a/markdown/local-run.md
+++ b/markdown/local-run.md
@@ -37,7 +37,16 @@ where `CRDS_PATH` points to your CRDS cache. If you do not have a cache already,
 
  Some notebooks use packages like **STPSF**, **Pandeia**, **STIPS**, and **Synphot** requiring data files that are distributed separately and that are expected to follow a certain directory structure under the root directory.
 
- For convenience, we have included the script `notebook_data_dependencies.py` which does this for you. The script is located in the directory *repo-root/shared/*. You can copy this script to your notebook folder or leave it in the *repo-root/shared/* directory.
+ For convenience, we have included the script `notebook_data_dependencies.py` which does this for you.This script is in the notebook folder or in the *repo-root/shared/* folder.
+
+ If downloading only the content of a folder, you need to add the following environmen variable before running your notebook.
+
+ ```
+ export ROMAN_REFDATA_MANIFEST https://raw.githubusercontent.com/spacetelescope/roman_notebooks/main/refdata_dependencies.yaml
+ ```
+
+This will point to the configuration file for the data files.
+
 
 ### How it works:
 

--- a/markdown/local-run.md
+++ b/markdown/local-run.md
@@ -39,7 +39,7 @@ where `CRDS_PATH` points to your CRDS cache. If you do not have a cache already,
 
  For convenience, we have included the script `notebook_data_dependencies.py` which does this for you.This script is in the notebook folder or in the *repo-root/shared/* folder.
 
- If downloading only the content of a folder, you need to add the following environmen variable before running your notebook.
+ If only downloading the content of a folder, you need to add the following environment variable before running your notebook.
 
  ```
  export ROMAN_REFDATA_MANIFEST https://raw.githubusercontent.com/spacetelescope/roman_notebooks/main/refdata_dependencies.yaml


### PR DESCRIPTION
updated the local_run markdown file to add instruction on how to set the new environment variable ROMAN_REFDATA_MANIFEST that sets the location of the refdata_dependencies.yaml. This is need by the notebook_data_dependencies.py when working locally and only downloading the content of a notebook folder.

We will review this change to the notebook_data_dependencies.py   in a future release.
