### PR TITLE
Update image URL to absolute URL

### DIFF
--- a/notebooks/catalog_database_access/catalog_database_access.ipynb
+++ b/notebooks/catalog_database_access/catalog_database_access.ipynb
@@ -123,7 +123,7 @@
     "\n",
     "_Open the Launcher from the JupyterLab menu using **File -> New Launcher**._\n",
     "\n",
-    "<img src=\"../../images/Launcher_SB.jpg\" alt=\"Launcher panel\" width=\"300\" />\n",
+    "<img src=\"https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/images/Launcher_SB.jpg\" alt=\"Launcher panel\" width=\"300\" />\n",
     "\n",
     "<br>\n",
     "In the future, user-contributed catalogs (L5) are anticipated to be made available through similar methods; these will be documented separately."


### PR DESCRIPTION
Update image URL showing schema browser launch button to an absolute URL in the GitHub repository.