### PR TITLE
Patch 2026.2.1 to fix issues with Dask and CRDS

### DIFF
--- a/notebooks/crds_reference_files/crds_reference_files.ipynb
+++ b/notebooks/crds_reference_files/crds_reference_files.ipynb
@@ -232,7 +232,7 @@
     "\n",
     "CRDS organizes the reference files using mapping files: the PMAP file, the IMAP files, and tje RMAP files. The first and most important mapping file is the PMAP file (commonly referred to as the CRDS context). This file is set by the the `CRDS_CONTEXT` environment variable. It provides a way to identify to the full set of reference files that each step of the `RomanCal` pipeline will use at a given time. By using the reference files tied to the same PMAP, you ensure compatibility between reference files.\n",
     "\n",
-    "If not already set, we can select a particular context with the following command."
+    "If not already set, we can select a particular CRDS context with the following command."
    ]
   },
   {
@@ -271,11 +271,11 @@
    "source": [
     "We can see that the PMAP was correctly set.\n",
     "\n",
-    "The IMAP is the second tier of mapping files. It contains the full set of reference types applicable to a giver instrument and available for use by `RomanCal`. For WFI, a particular version of the IMAP provides a list of all the reference file types used by `RomanCal` to calibrate that instrument, along with the RMAP versions part of the selected context. \n",
+    "The IMAP is the second tier of mapping files. It contains the full set of reference types applicable to a giver instrument and available for use by `RomanCal`. For WFI, a particular version of the IMAP provides a list of all the reference file types used by `RomanCal` to calibrate that instrument, along with the RMAP versions part of the selected CRDS context. \n",
     "\n",
-    "The RMAP is the third tier of mapping files. It provides the full list of reference files active with a given context, along with the selection parameters for that particular reference file type, which matches them to science observations. An RMAP includes the versions of the reference file that is part of that context.\n",
+    "The RMAP is the third tier of mapping files. It provides the full list of reference files active with a given CRDS context, along with the selection parameters for that particular reference file type, which matches them to science observations. An RMAP includes the versions of the reference file that is part of that CRDS context.\n",
     "\n",
-    "From the user point of view, only the PMAP or context file needs to be set. Note, however, that the context is also CRDS server-dependent and is set by the environment variable `CRDS_SERVER_URL`. "
+    "From the user point of view, only the PMAP or CRDS context file needs to be set. Note, however, that the CRDS context is also CRDS server-dependent and is set by the environment variable `CRDS_SERVER_URL`. "
    ]
   },
   {
@@ -283,7 +283,7 @@
    "id": "eccd2ac0-43fa-4dc6-a329-2a348e5e078a",
    "metadata": {},
    "source": [
-    " Note that in the above case, we selected a particular context. Since we want the default context, we revert the bove selection to the default context using the `crds.get_default_context` function first and then checking the version for the latest context."
+    "Note that in the above case, we selected a particular CRDS context. To revert the above selection to the default CRDS context, we use the `crds.get_default_context` function. We then check we have the correct CRDS context.\n"
    ]
   },
   {
@@ -293,8 +293,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The following line select the default pmap for the Roman observatory.\n",
+    "# The following line selects the default pmap for the Roman observatory.\n",
     "pmap = crds.get_default_context(\"roman\")\n",
+    "\n",
+    "# We check we have the correct CRDS context\n",
     "print(\"Selected pmap:\", pmap)\n",
     "\n",
     "# Typical location of the pmap in the cache\n",
@@ -319,7 +321,7 @@
    "id": "96374747",
    "metadata": {},
    "source": [
-    "Now let's explore the set of mappings associated with our selected context."
+    "Now let's explore the set of mappings associated with our selected CRDS context."
    ]
   },
   {
@@ -458,6 +460,7 @@
    "id": "24865974",
    "metadata": {},
    "source": [
+    "---\n",
     "## What is Next \n",
     "\n",
     "* Understand and Explore the [Area Pixels Mask](area_reffile.ipynb) reference file.\n",
@@ -482,7 +485,7 @@
     "## About this Notebook\n",
     "**Author:** R. Diaz, T. Desjardins.\n",
     "\n",
-    "**Updated On:** 2026-07-02"
+    "**Updated On:** August 2026"
    ]
   },
   {
@@ -509,7 +512,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Roman Research Nexus 2026.2.0",
+   "display_name": "Roman Research Nexus 2026.2",
    "language": "python",
    "name": "roman_cal"
   },

