### PR TITLE
Add Roman mission introduction to Getting Started

### DIFF
--- a/content/intro.md
+++ b/content/intro.md
@@ -6,6 +6,8 @@ During Early Access, the Nexus provides simulated Roman datasets and tools that 
 
 ## Getting Started 
 
+<img src="../images/icons/roman-spacecraft.svg" style="vertical-align: middle; width:1.5em; margin-right:0.25em;"/> [Introduction to the Roman Mission](../markdown/roman_Intro.md)
+
 <img src="../images/icons/jupyter.svg" style="vertical-align: middle; width:1.5em; margin-right:0.25em;"/> [Working in JupyterLab](../markdown/jupyter.md)
 
 <img src="../images/icons/cloud_download.svg" style="vertical-align: bottom; width:1.5em; margin-right:0.25em;"/> [Managing Your Server](../markdown/server.md)

--- a/images/icons/roman-spacecraft.svg
+++ b/images/icons/roman-spacecraft.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 48" fill="currentColor">
+  <path d="M3 10 25 17h26l8 5-3 16H25L3 42l7-12v-8z"/>
+  <path d="m18 6 43 3-13 8H24z"/>
+  <path d="m25 35 33 1-9 7H19z"/>
+</svg>


### PR DESCRIPTION
## Summary
- add the Roman mission introduction as the first Getting Started resource
- add a simplified Roman spacecraft silhouette icon for the new link

## Validation
- rendered `content/intro.md` as HTML and reviewed the updated page
- validated the SVG with `xmllint`