### PR TITLE
Refine WFI data simulation workflow

### DIFF
--- a/markdown/workflows/wfi-data-sim.md
+++ b/markdown/workflows/wfi-data-sim.md
@@ -6,9 +6,9 @@ This science workflow guides users through the simulation, processing, manipulat
 
 
 ## Workflow Overview
-1. [**Roman I-sim**](../../notebooks/romanisim/romanisim.ipynb)
+1. [**Roman I-Sim**](../../notebooks/romanisim/romanisim.ipynb)
 
-   Simulate Roman WFI raw (L1) and exposure-level (L2) products using [Roman I-sim](https://romanisim.readthedocs.io/en/latest/), a GalSim-based simulator for WFI imaging data. Roman I-sim uses [Galsim](https://github.com/GalSim-developers/GalSim) to render astronomical scenes, [STPSF](https://roman-docs.stsci.edu/simulation-tools-handbook-home/stpsf-for-roman) to model the point-spread function, and [CRDS](https://roman-docs.stsci.edu/data-handbook-home/accessing-wfi-data/crds-for-reference-files) reference files to apply instrument calibration effects. Simulations can be generated from either synthetic catalogs or Gaia-based catalogs. Outputs are written in the standard [Roman ASDF format](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/introduction-to-asdf).
+   Simulate Roman WFI raw (L1) and exposure-level (L2) products using [Roman I-Sim](https://romanisim.readthedocs.io/en/latest/), a GalSim-based simulator for WFI imaging data. Roman I-Sim uses [Galsim](https://github.com/GalSim-developers/GalSim) to render astronomical scenes, [STPSF](https://roman-docs.stsci.edu/simulation-tools-handbook-home/stpsf-for-roman) to model the point-spread function, and [CRDS](https://roman-docs.stsci.edu/data-handbook-home/accessing-wfi-data/crds-for-reference-files) reference files to apply instrument calibration effects. Simulations can be generated from either synthetic catalogs or Gaia-based catalogs. Outputs are written in the standard [Roman ASDF format](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/introduction-to-asdf).
   
 
 2. [**Working with ASDF**](../../notebooks/working_with_asdf/working_with_asdf.ipynb)

--- a/markdown/workflows/wfi-data-sim.md
+++ b/markdown/workflows/wfi-data-sim.md
@@ -1,4 +1,4 @@
-# RRN Science Workflows: WFI Data Simulations
+# RRN Science Workflows: WFI Data Simulation
 
 This science workflow guides users through the simulation, processing, manipulation, and visualization of Roman WFI imaging data products.
 
@@ -6,34 +6,37 @@ This science workflow guides users through the simulation, processing, manipulat
 
 
 ## Workflow Overview
-- [**Roman-I-Sim**](../../notebooks/romanisim/romanisim.ipynb)
+1. [**Roman I-sim**](../../notebooks/romanisim/romanisim.ipynb)
 
-  Simulate Roman WFI raw (L1) and exposure-level (L2) products using [Roman-I-Sim](https://romanisim.readthedocs.io/en/latest/), a GalSim-based simulator for WFI imaging data. Roman I-Sim uses [Galsim](https://github.com/GalSim-developers/GalSim) to render astronomical scenes, [STPSF](https://roman-docs.stsci.edu/simulation-tools-handbook-home/stpsf-for-roman) to model the point-spread function, and [CRDS](https://roman-docs.stsci.edu/data-handbook-home/accessing-wfi-data/crds-for-reference-files) reference files to apply instrument calibration effects. Simulations can be generated from either synthetic catalogs or Gaia-based catalogs. Outputs are written in the standard [Roman ASDF format](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/introduction-to-asdf).
+   Simulate Roman WFI raw (L1) and exposure-level (L2) products using [Roman I-sim](https://romanisim.readthedocs.io/en/latest/), a GalSim-based simulator for WFI imaging data. Roman I-sim uses [Galsim](https://github.com/GalSim-developers/GalSim) to render astronomical scenes, [STPSF](https://roman-docs.stsci.edu/simulation-tools-handbook-home/stpsf-for-roman) to model the point-spread function, and [CRDS](https://roman-docs.stsci.edu/data-handbook-home/accessing-wfi-data/crds-for-reference-files) reference files to apply instrument calibration effects. Simulations can be generated from either synthetic catalogs or Gaia-based catalogs. Outputs are written in the standard [Roman ASDF format](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/introduction-to-asdf).
   
-- [**Working with ASDF**](../../notebooks/working_with_asdf/working_with_asdf.ipynb)
 
-  Explore Roman WFI data products stored in the [Advanced Scientific Data Format (ASDF)](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/introduction-to-asdf). This step introduces the structure of Roman WFI ASDF files, including metadata, data arrays, and provenance information, and applies to both simulated and future flight-like data products. To learn more, visit the [RDox pages on Roman WFI data levels and products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products).
+2. [**Working with ASDF**](../../notebooks/working_with_asdf/working_with_asdf.ipynb)
+
+   Explore Roman WFI data products stored in the [Advanced Scientific Data Format (ASDF)](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/introduction-to-asdf). This step introduces the structure of Roman WFI ASDF files, including metadata, data arrays, and provenance information, and applies to both simulated and future flight-like data products. To learn more, visit the [RDox pages on Roman WFI data levels and products](https://roman-docs.stsci.edu/data-handbook-home/wfi-data-format/data-levels-and-products).
   
-- [**Exposure Pipeline**](../../notebooks/exposure_pipeline/exposure_pipeline.ipynb)
+
+3. [**Exposure Pipeline**](../../notebooks/exposure_pipeline/exposure_pipeline.ipynb)
   
-  Process Roman WFI raw (L1) data into exposure-level (L2) products using RomanCal, the Roman science calibration pipeline. This stage corrects instrumental effects and collapses ramp data into rate images suitable for scientific analysis. To learn more about the overall exposure level pipeline visit the [RDox documentation]([https://roman-docs.stsci.edu/data-handbook-home/roman-stsci-data-pipelines/exposure-level-pipeline](https://roman-docs.stsci.edu/data-handbook-home/roman-data-pipelines/exposure-level-pipeline)).
+   Process Roman WFI raw (L1) data into exposure-level (L2) products using RomanCal, the Roman science calibration pipeline. This stage corrects instrumental effects and collapses ramp data into rate images suitable for scientific analysis. To learn more about the overall exposure level pipeline, visit the [RDox documentation](https://roman-docs.stsci.edu/data-handbook-home/roman-data-pipelines/exposure-level-pipeline).
  
-- **Data Visualization**
 
-  Visualize Roman WFI exposure-level products using Matplotlib and Jdaviz. This step focuses on quick-look inspection and basic analysis of calibrated L2 images. Imviz is based on the Jupyter platform and includes built-in Astropy functionality. For additional background information, consult [Jdaviz documentation on ReadTheDocs](https://jdaviz.readthedocs.io/en/latest/imviz/index.html).
+4. **Data Visualization**
 
-   - [Using Matplotlib](../../notebooks/data_visualization/data_visualization.ipynb)
-   - [Using JDaviz](../../notebooks/data_visualization/jdaaviz_data_visualization.ipynb)
+   Visualize Roman WFI exposure-level products using Matplotlib or Imviz, Jdaviz's image-visualization tool. This step focuses on quick-look inspection and basic analysis of calibrated L2 images. For additional background information, consult the [Imviz documentation on ReadTheDocs](https://jdaviz.readthedocs.io/en/latest/imviz/index.html).
 
-- [**Mosaic Pipeline**](../../notebooks/mosaic_pipeline/mosaic_pipeline.ipynb)
+    - [Using Matplotlib](../../notebooks/data_visualization/data_visualization.ipynb)
+    - [Using Jdaviz](../../notebooks/data_visualization/jdaviz_data_visualization.ipynb)
 
-  Combine multiple exposure-level (L2) products into mosaic-level (L3) images using RomanCal. The mosaic pipeline aligns, distortion-corrects, and coadds individual detector exposures to produce deeper, wide-field images. To learn more about the overall mosaic level pipeline visit the [RDox documentation](https://roman-docs.stsci.edu/data-handbook-home/roman-data-pipelines/mosaic-level-pipeline).
+5. [**Mosaic Pipeline**](../../notebooks/mosaic_pipeline/mosaic_pipeline.ipynb)
 
-- [**Core Community Survey**](../../notebooks/ccs_simulations/ccs_simulations.ipynb)
+   Combine multiple exposure-level (L2) products into mosaic-level (L3) images using RomanCal. The mosaic pipeline aligns, distortion-corrects, and coadds individual detector exposures to produce deeper, wide-field images. To learn more about the overall mosaic level pipeline visit the [RDox documentation](https://roman-docs.stsci.edu/data-handbook-home/roman-data-pipelines/mosaic-level-pipeline).
 
-  Explore a suite of simulated data products based on downscaled versions of the Roman Core Community Survey (CCS) programs. These simulated products were created to test the SOC data pipelines and provide sufficient scientific fidelity. These simulations do not necessarily include everything that may be observed on-orbit. Specifically, the simulations *do not include time-variable sources.* More details on what is included in the simulations are provided in the descriptions of each simulation set.
+6. [**Optional: Explore Core Community Survey Simulations**](../../notebooks/ccs_simulations/ccs_simulations.ipynb)
 
-<img src="https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/images/wfi-data-sim.jpg" alt="WFI Data Analysis Workflow" width="250" />
+   Independently explore a suite of pre-generated simulated data products based on downscaled versions of the Roman Core Community Survey (CCS) programs. These products are not outputs of the preceding Mosaic Pipeline tutorial. They were created to test the SOC data pipelines and provide sufficient scientific fidelity, but do not necessarily include everything that may be observed on orbit. Specifically, the simulations *do not include time-variable sources.* More details about each simulation set are provided in the notebook.
+
+<img src="https://raw.githubusercontent.com/spacetelescope/roman_notebooks/refs/heads/main/images/wfi-data-sim.jpg" alt="WFI Data Simulation Workflow" width="320" />
 
 ## Caveats and Limitations
 


### PR DESCRIPTION
## Summary
- standardize Roman I-sim naming and clarify the workflow title
- present the workflow as ordered steps with the CCS simulations marked as optional and independent
- correct the Exposure Pipeline and Jdaviz links, Imviz wording, diagram alt text, and image width

The deferred `tutorials.md` catalog update is intentionally excluded.