--- a/notebooks/crds_reference_files/crds_reference_files.ipynb
+++ b/notebooks/crds_reference_files/crds_reference_files.ipynb
@@ -65,9 +65,6 @@
     "import copy\n",
     "from pathlib import Path\n",
     "\n",
-    "import crds\n",
-    "from crds.client import api\n",
-    "\n",
     "import numpy as np\n",
     "import roman_datamodels as rdm\n",
     "#import s3fs"
@@ -94,7 +91,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import crds"
+    "import crds\n",
+    "from crds.client import api"
    ]
   },
   {
@@ -282,10 +280,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d4bfb5ba",
+   "id": "eccd2ac0-43fa-4dc6-a329-2a348e5e078a",
    "metadata": {},
    "source": [
-    "Let's check if we have the context. Note that in this case we are selecting a particular context, if you want the default context you can do it by uncommenting the first command in the following cell."
+    " Note that in the above case, we selected a particular context. Since we want the default context, we revert the bove selection to the default context using the `crds.get_default_context` function first and then checking the version for the latest context."
    ]
   },
   {
@@ -295,8 +293,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Uncomment the following line to select the default pmap for the Roman observatory.\n",
-    "#pmap = crds.get_default_context(\"roman\")\n",
+    "# The following line select the default pmap for the Roman observatory.\n",
+    "pmap = crds.get_default_context(\"roman\")\n",
     "print(\"Selected pmap:\", pmap)\n",
     "\n",
     "# Typical location of the pmap in the cache\n",
@@ -511,9 +509,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Roman Research Nexus 2026.2.0",
    "language": "python",
-   "name": "python3"
+   "name": "roman_cal"
   },
   "language_info": {
    "codemirror_mode": {

--- a/notebooks/crds_reference_files/crds_reference_files.ipynb
+++ b/notebooks/crds_reference_files/crds_reference_files.ipynb
@@ -230,7 +230,7 @@
     "\n",
     "### CRDS Mapping Files\n",
     "\n",
-    "CRDS organizes the reference files using mapping files: the PMAP file, the IMAP files, and tje RMAP files. The first and most important mapping file is the PMAP file (commonly referred to as the CRDS context). This file is set by the the `CRDS_CONTEXT` environment variable. It provides a way to identify to the full set of reference files that each step of the `RomanCal` pipeline will use at a given time. By using the reference files tied to the same PMAP, you ensure compatibility between reference files.\n",
+    "CRDS organizes the reference files using mapping files: the PMAP file, the IMAP files, and the RMAP files. The first and most important mapping file is the PMAP file (commonly referred to as the CRDS context). This file is set by the `CRDS_CONTEXT` environment variable. It provides a way to identify the full set of reference files that each step of the `RomanCal` pipeline will use at a given time. By using the reference files tied to the same PMAP, you ensure compatibility between reference files.\n",
     "\n",
     "If not already set, we can select a particular CRDS context with the following command."
    ]
@@ -271,7 +271,7 @@
    "source": [
     "We can see that the PMAP was correctly set.\n",
     "\n",
-    "The IMAP is the second tier of mapping files. It contains the full set of reference types applicable to a giver instrument and available for use by `RomanCal`. For WFI, a particular version of the IMAP provides a list of all the reference file types used by `RomanCal` to calibrate that instrument, along with the RMAP versions part of the selected CRDS context. \n",
+    "The IMAP is the second tier of mapping files. It contains the full set of reference types applicable to a given instrument and available for use by `RomanCal`. For WFI, a particular version of the IMAP provides a list of all the reference file types used by `RomanCal` to calibrate that instrument, along with the RMAP versions part of the selected CRDS context. \n",
     "\n",
     "The RMAP is the third tier of mapping files. It provides the full list of reference files active with a given CRDS context, along with the selection parameters for that particular reference file type, which matches them to science observations. An RMAP includes the versions of the reference file that is part of that CRDS context.\n",
     "\n",

--- a/notebooks/crds_reference_files/reference_pixel_reffile.ipynb
+++ b/notebooks/crds_reference_files/reference_pixel_reffile.ipynb
@@ -147,7 +147,7 @@
    "id": "5e2646d0",
    "metadata": {},
    "source": [
-    "If we want to change the context, we can do it in the next cell. In this case, we choose context `roman_0058.pmap`."
+    "If we want to change the context, we can do it  by uncomenting the next cell. In this case, we choose context `roman_0061.pmap`."
    ]
   },
   {
@@ -157,7 +157,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "os.environ['CRDS_CONTEXT']='roman_0058.pmap'"
+    "#os.environ['CRDS_CONTEXT']='roman_0061.pmap'"
    ]
   },
   {
@@ -409,7 +409,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Roman Research Nexus 2026.2",
+   "display_name": "Roman Research Nexus 2026.2.0",
    "language": "python",
    "name": "roman_cal"
   },

