### PR TITLE
Clarify science workflow summaries

### DIFF
--- a/markdown/workflows.md
+++ b/markdown/workflows.md
@@ -8,12 +8,12 @@ Workflows are designed to help users explore Roman-style analysis patterns in th
 
 The Early Access release currently includes six WFI-focused Science Workflows:
 
-- [Quickstart Workflow](./workflows/Intro_Workflow.md)
-- [WFI Data Simulation](./workflows/wfi-data-sim.md)
-- [WFI Data Analysis](./workflows/wfi-data-analysis.md)
-- [WFI Observation Planning](./workflows/wfi-obs-plan.md)
-- [CRDS Reference File Exploration](./workflows/crds-reference-files.md)
-- [Time Domain](./workflows/time-domain.md)
+- [Roman Data Essentials](./workflows/Intro_Workflow.md) — Get an entry-level introduction to the foundational tools and concepts for discovering, accessing, understanding, and visualizing Roman data.
+- [WFI Data Simulation](./workflows/wfi-data-sim.md) — Simulate Roman WFI imaging products and process them through the official WFI imaging processing pipeline.
+- [WFI Data Analysis](./workflows/wfi-data-analysis.md) — Discover, visualize, and analyze simulated WFI imaging and spectroscopic data.
+- [WFI Observation Planning](./workflows/wfi-obs-plan.md) — Evaluate exposure times, instrument performance, survey geometry, and observing strategies.
+- [WFI Reference File Exploration](./workflows/crds-reference-files.md) — Retrieve and inspect reference files used to calibrate Roman WFI data.
+- [Time Domain](./workflows/time-domain.md) — Simulate and analyze time-variable sources.
 
 Together, these workflows demonstrate how Roman tools can be used for pipeline-level data simulation, analysis of simulated WFI data products, exploration and validation of calibration reference products, proposal planning, and time-domain studies of transients and variable sources. They highlight different aspects of the Roman ecosystem, from generating synthetic datasets and processing them through the Roman calibration pipeline to performing photometric measurements across epochs and evaluating observing strategies. While the current materials focus primarily on WFI imaging applications, they also include an introductory spectroscopic example within the Data Analysis workflow, with additional spectroscopy-focused content planned for future releases.
 ## Using Workflows


### PR DESCRIPTION
## Summary

- update the Quickstart and reference-file workflow names to match their page titles
- add concise descriptions for all six WFI science workflows