--- a/notebooks/crds_reference_files/reference_pixel_reffile.ipynb
+++ b/notebooks/crds_reference_files/reference_pixel_reffile.ipynb
@@ -147,7 +147,7 @@
    "id": "5e2646d0",
    "metadata": {},
    "source": [
-    "If we want to change the context, we can do it  by uncomenting the next cell. In this case, we choose context `roman_0061.pmap`."
+    "If we want to change the context, we can do it by uncommenting the next cell. In this case, we choose context `roman_0061.pmap`."
    ]
   },
   {
@@ -409,7 +409,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Roman Research Nexus 2026.2.0",
+   "display_name": "Roman Research Nexus 2026.2",
    "language": "python",
    "name": "roman_cal"
   },

--- a/notebooks/footprint_visualization/footprint_visualization.ipynb
+++ b/notebooks/footprint_visualization/footprint_visualization.ipynb
@@ -80,7 +80,7 @@
    "outputs": [],
    "source": [
     "# healsparse>=1.11.1\n",
-    "%pip install ipympl\n",
+    "# %pip install ipympl\n",
     "# %pip install healpy\n",
     "# %pip install healsparse"
    ]
@@ -649,6 +649,7 @@
     "try:\n",
     "    client.close()\n",
     "except Exception:\n",
+    "    print(\"Warning: Dask client closed before Client.close() command.\")\n",
     "    pass"
    ]
   },

--- a/notebooks/footprint_visualization/footprint_visualization.ipynb
+++ b/notebooks/footprint_visualization/footprint_visualization.ipynb
@@ -80,7 +80,7 @@
    "outputs": [],
    "source": [
     "# healsparse>=1.11.1\n",
-    "# %pip install ipympl\n",
+    "%pip install ipympl\n",
     "# %pip install healpy\n",
     "# %pip install healsparse"
    ]
@@ -128,6 +128,16 @@
    "metadata": {},
    "source": [
     "By default, this notebook will allow you to produce interactive plots; however, some of the plots presented here could lead to reduced performance in certain systems. In order to generate static plots, set the `interactive` variable below to `False`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nest_asyncio2\n",
+    "nest_asyncio2.apply()"
    ]
   },
   {
@@ -565,7 +575,7 @@
    "outputs": [],
    "source": [
     "# Starts a Dask distributed scheduler (if one isn’t already running).\n",
-    "client = Client(processes=True)  # In some instances processes=False will perform better"
+    "client = Client(processes=True, dashboard_address=None)  # In some instances processes=False will perform better"
    ]
   },
   {
@@ -636,7 +646,10 @@
    "outputs": [],
    "source": [
     "# Close the dask client\n",
-    "client.close()"
+    "try:\n",
+    "    client.close()\n",
+    "except Exception:\n",
+    "    pass"
    ]
   },
   {

--- a/notebooks/footprint_visualization/footprint_visualization.ipynb
+++ b/notebooks/footprint_visualization/footprint_visualization.ipynb
@@ -649,7 +649,6 @@
     "try:\n",
     "    client.close()\n",
     "except Exception:\n",
-    "    print(\"Warning: Dask client closed before Client.close() command.\")\n",
     "    pass"
    ]
   },

--- a/notebooks/romanisim/romanisim.ipynb
+++ b/notebooks/romanisim/romanisim.ipynb
@@ -854,11 +854,10 @@
     "    results = dask_client.gather(tasks)\n",
     "    \n",
     "    # Don't forget to close the Dask client!\n",
-    "        # Close the dask client\n",
-    "        try:\n",
-    "            dask_client.close(timeout=5)\n",
-    "        except Exception:\n",
-    "            pass"
+    "    try:\n",
+    "        dask_client.close(timeout=5)\n",
+    "    except Exception:\n",
+    "        pass"
    ]
   },
   {
@@ -1191,7 +1190,7 @@
    "source": [
     "## About this Notebook\n",
     "**Author:** Sanjib Sharma, Tyler Desjardins, Rosa Diaz<br>\n",
-    "**Updated On:** AUgust 2026"
+    "**Updated On:** August 2026"
    ]
   },
   {
@@ -1216,7 +1215,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Roman Research Nexus 2026.2.0",
+   "display_name": "Roman Research Nexus 2026.2",
    "language": "python",
    "name": "roman_cal"
   },

--- a/notebooks/romanisim/romanisim.ipynb
+++ b/notebooks/romanisim/romanisim.ipynb
@@ -162,8 +162,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import nest_asyncio\n",
-    "nest_asyncio.apply()"
+    "import nest_asyncio2\n",
+    "nest_asyncio2.apply()"
    ]
   },
   {
@@ -857,6 +857,7 @@
     "    try:\n",
     "        dask_client.close(timeout=5)\n",
     "    except Exception:\n",
+    "        print(\"Warning: Dask client closed before Client.close() command.\")\n",
     "        pass"
    ]
   },

--- a/notebooks/romanisim/romanisim.ipynb
+++ b/notebooks/romanisim/romanisim.ipynb
@@ -857,7 +857,6 @@
     "    try:\n",
     "        dask_client.close(timeout=5)\n",
     "    except Exception:\n",
-    "        print(\"Warning: Dask client closed before Client.close() command.\")\n",
     "        pass"
    ]
   },

--- a/notebooks/romanisim/romanisim.ipynb
+++ b/notebooks/romanisim/romanisim.ipynb
@@ -157,6 +157,16 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import nest_asyncio\n",
+    "nest_asyncio.apply()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -829,22 +839,26 @@
     "# Set up Dask client\n",
     "# Give each simulation call its own worker so that no one worker exceeds\n",
     "# the allocated memory.\n",
-    "dask_client = Client(n_workers=n_detectors)\n",
-    "\n",
-    "# Create simulation runs to send to the client\n",
-    "tasks = []\n",
-    "for i in range(n_detectors):\n",
-    "\n",
-    "    # Create simulations with the full_catalog defined above and for 3\n",
-    "    # WFI detectors. Otherwise, use the default parameters.\n",
-    "    tasks.append(dask_client.submit(run_romanisim, full_catalog,\n",
-    "                                    **{'ra': pointing.ra, 'dec': pointing.dec, 'sca': (i + 1 + offset), 'expnum': expnum}))\n",
-    "\n",
-    "# Wait for all tasks to complete\n",
-    "results = dask_client.gather(tasks)\n",
-    "\n",
-    "# Don't forget to close the Dask client!\n",
-    "dask_client.close()"
+    "with Client(n_workers=n_detectors, processes=True, dashboard_address=None) as dask_client:\n",
+    "    \n",
+    "    # Create simulation runs to send to the client\n",
+    "    tasks = []\n",
+    "    for i in range(n_detectors):\n",
+    "    \n",
+    "        # Create simulations with the full_catalog defined above and for 3\n",
+    "        # WFI detectors. Otherwise, use the default parameters.\n",
+    "        tasks.append(dask_client.submit(run_romanisim, full_catalog,\n",
+    "                                        **{'ra': pointing.ra, 'dec': pointing.dec, 'sca': (i + 1 + offset), 'expnum': expnum}))\n",
+    "    \n",
+    "    # Wait for all tasks to complete\n",
+    "    results = dask_client.gather(tasks)\n",
+    "    \n",
+    "    # Don't forget to close the Dask client!\n",
+    "        # Close the dask client\n",
+    "        try:\n",
+    "            dask_client.close(timeout=5)\n",
+    "        except Exception:\n",
+    "            pass"
    ]
   },
   {
@@ -1177,7 +1191,7 @@
    "source": [
     "## About this Notebook\n",
     "**Author:** Sanjib Sharma, Tyler Desjardins, Rosa Diaz<br>\n",
-    "**Updated On:** 2026-07-09"
+    "**Updated On:** AUgust 2026"
    ]
   },
   {
@@ -1202,7 +1216,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Roman Research Nexus 2026.2",
+   "display_name": "Roman Research Nexus 2026.2.0",
    "language": "python",
    "name": "roman_cal"
   },


### PR DESCRIPTION
Notebook testing in Nexus revealed an issue with CRDS and and Dask.

1. CRDS:
  1.1. The CRDS notebook reference_pixel_reffile.ipynb was updated to use the default context and only show how to select a particular context. The notebook was explicitly using context roman_0058.pmap that recommended a "refpix" reference file that was recently marked as bad and made unaccessible. 
With this fix we ensure the notebook uses the latest context only.
  1.2. Updated crds_reference_files.ipynb to remove an extra crds import. This was not an issue but rather an unnecessary step.

2. Dask:
   2.1. The footprint_visualization.ipynb and the romanisim.ipynb notebook were updated to address an issue with Dask throwing random errors due to asynchronous runs. The runtime error appeared, most of the time,  when running the notebook with Wrangler.

